### PR TITLE
Wrap more classes and introduce unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,7 @@ setup(
     cmdclass=cmdclass,
     zip_safe=False,
     python_requires='>=3.6, <3.10',
-    # tests_require=['pytest'],
+    tests_require=['pytest'],
     install_requires=install_requires,
     # cmdclass={'test': PyTest},
     # platforms='any',

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -42,4 +42,6 @@ void init_AMReX(py::module& m)
     m.def("finalize",
           py::overload_cast<>(&Finalize));
     m.def("finalize", py::overload_cast<AMReX*>(&Finalize));
+
+    m.def("space_dim", [](){ return AMREX_SPACEDIM; });
 }

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <AMReX_Config.H>
 #include <AMReX.H>

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -1,0 +1,45 @@
+#include <pybind11/pybind11.h>
+
+#include <AMReX_Config.H>
+#include <AMReX.H>
+#include <AMReX_Vector.H>
+#include <AMReX_ParmParse.H>
+
+#include <string>
+
+namespace py = pybind11;
+using namespace amrex;
+
+void init_AMReX(py::module& m)
+{
+    py::class_<AMReX>(m, "AMReX")
+        .def_static("empty", &AMReX::empty)
+        .def_static("size", &AMReX::size)
+        .def_static("erase", &AMReX::erase)
+        .def_static("top", &AMReX::top,
+                    py::return_value_policy::reference)
+        ;
+
+    m.def("initialize",
+          [](const py::list args) {
+              Vector<std::string> cargs{"pyamrex"};
+              Vector<char*> argv{&cargs.back()[0]};
+
+              // Populate the "command line"
+              for (const auto& v: args) {
+                  cargs.push_back(v.cast<std::string>());
+                  argv.push_back(&cargs.back()[0]);
+              }
+
+              int argc = argv.size();
+              char** tmp = argv.data();
+              const bool build_parm_parse = (cargs.size() > 1);
+              // TODO: handle version with MPI
+              return Initialize(argc, tmp, build_parm_parse);
+          }, py::return_value_policy::reference,
+          "Initialize AMReX library");
+
+    m.def("finalize",
+          py::overload_cast<>(&Finalize));
+    m.def("finalize", py::overload_cast<AMReX*>(&Finalize));
+}

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -1,5 +1,7 @@
 target_sources(pyAMReX
   PRIVATE
+    AMReX.cpp
     Box.cpp
+    Dim3.cpp
     IntVect.cpp
 )

--- a/src/Base/Dim3.cpp
+++ b/src/Base/Dim3.cpp
@@ -1,0 +1,40 @@
+#include <pybind11/pybind11.h>
+
+#include <AMReX_Config.H>
+#include <AMReX_Dim3.H>
+
+#include <sstream>
+
+namespace py = pybind11;
+using namespace amrex;
+
+void init_Dim3(py::module& m)
+{
+    py::class_<Dim3>(m, "Dim3")
+        .def("__repr__",
+             [](const Dim3& d) {
+                 std::stringstream s;
+                 s << d;
+                 return "<pyamrex.Dim3 '" + s.str() + "'>";
+             }
+        )
+        .def("__str__",
+             [](const Dim3& d) {
+                 std::stringstream s;
+                 s << d;
+                 return s.str();
+             }
+        )
+        .def(py::init<int, int, int>())
+        .def_readwrite("x", &Dim3::x)
+        .def_readwrite("y", &Dim3::y)
+        .def_readwrite("z", &Dim3::z)
+        ;
+
+    py::class_<XDim3>(m, "XDim3")
+        .def(py::init<Real, Real, Real>())
+        .def_readwrite("x", &XDim3::x)
+        .def_readwrite("y", &XDim3::y)
+        .def_readwrite("z", &XDim3::z)
+        ;
+}

--- a/src/Base/Dim3.cpp
+++ b/src/Base/Dim3.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <AMReX_Config.H>
 #include <AMReX_Dim3.H>

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -57,7 +57,7 @@ void init_IntVect(py::module &m) {
         .def("dim3", &IntVect::dim3)
         .def("__getitem__",
              [](const IntVect& v, const int i) {
-                 const size_t ii = (i >= 0) ? i : AMREX_SPACEDIM + i;
+                 const int ii = (i >= 0) ? i : AMREX_SPACEDIM + i;
                  if ((ii < 0) || (ii >= AMREX_SPACEDIM))
                      throw py::index_error(
                          "Index must be between 0 and " +
@@ -66,7 +66,7 @@ void init_IntVect(py::module &m) {
              })
         .def("__setitem__",
              [](IntVect& v, const int i, const int& val) {
-                 const size_t ii = (i >= 0) ? i : AMREX_SPACEDIM + i;
+                 const int ii = (i >= 0) ? i : AMREX_SPACEDIM + i;
                  if ((ii < 0) || (ii >= AMREX_SPACEDIM))
                      throw py::index_error(
                          "Index must be between 0 and " +

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -5,6 +5,7 @@
  */
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/numpy.h>
 
 #include <AMReX_Config.H>
 #include <AMReX_Dim3.H>
@@ -56,7 +57,7 @@ void init_IntVect(py::module &m) {
         .def("dim3", &IntVect::dim3)
         .def("__getitem__",
              [](const IntVect& v, const int i) {
-                 const size_t ii = (i > 0) ? i : AMREX_SPACEDIM - i;
+                 const size_t ii = (i >= 0) ? i : AMREX_SPACEDIM + i;
                  if ((ii < 0) || (ii >= AMREX_SPACEDIM))
                      throw py::index_error(
                          "Index must be between 0 and " +
@@ -65,12 +66,77 @@ void init_IntVect(py::module &m) {
              })
         .def("__setitem__",
              [](IntVect& v, const int i, const int& val) {
-                 const size_t ii = (i > 0) ? i : AMREX_SPACEDIM - i;
+                 const size_t ii = (i >= 0) ? i : AMREX_SPACEDIM + i;
                  if ((ii < 0) || (ii >= AMREX_SPACEDIM))
                      throw py::index_error(
                          "Index must be between 0 and " +
                          std::to_string(AMREX_SPACEDIM));
                  return v[ii] = val;
+             })
+
+        .def("__eq__",
+             py::overload_cast<int>(&IntVect::operator==, py::const_))
+        .def("__eq__",
+             py::overload_cast<const IntVect&>(&IntVect::operator==, py::const_))
+        .def("__ne__",
+             py::overload_cast<int>(&IntVect::operator!=, py::const_))
+        .def("__ne__",
+             py::overload_cast<const IntVect&>(&IntVect::operator!=, py::const_))
+        .def("__lt__", &IntVect::operator<)
+        .def("__le__", &IntVect::operator<=)
+        .def("__gt__", &IntVect::operator>)
+        .def("__ge__", &IntVect::operator>=)
+
+        .def("__add__",
+             py::overload_cast<int>(&IntVect::operator+, py::const_))
+        .def("__add__",
+             py::overload_cast<const IntVect&>(&IntVect::operator+, py::const_))
+        .def("__sub__",
+             py::overload_cast<int>(&IntVect::operator-, py::const_))
+        .def("__sub__",
+             py::overload_cast<const IntVect&>(&IntVect::operator-, py::const_))
+        .def("__mul__",
+             py::overload_cast<int>(&IntVect::operator*, py::const_))
+        .def("__mul__",
+             py::overload_cast<const IntVect&>(&IntVect::operator*, py::const_))
+        .def("__truediv__",
+             py::overload_cast<int>(&IntVect::operator/, py::const_))
+        .def("__truediv__",
+             py::overload_cast<const IntVect&>(&IntVect::operator/, py::const_))
+        .def("__iadd__",
+             py::overload_cast<int>(&IntVect::operator+=))
+        .def("__iadd__",
+             py::overload_cast<const IntVect&>(&IntVect::operator+=))
+        .def("__isub__",
+             py::overload_cast<int>(&IntVect::operator-=))
+        .def("__isub__",
+             py::overload_cast<const IntVect&>(&IntVect::operator-=))
+        .def("__imul__",
+             py::overload_cast<int>(&IntVect::operator*=))
+        .def("__imul__",
+             py::overload_cast<const IntVect&>(&IntVect::operator*=))
+        .def("__itruediv__",
+             py::overload_cast<int>(&IntVect::operator/=))
+        .def("__itruediv__",
+             py::overload_cast<const IntVect&>(&IntVect::operator/=))
+
+        .def("numpy",
+             [](const IntVect& iv) {
+                 auto result = py::array(
+                     py::buffer_info(
+                         nullptr,
+                         sizeof(int),
+                         py::format_descriptor<int>::value,
+                         1,
+                         { AMREX_SPACEDIM },
+                         { sizeof(int) }
+                     ));
+                 auto buf = result.request();
+                 double* ptr = static_cast<double*>(buf.ptr);
+                 for (int i=0; i < AMREX_SPACEDIM; ++i)
+                     ptr[i] = iv[0];
+
+                 return result;
              })
     ;
 

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -132,7 +132,7 @@ void init_IntVect(py::module &m) {
                          { sizeof(int) }
                      ));
                  auto buf = result.request();
-                 double* ptr = static_cast<double*>(buf.ptr);
+                 int* ptr = static_cast<int*>(buf.ptr);
                  for (int i=0; i < AMREX_SPACEDIM; ++i)
                      ptr[i] = iv[0];
 

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -7,6 +7,7 @@
 #include <pybind11/stl.h>
 
 #include <AMReX_Config.H>
+#include <AMReX_Dim3.H>
 #include <AMReX_IntVect.H>
 
 #include <sstream>
@@ -16,17 +17,28 @@ using namespace amrex;
 
 
 void init_IntVect(py::module &m) {
-    py::class_< IntVect >(m, "Int_Vect")
+    py::class_< IntVect >(m, "IntVect")
         .def("__repr__",
-            [](IntVect const & iv) {
-                std::stringstream s;
-                s << iv;
-                return "<pyamrex.Int_Vect '" + s.str() + "'>";
+             [](py::object& obj) {
+                 py::str py_name = obj.attr("__class__").attr("__name__");
+                 const std::string name = py_name;
+                 const auto iv = obj.cast<IntVect>();
+                 std::stringstream s;
+                 s << iv;
+                 return "<" + name + " " + s.str() + ">";
             }
         )
+        .def("__str",
+             [](const IntVect& iv) {
+                 std::stringstream s;
+                 s << iv;
+                 return s.str();
+             })
 
         .def(py::init<>())
+#if (AMREX_SPACEDIM > 1)
         .def(py::init<AMREX_D_DECL(int, int, int)>())
+#endif
         .def(py::init<int>())
 
         .def_property_readonly("sum", &IntVect::sum)
@@ -34,18 +46,40 @@ void init_IntVect(py::module &m) {
             py::overload_cast<>(&IntVect::max, py::const_))
         .def_property_readonly("min",
             py::overload_cast<>(&IntVect::min, py::const_))
-        .def_property_readonly("the_zero_vector", &IntVect::TheZeroVector)
-        .def_property_readonly("the_unit_vector", &IntVect::TheUnitVector)
-        .def_property_readonly("the_node_vector", &IntVect::TheNodeVector)
-        .def_property_readonly("the_cell_vector", &IntVect::TheCellVector)
-        .def_property_readonly("the_max_vector", &IntVect::TheMaxVector)
-        .def_property_readonly("the_min_vector", &IntVect::TheMinVector)
+        .def_static("zero_vector", &IntVect::TheZeroVector)
+        .def_static("unit_vector", &IntVect::TheUnitVector)
+        .def_static("node_vector", &IntVect::TheNodeVector)
+        .def_static("cell_vector", &IntVect::TheCellVector)
+        .def_static("max_vector", &IntVect::TheMaxVector)
+        .def_static("min_vector", &IntVect::TheMinVector)
 
-        //.def("to_array", &IntVect::toArray)
-        // maxDir
-
-        // __getitem__
-        // __iter__
-
+        .def("dim3", &IntVect::dim3)
+        .def("__getitem__",
+             [](const IntVect& v, const int i) {
+                 const size_t ii = (i > 0) ? i : AMREX_SPACEDIM - i;
+                 if ((ii < 0) || (ii >= AMREX_SPACEDIM))
+                     throw py::index_error(
+                         "Index must be between 0 and " +
+                         std::to_string(AMREX_SPACEDIM));
+                 return v[ii];
+             })
+        .def("__setitem__",
+             [](IntVect& v, const int i, const int& val) {
+                 const size_t ii = (i > 0) ? i : AMREX_SPACEDIM - i;
+                 if ((ii < 0) || (ii >= AMREX_SPACEDIM))
+                     throw py::index_error(
+                         "Index must be between 0 and " +
+                         std::to_string(AMREX_SPACEDIM));
+                 return v[ii] = val;
+             })
     ;
+
+    m.def("coarsen",
+         py::overload_cast<const IntVect&, const IntVect&>(&coarsen));
+    m.def("coarsen",
+          py::overload_cast<const Dim3&, const IntVect&>(&coarsen));
+    m.def("coarsen",
+          py::overload_cast<const IntVect&, int>(&coarsen));
+    m.def("refine",
+          py::overload_cast<const Dim3&, const IntVect&>(&refine));
 }

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -16,7 +16,9 @@ namespace py = pybind11;
 
 
 // forward declarations of exposed classes
+void init_AMReX(py::module&);
 void init_Box(py::module &);
+void init_Dim3(py::module&);
 void init_IntVect(py::module &);
 
 PYBIND11_MODULE(pyamrex_cxx, m) {
@@ -32,6 +34,8 @@ PYBIND11_MODULE(pyamrex_cxx, m) {
     )pbdoc";
 
     // note: order from parent to child classes
+    init_AMReX(m);
+    init_Dim3(m);
     init_IntVect(m);
     init_Box(m);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import pyamrex as amrex
+
+@pytest.fixture(autouse=True, scope='session')
+def amrex_init():
+    amrex.initialize(["amrex.verbose=-1"])
+    yield
+    amrex.finalize()

--- a/tests/test_dim3.py
+++ b/tests/test_dim3.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+import pyamrex as amrex
+
+def test_dim3():
+    obj = amrex.Dim3(1, 2, 3)
+    assert(obj.x == 1)
+    assert(obj.y == 2)
+    assert(obj.z == 3)
+
+def test_xdim3():
+    obj = amrex.XDim3(1.0, 2.0, 3.0)
+    np.testing.assert_allclose(obj.x, 1.0)
+    np.testing.assert_allclose(obj.y, 2.0)
+    np.testing.assert_allclose(obj.z, 3.0)

--- a/tests/test_intvect.py
+++ b/tests/test_intvect.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+import pyamrex as amrex
+
+@pytest.mark.skipif(amrex.space_dim() != 1,
+                    reason="Requires AMREX_SPACEDIM = 1")
+def test_iv_1d():
+    obj = amrex.IntVect(1)
+    assert(obj[0] == 1)
+    assert(obj[-1] == 1)
+    with pytest.raises(IndexError):
+        obj[-2]
+    with pytest.raises(IndexError):
+        obj[1]
+
+@pytest.mark.skipif(amrex.space_dim() != 2,
+                    reason="Requires AMREX_SPACEDIM = 2")
+def test_iv_2d():
+    obj = amrex.IntVect(1, 2)
+    assert(obj[0] == 1)
+    assert(obj[1] == 2)
+    assert(obj[-1] == 3)
+    assert(obj[-2] == 2)
+
+    with pytest.raises(IndexError):
+        obj[-3]
+    with pytest.raises(IndexError):
+        obj[2]
+
+@pytest.mark.skipif(amrex.space_dim() != 3,
+                    reason="Requires AMREX_SPACEDIM = 3")
+def test_iv_3d1():
+    obj = amrex.IntVect(1, 2, 3)
+
+    # Check indexing
+    assert(obj[0] == 1)
+    assert(obj[1] == 2)
+    assert(obj[2] == 3)
+    assert(obj[-1] == 3)
+    assert(obj[-2] == 2)
+    assert(obj[-3] == 1)
+    with pytest.raises(IndexError):
+        obj[-4]
+    with pytest.raises(IndexError):
+        obj[3]
+
+    # Check properties
+    assert(obj.max == 3)
+    assert(obj.min == 1)
+    assert(obj.sum == 6)
+
+    # Check assignment
+    obj[0] = 2
+    obj[1] = 3
+    obj[2] = 4
+    assert(obj[0] == 2)
+    assert(obj[1] == 3)
+    assert(obj[2] == 4)
+
+@pytest.mark.skipif(amrex.space_dim() != 3,
+                    reason="Requires AMREX_SPACEDIM = 3")
+def test_iv_3d2():
+    obj = amrex.IntVect(3)
+    assert(obj[0] == 3)
+    assert(obj[1] == 3)
+    assert(obj[2] == 3)
+    assert(obj[-1] == 3)
+    assert(obj[-2] == 3)
+    assert(obj[-3] == 3)
+
+    with pytest.raises(IndexError):
+        obj[-4]
+    with pytest.raises(IndexError):
+        obj[3]
+
+def test_iv_static():
+    zero = amrex.IntVect.zero_vector()
+    for i in range(amrex.space_dim()):
+        assert(zero[i] == 0)
+
+    one = amrex.IntVect.unit_vector()
+    for i in range(amrex.space_dim()):
+        assert(one[i] == 1)
+
+    assert(zero == amrex.IntVect.cell_vector())
+    assert(one == amrex.IntVect.node_vector())
+
+def test_iv_ops():
+    gold = amrex.IntVect(2)
+    one = amrex.IntVect.unit_vector()
+
+    two = one + one
+    assert(two == gold)
+    assert(two != amrex.IntVect.zero_vector())
+    assert(two > one)
+    assert(two >= gold)
+    assert(one < two)
+    assert(one <= one)
+
+    assert(not (one > two))
+
+    zero = one - one
+    assert(zero == amrex.IntVect.zero_vector())
+
+    mtwo = one * gold
+    assert(two == mtwo)
+
+    four = amrex.IntVect(4)
+    dtwo = four / gold
+    assert(dtwo == mtwo)
+
+def test_iv_conversions():
+    obj = amrex.IntVect.max_vector().numpy()
+    assert(isinstance(obj, np.ndarray))
+    assert(obj.dtype == np.int32)


### PR DESCRIPTION
- Start wrapping functionality from `AMReX.H` 
- Introduce `Dim3`
- Expand `IntVect` wrapping (also renamed `Int_Vect` to `IntVect`)
- Introduce unit testing using `pytest`

Sample unit test output 

```
============================= test session starts ==============================
platform darwin -- Python 3.8.3, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /pymarex
collected 9 items

tests/test_dim3.py ..
tests/test_intvect.py ss.....

========================= 7 passed, 2 skipped in 0.21s =========================
```