### PR TITLE
Introduce AMReX configuration query object

### DIFF
--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -56,6 +56,15 @@ void init_AMReX(py::module& m)
 #endif
             })
         .def_property_readonly_static(
+            "have_omp",
+            [](py::object){
+#ifdef AMREX_USE_OMP
+                return true;
+#else
+                return false;
+#endif
+            })
+        .def_property_readonly_static(
             "gpu_backend",
             [](py::object){
 #ifdef AMREX_USE_CUDA

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 import pyamrex as amrex
 
-if amrex.have_mpi():
+if amrex.Config.have_mpi:
     from mpi4py import MPI
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/test_intvect.py
+++ b/tests/test_intvect.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 import pyamrex as amrex
 
-@pytest.mark.skipif(amrex.space_dim() != 1,
+@pytest.mark.skipif(amrex.Config.spacedim != 1,
                     reason="Requires AMREX_SPACEDIM = 1")
 def test_iv_1d():
     obj = amrex.IntVect(1)
@@ -15,7 +15,7 @@ def test_iv_1d():
     with pytest.raises(IndexError):
         obj[1]
 
-@pytest.mark.skipif(amrex.space_dim() != 2,
+@pytest.mark.skipif(amrex.Config.spacedim != 2,
                     reason="Requires AMREX_SPACEDIM = 2")
 def test_iv_2d():
     obj = amrex.IntVect(1, 2)
@@ -29,7 +29,7 @@ def test_iv_2d():
     with pytest.raises(IndexError):
         obj[2]
 
-@pytest.mark.skipif(amrex.space_dim() != 3,
+@pytest.mark.skipif(amrex.Config.spacedim != 3,
                     reason="Requires AMREX_SPACEDIM = 3")
 def test_iv_3d1():
     obj = amrex.IntVect(1, 2, 3)
@@ -59,7 +59,7 @@ def test_iv_3d1():
     assert(obj[1] == 3)
     assert(obj[2] == 4)
 
-@pytest.mark.skipif(amrex.space_dim() != 3,
+@pytest.mark.skipif(amrex.Config.spacedim != 3,
                     reason="Requires AMREX_SPACEDIM = 3")
 def test_iv_3d2():
     obj = amrex.IntVect(3)
@@ -77,11 +77,11 @@ def test_iv_3d2():
 
 def test_iv_static():
     zero = amrex.IntVect.zero_vector()
-    for i in range(amrex.space_dim()):
+    for i in range(amrex.Config.spacedim):
         assert(zero[i] == 0)
 
     one = amrex.IntVect.unit_vector()
-    for i in range(amrex.space_dim()):
+    for i in range(amrex.Config.spacedim):
         assert(one[i] == 1)
 
     assert(zero == amrex.IntVect.cell_vector())


### PR DESCRIPTION
Use a Python class with read-only static properties to allow Python query of
AMReX build time configuration.
