### PR TITLE
CMake: 3.17.3+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.17.3)
 project(pyAMReX VERSION 21.02)
 
 include(${pyAMReX_SOURCE_DIR}/cmake/pyAMReXFunctions.cmake)
@@ -64,7 +64,14 @@ set_default_build_type("RelWithDebInfo")
 include(${pyAMReX_SOURCE_DIR}/cmake/dependencies/AMReX.cmake)
 
 # Python
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+set(_PY_DEV_MODULE Development.Module)
+if(CMAKE_VERSION VERSION_LESS 3.18.0)
+    # over-specification needed for CMake<3.18
+    #   https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
+    #   https://cmake.org/cmake/help/v3.18/module/FindPython.html
+    set(_PY_DEV_MODULE Development)
+endif()
+find_package(Python COMPONENTS Interpreter ${_PY_DEV_MODULE} REQUIRED)
 
 # pybind11
 #   builds pybind11 from git (default), form local source or

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you just want to use CMake to build the project, jump into sections *1. Intro
 pyAMReX depends on the following popular third party software.
 
 - a mature [C++14](https://en.wikipedia.org/wiki/C%2B%2B14) compiler: e.g. g++ 5.0+, clang 5.0+, VS 2017+
-- [CMake 3.18.0+](https://cmake.org)
+- [CMake 3.17.3+](https://cmake.org) ([3.18.2+ recommended](https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode))
 - [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
 - [pybind11](https://github.com/pybind/pybind11/) 2.6.2+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
   - [Python](https://python.org) 3.6+
@@ -80,7 +80,7 @@ brew update
 brew install ccache cmake libomp mpi4py numpy open-mpi python
 ```
 
-Now, `cmake --version` should be at version 3.18.0 or newer.
+Now, `cmake --version` should be at version 3.17.3 or newer.
 
 Or go:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools>38.6", "wheel", "cmake>=3.18.0,<4.0.0"]
+requires = ["setuptools>38.6", "wheel", "cmake>=3.17.3,<4.0.0"]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError(
-                "CMake 3.18.0+ must be installed to build the following " +
+                "CMake 3.17.3+ must be installed to build the following " +
                 "extensions: " +
                 ", ".join(e.name for e in self.extensions))
 
@@ -69,8 +69,8 @@ class CMakeBuild(build_ext):
             r'version\s*([\d.]+)',
             out.decode()
         ).group(1))
-        if cmake_version < '3.18.0':
-            raise RuntimeError("CMake >= 3.18.0 is required")
+        if cmake_version < '3.17.3':
+            raise RuntimeError("CMake >= 3.17.3 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
We don't use the DEVICE_LINK features in upstream AMReX logic yet, so we can stay with 3.17.3+ for now.

For CMake < 3.18.0 we need to overspecify the Python dependencies that we are actually looking for. This is mainly a problem with `manylinux` images (but there we can upgrade CMake with `pip` first) and fine-grained package managers.

Generally, anticipate a switch of AMReX as a whole to CMake 3.19+ in the mid-term because a lot of niceness landed in it.

Hand-crafted for @sayerhs so he does not need to upgrade his clusters on a Saturday :)