### PR TITLE
MultiFab & Array4

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
   clang:
     name: Clang w/o MPI
     runs-on: windows-latest
-    env: {PYAMREX_LIBDIR: build/lib/site-packages/amrex/Release/}
+    env: {PYAMREX_LIBDIR: build/lib/site-packages/amrex/Debug/}
     steps:
     - uses: actions/checkout@v2
     - uses: seanmiddleditch/gha-setup-ninja@master
@@ -38,11 +38,11 @@ jobs:
               -DAMReX_MPI=OFF             `
               -DPython_EXECUTABLE=C:\\hostedtoolcache\\windows\\python\\3.9.10\\x64\\python3.exe
 
-        cmake --build build --config Release -j 2
+        cmake --build build --config Debug -j 2
         python3 -m pip install -v .
     - name: Unit tests
       run: |
-        ctest --test-dir build -C Release --output-on-failure
+        ctest --test-dir build -C Debug --output-on-failure
 
 # C:\\hostedtoolcache\\windows\\python\\3.9.10\\x64\\python3.exe
 # C:\\hostedtoolcache\\windows\\Python\\3.10.2\\x64\\python3.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Unit tests
       shell: cmd
       run: |
-        python3 -m pytest -s -vvvv tests/test_array4.py
+        python3 -m pytest tests
 
   clang:
     name: Clang w/o MPI
@@ -42,7 +42,7 @@ jobs:
         python3 -m pip install -v .
     - name: Unit tests
       run: |
-        python3 -m pytest -s -vvvv tests/test_array4.py
+        ctest --test-dir build -C Release --output-on-failure
 
 # C:\\hostedtoolcache\\windows\\python\\3.9.10\\x64\\python3.exe
 # C:\\hostedtoolcache\\windows\\Python\\3.10.2\\x64\\python3.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Unit tests
       shell: cmd
       run: |
-        python3 -m pytest -s -vvvv tests
+        python3 -m pytest -s -vvvv tests/test_array4.py
 
   clang:
     name: Clang w/o MPI
@@ -42,7 +42,7 @@ jobs:
         python3 -m pip install -v .
     - name: Unit tests
       run: |
-        ctest --test-dir build -C Release --output-on-failure
+        python3 -m pytest -s -vvvv tests/test_array4.py
 
 # C:\\hostedtoolcache\\windows\\python\\3.9.10\\x64\\python3.exe
 # C:\\hostedtoolcache\\windows\\Python\\3.10.2\\x64\\python3.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Unit tests
       shell: cmd
       run: |
-        python3 -m pytest tests
+        python3 -m pytest -s -vvvv tests
 
   clang:
     name: Clang w/o MPI

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ python3 -m pytest tests/test_intvect.py
 
 # Run a single test (useful during debugging)
 python3 -m pytest tests/test_intvect.py::test_iv_conversions
+
+# Check all print and be maximum verbose
+python3 -m pytest -vvvv -s tests/test_multifab.py::test_mfab_simple
 ```
 
 ### Build Options

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ python3 -m pytest tests/test_intvect.py
 # Run a single test (useful during debugging)
 python3 -m pytest tests/test_intvect.py::test_iv_conversions
 
-# Check all print and be maximum verbose
-python3 -m pytest -vvvv -s tests/test_multifab.py::test_mfab_simple
+# Run all tests, do not capture "print" output and be verbose
+python3 -m pytest -s -vvvv tests/
 ```
 
 ### Build Options

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 The AMReX Community
+/* Copyright 2021-2022 The AMReX Community
  *
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -1,0 +1,160 @@
+/* Copyright 2021 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <AMReX_Config.H>
+#include <AMReX_Array4.H>
+#include <AMReX_IntVect.H>
+
+#include <sstream>
+#include <type_traits>
+
+namespace py = pybind11;
+using namespace amrex;
+
+
+template< typename T >
+void make_Array4(py::module &m, std::string typestr)
+{
+    // dispatch simpler via: py::format_descriptor<T>::format() naming
+    auto const array_name = std::string("Array4_").append(typestr);
+    py::class_< Array4<T> >(m, array_name.c_str(), py::buffer_protocol())
+        .def("__repr__",
+             [](Array4<T> const & a4) {
+                 std::stringstream s;
+                 s << a4.size();
+                 return "<amrex.Array4 of size '" + s.str() + "'>";
+             }
+        )
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+        .def("index_assert", &Array4<T>::index_assert)
+#endif
+
+        .def_property_readonly("size", &Array4<T>::size)
+        .def_property_readonly("nComp", &Array4<T>::nComp)
+
+        .def(py::init< >())
+        .def(py::init< Array4<T> const & >())
+        .def(py::init< Array4<T> const &, int >())
+        .def(py::init< Array4<T> const &, int, int >())
+        //.def(py::init< T*, Dim3 const &, Dim3 const &, int >())
+
+        .def(py::init([](py::array_t<T> & arr) {
+            py::buffer_info buf = arr.request();
+
+            auto a4 = std::make_unique< Array4<T> >();
+            a4.get()->p = (T*)buf.ptr;
+            a4.get()->begin = Dim3{0, 0, 0};
+            // TODO: likely C->F index conversion here
+            // p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];
+            a4.get()->end.x = (int)buf.shape.at(0);
+            a4.get()->end.y = (int)buf.shape.at(1);
+            a4.get()->end.z = (int)buf.shape.at(2);
+            a4.get()->ncomp = 1;
+            // buffer protocol strides are in bytes, AMReX strides are elements
+            a4.get()->jstride = (int)buf.strides.at(0) / sizeof(T);
+            a4.get()->kstride = (int)buf.strides.at(1) / sizeof(T);
+            a4.get()->nstride = (int)buf.strides.at(2) * (int)buf.shape.at(2) / sizeof(T);
+            return a4;
+        }))
+
+
+        .def_property_readonly("__array_interface__", [](Array4<T> const & a4) {
+            auto d = py::dict();
+            auto const len = length(a4);
+            // TODO: likely F->C index conversion here
+            // p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];
+            auto shape = py::make_tuple(  // Buffer dimensions
+                    len.x < 0 ? 0 : len.x,
+                    len.y < 0 ? 0 : len.y,
+                    len.z < 0 ? 0 : len.z//,  // zero-size shall not have negative dimension
+                    //a4.ncomp
+            );
+            // buffer protocol strides are in bytes, AMReX strides are elements
+            auto const strides = py::make_tuple(  // Strides (in bytes) for each index
+                    sizeof(T) * a4.jstride,
+                    sizeof(T) * a4.kstride,
+                    sizeof(T)//,
+                    //sizeof(T) * a4.nstride
+            );
+            d["data"] = py::make_tuple(long(a4.dataPtr()), false);
+            d["typestr"] = py::format_descriptor<T>::format();
+            d["shape"] = shape;
+            d["strides"] = strides;
+            // d["strides"] = py::none();
+            d["version"] = 3;
+            return d;
+        })
+
+        // not sure if useful to have this implemented on top
+/*
+        .def_buffer([](Array4<T> & a4) -> py::buffer_info {
+            auto const len = length(a4);
+            // TODO: likely F->C index conversion here
+            // p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];
+            auto shape = {  // Buffer dimensions
+                    len.x < 0 ? 0 : len.x,
+                    len.y < 0 ? 0 : len.y,
+                    len.z < 0 ? 0 : len.z//,  // zero-size shall not have negative dimension
+                    //a4.ncomp
+            };
+            // buffer protocol strides are in bytes, AMReX strides are elements
+            auto const strides = {  // Strides (in bytes) for each index
+                    sizeof(T) * a4.jstride,
+                    sizeof(T) * a4.kstride,
+                    sizeof(T)//,
+                    //sizeof(T) * a4.nstride
+            };
+            return py::buffer_info(
+                a4.dataPtr(),
+                shape,
+                strides
+            );
+        })
+*/
+    ;
+}
+
+void init_Array4(py::module &m) {
+    make_Array4< float >(m, "float");
+    make_Array4< double >(m, "double");
+    make_Array4< long double >(m, "longdouble");
+
+    make_Array4< short >(m, "short");
+    make_Array4< int >(m, "int");
+    make_Array4< long >(m, "long");
+    make_Array4< long long >(m, "longlong");
+
+    make_Array4< unsigned short >(m, "ushort");
+    make_Array4< unsigned int >(m, "uint");
+    make_Array4< unsigned long >(m, "ulong");
+    make_Array4< unsigned long long >(m, "ulonglong");
+
+    // std::complex< float|double|long double> ?
+
+    /*
+    py::class_< PolymorphicArray4, Array4 >(m, "PolymorphicArray4")
+        .def("__repr__",
+             [](PolymorphicArray4 const & pa4) {
+                 std::stringstream s;
+                 s << pa4.size();
+                 return "<amrex.PolymorphicArray4 of size '" + s.str() + "'>";
+             }
+        )
+    ;
+     */
+
+    // free standing C++ functions:
+    /*
+    contains
+    lbound
+    ubound
+    length
+    makePolymorphic
+    */
+}

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -58,8 +58,13 @@ void make_Array4(py::module &m, std::string typestr)
             //   We could also add support for 4D numpy arrays, treating the slowest
             //   varying index as component "n".
 
+            if (buf.format != py::format_descriptor<T>::format())
+                throw std::runtime_error("Incompatible format: expected '" +
+                    py::format_descriptor<T>::format() +
+                    "' and received '" + buf.format + "'!");
+
             auto a4 = std::make_unique< Array4<T> >();
-            a4.get()->p = (T*)buf.ptr;
+            a4.get()->p = static_cast<T*>(buf.ptr);
             a4.get()->begin = Dim3{0, 0, 0};
             // C->F index conversion here
             // p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -124,15 +124,22 @@ void make_Array4(py::module &m, std::string typestr)
         .def("contains", &Array4<T>::contains)
         //.def("__contains__", &Array4<T>::contains)
 
-        //.def("__setitem__", [](Array4<T> & a4, IntVect v, T const value){ a4(v[0], v[1], v[2]) = value; })
-        .def("__setitem__", [](Array4<T> & a4, std::array<int, 4> key, T const value){
+        // setter & getter
+        .def("__setitem__", [](Array4<T> & a4, IntVect const & v, T const value){ a4(v) = value; })
+        .def("__setitem__", [](Array4<T> & a4, std::array<int, 4> const key, T const value){
             a4(key[0], key[1], key[2], key[3]) = value;
         })
-        .def("__setitem__", [](Array4<T> & a4, std::array<int, 3> key, T const value){
+        .def("__setitem__", [](Array4<T> & a4, std::array<int, 3> const key, T const value){
             a4(key[0], key[1], key[2]) = value;
         })
 
-        // __getitem__
+        .def("__getitem__", [](Array4<T> & a4, IntVect const & v){ return a4(v); })
+        .def("__getitem__", [](Array4<T> & a4, std::array<int, 4> const key){
+            return a4(key[0], key[1], key[2], key[3]);
+        })
+        .def("__getitem__", [](Array4<T> & a4, std::array<int, 3> const key){
+            return a4(key[0], key[1], key[2]);
+        })
     ;
 
     // free standing C++ functions:

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -11,6 +11,7 @@
 #include <AMReX_BLassert.H>
 #include <AMReX_IntVect.H>
 
+#include <cstdint>
 #include <sstream>
 #include <type_traits>
 
@@ -110,7 +111,7 @@ void make_Array4(py::module &m, std::string typestr)
                     sizeof(T)  // fastest varying index
             );
             bool const read_only = false;
-            d["data"] = py::make_tuple(long(a4.dataPtr()), read_only);
+            d["data"] = py::make_tuple(std::intptr_t(a4.dataPtr()), read_only);
             //d["offset"] = 0;
             //d["mask"] = py::none();
 

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -52,6 +52,9 @@ void make_Array4(py::module &m, std::string typestr)
 
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(buf.ndim == 3,
                 "We can only create amrex::Array4 views into 3D Python arrays at the moment.");
+            // TODO:
+            //   In 2D, Array4 still needs to be accessed with (i,j,k) or (i,j,k,n), with k = 0.
+            //   Likewise in 1D.
 
             auto a4 = std::make_unique< Array4<T> >();
             a4.get()->p = (T*)buf.ptr;

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -23,7 +23,7 @@ void make_Array4(py::module &m, std::string typestr)
 {
     // dispatch simpler via: py::format_descriptor<T>::format() naming
     auto const array_name = std::string("Array4_").append(typestr);
-    py::class_< Array4<T> >(m, array_name.c_str(), py::buffer_protocol())
+    py::class_< Array4<T> >(m, array_name.c_str() /*, py::buffer_protocol() */)
         .def("__repr__",
              [](Array4<T> const & a4) {
                  std::stringstream s;

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -26,10 +26,11 @@ void make_Array4(py::module &m, std::string typestr)
     auto const array_name = std::string("Array4_").append(typestr);
     py::class_< Array4<T> >(m, array_name.c_str())
         .def("__repr__",
-             [](Array4<T> const & a4) {
+             [typestr](Array4<T> const & a4) {
                  std::stringstream s;
                  s << a4.size();
-                 return "<amrex.Array4 of size '" + s.str() + "'>";
+                 return "<amrex.Array4 of type '" + typestr +
+                        "' and size '" + s.str() + "'>";
              }
         )
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)

--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 The AMReX Community
+/* Copyright 2021-2022 The AMReX Community
  *
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL

--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -4,6 +4,7 @@
  * License: BSD-3-Clause-LBNL
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
 #include <AMReX_Config.H>
@@ -31,7 +32,7 @@ namespace
 
         Box3DConstIter& operator++() {
             // from FABio_ascii::write
-            if (m_it <= m_box.bigEnd()) {
+            if (m_it < m_box.bigEnd()) {
                 m_box.next(m_it.value());
                 return *this;
             }
@@ -82,6 +83,8 @@ void init_Box(py::module &m) {
         .def(py::init< IntVect const &, IntVect const &, IntVect const & >())
         //.def(py::init< IntVect const &, IntVect const &, IndexType >())
 
+        .def_property_readonly("small_end", [](Box const & bx){ return bx.smallEnd(); })
+        .def_property_readonly("big_end", [](Box const & bx){ return bx.bigEnd(); })
         /*
         .def_property("small_end",
             &Box::smallEnd,
@@ -89,7 +92,7 @@ void init_Box(py::module &m) {
         .def_property("big_end",
             &Box::bigEnd,
             &Box::setBig)
-        */
+
         .def_property("type",
             py::overload_cast<>(&Box::type, py::const_),
             &Box::setType)
@@ -126,13 +129,21 @@ void init_Box(py::module &m) {
         // atOffset
         // atOffset3d
         // setRange
-        // shift
         // shiftHalf
+        */
+        .def("shift", [](Box & bx, IntVect const& iv) { return bx.shift(iv); })
+
+        .def(py::self + IntVect())
+        .def(py::self - IntVect())
+        .def(py::self += IntVect())
+        .def(py::self -= IntVect())
 
         .def("convert",
              py::overload_cast< IndexType >(&Box::convert))
         .def("convert",
              py::overload_cast< IntVect const & >(&Box::convert))
+
+        .def("grow", [](Box & bx, IntVect const& iv) { return bx.grow(iv); })
 
         //.def("surrounding_nodes",
         //     py::overload_cast< >(&Box::surroundingNodes))

--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -17,6 +17,8 @@ using namespace amrex;
 
 
 void init_Box(py::module &m) {
+    py::class_< Direction >(m, "Direction");
+
     py::class_< Box >(m, "Box")
         .def("__repr__",
             [](Box const & b) {
@@ -57,8 +59,8 @@ void init_Box(py::module &m) {
 
         // loVect3d
         // hiVect3d
-        // loVect
-        // hiVect
+        .def_property_readonly("lo_vect", &Box::loVect)
+        .def_property_readonly("hi_vect", &Box::hiVect)
 
         .def("contains",
             py::overload_cast< IntVect const & >(&Box::contains, py::const_))
@@ -76,8 +78,21 @@ void init_Box(py::module &m) {
         // setRange
         // shift
         // shiftHalf
-        // convert
-        // surroundingNodes
+
+        .def("convert",
+             py::overload_cast< IndexType >(&Box::convert))
+        .def("convert",
+             py::overload_cast< IntVect const & >(&Box::convert))
+
+        //.def("surrounding_nodes",
+        //     py::overload_cast< >(&Box::surroundingNodes))
+        //.def("surrounding_nodes",
+        //     py::overload_cast< int >(&Box::surroundingNodes),
+        //     py::arg("dir"))
+        //.def("surrounding_nodes",
+        //     py::overload_cast< Direction >(&Box::surroundingNodes),
+        //     py::arg("d"))
+
         // enclosedCells
         // minBox
         // chop

--- a/src/Base/BoxArray.cpp
+++ b/src/Base/BoxArray.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 The AMReX Community
+/* Copyright 2021-2022 The AMReX Community
  *
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL

--- a/src/Base/BoxArray.cpp
+++ b/src/Base/BoxArray.cpp
@@ -1,0 +1,269 @@
+/* Copyright 2021 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <AMReX_Config.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_IntVect.H>
+
+#include <sstream>
+
+namespace py = pybind11;
+using namespace amrex;
+
+
+void init_BoxArray(py::module &m) {
+    /* A collection of Boxes stored in an Array.  It is a
+     * reference-counted concrete class, not a polymorphic one; i.e. you
+     * cannot use any of the List member functions with a BoxList
+     */
+    py::class_< BoxArray >(m, "BoxArray")
+        .def("__repr__",
+            [](BoxArray const & ba) {
+                std::stringstream s;
+                s << ba.size();
+                return "<amrex.BoxArray of size '" + s.str() + "'>";
+            }
+        )
+
+        //! Construct an empty BoxArray
+        .def(py::init<>())
+        //.def(py::init< BoxArray const& >())
+        //.def(py::init< BoxArray const&& >())
+
+        //! Construct a BoxArray from an array of Boxes of size nbox.
+        .def(py::init< Box const & >())
+        //! Construct a BoxArray from an array of Boxes of size nbox.
+        .def(py::init< const Box*, int >())
+
+        /*
+        //! Construct a BoxArray from a BoxList.
+        explicit BoxArray (const BoxList& bl);
+        explicit BoxArray (BoxList&& bl) noexcept;
+
+        BoxArray (const BoxArray& rhs, const BATransformer& trans);
+
+        BoxArray (BoxList&& bl, IntVect const& max_grid_size);
+        */
+
+        .def_property_readonly("size", &BoxArray::size)
+        .def_property_readonly("capacity", &BoxArray::capacity)
+        .def_property_readonly("empty", &BoxArray::empty)
+        .def_property_readonly("numPts", &BoxArray::numPts)
+        .def_property_readonly("d_numPts", &BoxArray::d_numPts)
+/*
+        .def_property("type",
+            py::overload_cast<>(&BoxArray::type, py::const_),
+            &Box::setType)
+
+        .def_property_readonly("length",
+            py::overload_cast<>(&Box::length, py::const_))
+        .def_property_readonly("is_empty", &Box::isEmpty)
+*/
+
+        .def("define",
+            py::overload_cast< Box const & >(&BoxArray::define))
+        //.def("define",
+        //    py::overload_cast< BoxList const & >(&BoxArray::define))
+        //.def("define",
+        //    py::overload_cast< BoxList&& >(&BoxArray::define))
+
+        .def("clear", &BoxArray::clear)
+        .def("resize", &BoxArray::resize)
+
+        .def("cell_equal", &BoxArray::CellEqual)
+
+        .def("max_size",
+            py::overload_cast< int >(&BoxArray::maxSize))
+        .def("max_size",
+            py::overload_cast< IntVect const& >(&BoxArray::maxSize))
+
+        .def("refine",
+            py::overload_cast< int >(&BoxArray::refine))
+        .def("refine",
+            py::overload_cast< IntVect const & >(&BoxArray::refine))
+
+        //! Coarsen each Box in the BoxArray to the specified ratio.
+        .def("coarsen",
+            py::overload_cast< IntVect const & >(&BoxArray::coarsen))
+        .def("coarsen",
+            py::overload_cast< int >(&BoxArray::coarsen))
+
+        //! Coarsen each Box in the BoxArray to the specified ratio.
+        .def("coarsenable",
+            py::overload_cast< int, int >(&BoxArray::coarsenable, py::const_))
+        .def("coarsenable",
+            py::overload_cast< IntVect const &, int >(&BoxArray::coarsenable, py::const_))
+        .def("coarsenable",
+            py::overload_cast< IntVect const &, IntVect const & >(&BoxArray::coarsenable, py::const_))
+
+/*
+    //! Grow and then coarsen each Box in the BoxArray.
+    BoxArray& growcoarsen (int n, const IntVect& refinement_ratio);
+    BoxArray& growcoarsen (IntVect const& ngrow, const IntVect& refinement_ratio);
+
+    //! Grow each Box in the BoxArray by the specified amount.
+    BoxArray& grow (int n);
+
+    //! Grow each Box in the BoxArray by the specified amount.
+    BoxArray& grow (const IntVect& iv);
+
+    //! \brief Grow each Box in the BoxArray on the low and high ends
+    //! by n_cell cells in the idir direction.
+    BoxArray& grow (int idir, int n_cell);
+
+    //! \brief Grow each Box in the BoxArray on the low end
+    /?! by n_cell cells in the idir direction.
+    BoxArray& growLo (int idir, int n_cell);
+
+    //! \brief Grow each Box in the BoxArray on the high end
+    //! by n_cell cells in the idir direction.
+    BoxArray& growHi (int idir, int n_cell);
+    //! \brief Apply surroundingNodes(Box) to each Box in BoxArray.
+    //! See the documentation of Box for details.
+    BoxArray& surroundingNodes ();
+    //!
+    //! \brief Apply surroundingNodes(Box,int) to each Box in
+    //! BoxArray.  See the documentation of Box for details.
+    BoxArray& surroundingNodes (int dir);
+
+    //! Apply Box::enclosedCells() to each Box in the BoxArray.
+    BoxArray& enclosedCells ();
+
+    //! Apply Box::enclosedCells(int) to each Box in the BoxArray.
+    BoxArray& enclosedCells  (int dir);
+
+    //! Apply Box::convert(IndexType) to each Box in the BoxArray.
+    BoxArray& convert (IndexType typ);
+
+    BoxArray& convert (const IntVect& typ);
+
+    //! Apply function (*fp)(Box) to each Box in the BoxArray.
+    BoxArray& convert (Box (*fp)(const Box&));
+
+    //! Apply Box::shift(int,int) to each Box in the BoxArray.
+    BoxArray& shift (int dir, int nzones);
+
+    //! Apply Box::shift(const IntVect &iv) to each Box in the BoxArray.
+    BoxArray& shift (const IntVect &iv);
+
+    //! Set element i in this BoxArray to Box ibox.
+    void set (int i, const Box& ibox);
+
+    //! Return element index of this BoxArray.
+    Box operator[] (int index) const noexcept {
+        return m_bat(m_ref->m_abox[index]);
+    }
+
+    //! Return element index of this BoxArray.
+    Box operator[] (const MFIter& mfi) const noexcept;
+
+    //! Return element index of this BoxArray.
+    Box get (int index) const noexcept { return operator[](index); }
+
+    //! Return cell-centered box at element index of this BoxArray.
+    Box getCellCenteredBox (int index) const noexcept {
+        return m_bat.coarsen(m_ref->m_abox[index]);
+    }
+
+    //! \brief Return true if Box is valid and they all have the same
+    //! IndexType.  Is true by default if the BoxArray is empty.
+    bool ok () const;
+
+    //! Return true if set of intersecting Boxes in BoxArray is null.
+    bool isDisjoint () const;
+
+    //! Create a BoxList from this BoxArray.
+    BoxList boxList () const;
+
+    //! True if the IntVect is within any of the Boxes in this BoxArray.
+    bool contains (const IntVect& v) const;
+
+    //! \brief True if the Box is contained in this BoxArray(+ng).
+    //! The Box must also have the same IndexType as those in this BoxArray.
+    bool contains (const Box& b, bool assume_disjoint_ba = false,
+                   const IntVect& ng = IntVect(0)) const;
+
+    //! \brief True if all Boxes in ba are contained in this BoxArray(+ng).
+    bool contains (const BoxArray& ba, bool assume_disjoint_ba = false,
+                   const IntVect& ng = IntVect(0)) const;
+
+    //! Return smallest Box that contains all Boxes in this BoxArray.
+    Box minimalBox () const;
+    Box minimalBox (Long& npts_avg_box) const;
+
+    //! \brief True if the Box intersects with this BoxArray(+ghostcells).
+    //! The Box must have the same IndexType as those in this BoxArray.
+    bool intersects (const Box& b, int ng = 0) const;
+
+    bool intersects (const Box& b, const IntVect& ng) const;
+
+    //! Return intersections of Box and BoxArray
+    std::vector< std::pair<int,Box> > intersections (const Box& bx) const;
+
+    //! Return intersections of Box and BoxArray(+ghostcells).
+    std::vector< std::pair<int,Box> > intersections (const Box& bx, bool first_only, int ng) const;
+
+    std::vector< std::pair<int,Box> > intersections (const Box& bx, bool first_only, const IntVect& ng) const;
+
+    //! intersect Box and BoxArray, then store the result in isects
+    void intersections (const Box& bx, std::vector< std::pair<int,Box> >& isects) const;
+
+    //! intersect Box and BoxArray(+ghostcells), then store the result in isects
+    void intersections (const Box& bx, std::vector< std::pair<int,Box> >& isects,
+                        bool first_only, int ng) const;
+
+    void intersections (const Box& bx, std::vector< std::pair<int,Box> >& isects,
+                        bool first_only, const IntVect& ng) const;
+
+    //! Return box - boxarray
+    BoxList complementIn (const Box& b) const;
+    void complementIn (BoxList& bl, const Box& b) const;
+
+    //! Clear out the internal hash table used by intersections.
+    void clear_hash_bin () const;
+
+    //! Change the BoxArray to one with no overlap and then simplify it (see the simplify function in BoxList).
+    void removeOverlap (bool simplify=true);
+
+    //! whether two BoxArrays share the same data
+    static bool SameRefs (const BoxArray& lhs, const BoxArray& rhs) { return lhs.m_ref == rhs.m_ref; }
+
+    struct RefID {
+        RefID () noexcept : data(nullptr) {}
+        explicit RefID (BARef* data_) noexcept : data(data_) {}
+        bool operator<  (const RefID& rhs) const noexcept { return std::less<BARef*>()(data,rhs.data); }
+        bool operator== (const RefID& rhs) const noexcept { return data == rhs.data; }
+        bool operator!= (const RefID& rhs) const noexcept { return data != rhs.data; }
+        friend std::ostream& operator<< (std::ostream& os, const RefID& id);
+    private:
+        BARef* data;
+    };
+
+    //! Return a unique ID of the reference
+    RefID getRefID () const noexcept { return RefID { m_ref.get() }; }
+
+    //! Return index type of this BoxArray
+    IndexType ixType () const noexcept { return m_bat.index_type(); }
+
+    //! Return crse ratio of this BoxArray
+    IntVect crseRatio () const noexcept { return m_bat.coarsen_ratio(); }
+
+    static void Initialize ();
+    static void Finalize ();
+    static bool initialized;
+
+    //! Make ourselves unique.
+    void uniqify ();
+
+    BoxList const& simplified_list () const; // For regular AMR grids only!!!
+    BoxArray simplified () const; // For regular AMR grids only!!!
+
+*/
+
+    ;
+}

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(pyAMReX
   PRIVATE
     AMReX.cpp
+    Array4.cpp
     Box.cpp
     BoxArray.cpp
     Dim3.cpp

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -4,4 +4,5 @@ target_sources(pyAMReX
     Box.cpp
     Dim3.cpp
     IntVect.cpp
+    MultiFab.cpp
 )

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -2,7 +2,9 @@ target_sources(pyAMReX
   PRIVATE
     AMReX.cpp
     Box.cpp
+    BoxArray.cpp
     Dim3.cpp
+    DistributionMapping.cpp
     IntVect.cpp
     MultiFab.cpp
 )

--- a/src/Base/DistributionMapping.cpp
+++ b/src/Base/DistributionMapping.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 The AMReX Community
+/* Copyright 2021-2022 The AMReX Community
  *
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL

--- a/src/Base/DistributionMapping.cpp
+++ b/src/Base/DistributionMapping.cpp
@@ -1,0 +1,79 @@
+/* Copyright 2021 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <AMReX_Config.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Vector.H>
+
+#include <sstream>
+
+namespace py = pybind11;
+using namespace amrex;
+
+
+void init_DistributionMapping(py::module &m) {
+    py::class_< DistributionMapping >(m, "DistributionMapping")
+        .def("__repr__",
+            [](DistributionMapping const & dm) {
+                std::stringstream s;
+                s << dm.size();
+                return "<amrex.DistributionMapping of size '" + s.str() + "'>";
+            }
+        )
+
+        .def(py::init< >())
+        .def(py::init< DistributionMapping const & >())
+        //.def(py::init< DistributionMapping && >())
+        //.def(py::init< DistributionMapping const &, DistributionMapping const & >())
+        .def(py::init< Vector< int > const & >())
+        //.def(py::init< Vector< int > && >())
+        .def(py::init< BoxArray const & >(),
+            py::arg("boxes")
+        )
+        .def(py::init< BoxArray const &, int >(),
+            py::arg("boxes"), py::arg("nprocs")
+        )
+
+        .def("define",
+            [](DistributionMapping & dm, BoxArray const & boxes) {
+                dm.define(boxes);
+            },
+            py::arg("boxes")
+        )
+        .def("define",
+            py::overload_cast< BoxArray const &, int >(&DistributionMapping::define),
+            py::arg("boxes"), py::arg("nprocs")
+        )
+        .def("define",
+            py::overload_cast< Vector< int > const & >(&DistributionMapping::define))
+        //.def("define",
+        //    py::overload_cast< Vector< int > && >(&DistributionMapping::define))
+        //! Length of the underlying processor map.
+        .def_property_readonly("size", &DistributionMapping::size)
+        .def_property_readonly("capacity", &DistributionMapping::capacity)
+        .def_property_readonly("empty", &DistributionMapping::empty)
+
+        //! Number of references to this DistributionMapping
+        .def_property_readonly("link_count", &DistributionMapping::linkCount)
+
+        /**
+         * \brief Returns a constant reference to the mapping of boxes in the
+         * underlying BoxArray to the CPU that holds the FAB on that Box.
+         * ProcessorMap()[i] is an integer in the interval [0, NCPU) where
+         * NCPU is the number of CPUs being used.
+         */
+        .def("ProcessorMap", &DistributionMapping::ProcessorMap)
+
+        //! Equivalent to ProcessorMap()[index].
+        .def("__getitem__",
+            [](DistributionMapping const & dm, int index) -> int {
+                return dm[index];
+            })
+    ;
+}

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -37,7 +37,6 @@ void init_MultiFab(py::module &m) {
 
     py::class_< FArrayBox >(m, "FArrayBox");
 
-    //py::class_< MFIterWrapper >(m, "MFIterWrapper");
     py::class_< MFIter >(m, "MFIter")
         .def("__repr__",
              [](MFIter const & mfi) {
@@ -307,12 +306,10 @@ void init_MultiFab(py::module &m) {
         /* data access in Box index space */
         .def("__iter__",
             [](MultiFab& mf) {
-                //return py::make_iterator(MFIterWrapper(mf), ValidSentinel{});
                 return MFIter(mf);
             },
             // Essential: keep object alive while iterator exists
             py::keep_alive<0, 1>()
-            //py::return_value_policy::reference_internal
         )
     ;
 }

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -1,6 +1,6 @@
-/* Copyright 2021 The AMReX Community
+/* Copyright 2021-2022 The AMReX Community
  *
- * Authors: Axel Huebl, ...
+ * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
 #include <pybind11/pybind11.h>

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -111,14 +111,14 @@ void init_MultiFab(py::module &m) {
 
         /* sizes, etc. */
         .def("min",
-             [](MultiFab const & mf, int comp) { mf.min(comp); })
+             [](MultiFab const & mf, int comp) { return mf.min(comp); })
         .def("min",
              py::overload_cast< int, int, bool >(&MultiFab::min, py::const_))
         .def("min",
              py::overload_cast< Box const &, int, int, bool >(&MultiFab::min, py::const_))
 
         .def("max",
-             [](MultiFab const & mf, int comp) { mf.max(comp); })
+             [](MultiFab const & mf, int comp) { return mf.max(comp); })
         .def("max",
              py::overload_cast< int, int, bool >(&MultiFab::max, py::const_))
         .def("max",
@@ -150,6 +150,8 @@ void init_MultiFab(py::module &m) {
         .def("abs", py::overload_cast< int, int, int >(&MultiFab::abs))
 
         .def("plus", py::overload_cast< Real, int >(&MultiFab::plus))
+        .def("plus", [](MultiFab & mf, Real val, int comp, int num_comp) {
+             mf.plus(val, comp, num_comp); })
         .def("plus", py::overload_cast< Real, int, int, int >(&MultiFab::plus))
         .def("plus", py::overload_cast< Real, Box const &, int >(&MultiFab::plus))
         .def("plus", py::overload_cast< Real, Box const &, int, int, int >(&MultiFab::plus))
@@ -161,11 +163,15 @@ void init_MultiFab(py::module &m) {
         .def("divi", py::overload_cast< MultiFab const &, int, int, int >(&MultiFab::divide))
 
         .def("mult", py::overload_cast< Real, int >(&MultiFab::mult))
+        .def("mult", [](MultiFab & mf, Real val, int comp, int num_comp) {
+             mf.mult(val, comp, num_comp); })
         .def("mult", py::overload_cast< Real, int, int, int >(&MultiFab::mult))
         .def("mult", py::overload_cast< Real, Box const &, int >(&MultiFab::mult))
         .def("mult", py::overload_cast< Real, Box const &, int, int, int >(&MultiFab::mult))
 
         .def("invert", py::overload_cast< Real, int >(&MultiFab::invert))
+        .def("invert", [](MultiFab & mf, Real val, int comp, int num_comp) {
+             mf.invert(val, comp, num_comp); })
         .def("invert", py::overload_cast< Real, int, int, int >(&MultiFab::invert))
         .def("invert", py::overload_cast< Real, Box const &, int >(&MultiFab::invert))
         .def("invert", py::overload_cast< Real, Box const &, int, int, int >(&MultiFab::invert))

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -28,12 +28,12 @@ void init_MultiFab(py::module &m) {
         .def("is_nodal",
              py::overload_cast< int >(&FabArrayBase::is_nodal, py::const_))
 
+        .def_property_readonly("nComp", &FabArrayBase::nComp)
         .def_property_readonly("num_comp", &FabArrayBase::nComp)
+        .def_property_readonly("size", &FabArrayBase::size)
     ;
 
     py::class_< FArrayBox >(m, "FArrayBox");
-
-    py::class_< FabArray<FArrayBox>, FabArrayBase >(m, "FabArray_FArrayBox");
 
     //py::class_< MFIterWrapper >(m, "MFIterWrapper");
     py::class_< MFIter >(m, "MFIter")
@@ -92,6 +92,13 @@ void init_MultiFab(py::module &m) {
         int index()
         int length()
         */
+    ;
+
+    py::class_< FabArray<FArrayBox>, FabArrayBase >(m, "FabArray_FArrayBox")
+        //.def("array", py::overload_cast< const MFIter& >(&FabArray<FArrayBox>::array))
+        //.def("const_array", &FabArray<FArrayBox>::const_array)
+        .def("array", [](FabArray<FArrayBox> & fa, MFIter const & mfi) {return fa.array(mfi);})
+        .def("const_array", [](FabArray<FArrayBox> & fa, MFIter const & mfi) {return fa.const_array(mfi);})
     ;
 
     py::class_< MultiFab, FabArray<FArrayBox> >(m, "MultiFab")

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -31,6 +31,8 @@ void init_MultiFab(py::module &m) {
         .def_property_readonly("nComp", &FabArrayBase::nComp)
         .def_property_readonly("num_comp", &FabArrayBase::nComp)
         .def_property_readonly("size", &FabArrayBase::size)
+
+        .def_property_readonly("nGrowVect", &FabArrayBase::nGrowVect)
     ;
 
     py::class_< FArrayBox >(m, "FArrayBox");

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -1,0 +1,171 @@
+/* Copyright 2021 The AMReX Community
+ *
+ * Authors: Axel Huebl, ...
+ * License: BSD-3-Clause-LBNL
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <AMReX_Config.H>
+#include <AMReX_MultiFab.H>
+
+#include <string>
+
+namespace py = pybind11;
+using namespace amrex;
+
+
+void init_MultiFab(py::module &m) {
+    py::class_< MultiFab >(m, "MultiFab")
+        .def("__repr__",
+             [](MultiFab const & mf) {
+                 return "<amrex.MultiFab with '" + std::to_string(mf.nComp()) +
+                        "' components>";
+             }
+        )
+
+        /* Constructors */
+        .def(py::init< >())
+        .def(py::init< const BoxArray&, const DistributionMapping&, int, int,
+                       MFInfo const &, FabFactory<FArrayBox>const & >())
+        .def(py::init< const BoxArray&, const DistributionMapping&, int,
+                       IntVect const&,
+                       MFInfo const&, FabFactory<FArrayBox> const & >())
+        .def(py::init< MultiFab const&, MakeType, int, int >())
+
+        /* delayed defines */
+        .def("define",
+            py::overload_cast< const BoxArray&, const DistributionMapping&, int, int,
+                               MFInfo const &, FabFactory<FArrayBox> const &
+        >(&MultiFab::define))
+        .def("define",
+            py::overload_cast< const BoxArray&, const DistributionMapping&, int,
+                               IntVect const&, MFInfo const &, FabFactory<FArrayBox> const &
+        >(&MultiFab::define))
+
+        /* sizes, etc. */
+        .def("min",
+             py::overload_cast< int, int, bool >(&MultiFab::min, py::const_))
+        .def("min",
+             py::overload_cast< Box const &, int, int, bool >(&MultiFab::min, py::const_))
+        .def("max",
+             py::overload_cast< int, int, bool >(&MultiFab::max, py::const_))
+        .def("max",
+             py::overload_cast< Box const &, int, int, bool >(&MultiFab::max, py::const_))
+        .def("minIndex", &MultiFab::minIndex)
+        .def("maxIndex", &MultiFab::maxIndex)
+
+        /* norms */
+        .def("norm0", py::overload_cast< int, int, bool, bool >(&MultiFab::norm0, py::const_))
+        //.def("norm0", py::overload_cast< iMultiFab const &, int, int, bool >(&MultiFab::norm0, py::const_))
+
+        .def("norminf", py::overload_cast< int, int, bool, bool >(&MultiFab::norminf, py::const_))
+        //.def("norminf", py::overload_cast< iMultiFab const &, int, int, bool >(&MultiFab::norminf, py::const_))
+
+        .def("norm1", py::overload_cast< int, Periodicity const&, bool >(&MultiFab::norm1, py::const_))
+        .def("norm1", py::overload_cast< int, int, bool >(&MultiFab::norm1, py::const_))
+        .def("norm1", py::overload_cast< Vector<int> const &, int, bool >(&MultiFab::norm1, py::const_))
+
+        .def("norm2", py::overload_cast< int >(&MultiFab::norm2, py::const_))
+        .def("norm2", py::overload_cast< int, Periodicity const& >(&MultiFab::norm2, py::const_))
+        .def("norm2", py::overload_cast< Vector<int> const & >(&MultiFab::norm2, py::const_))
+
+        /* simple math */
+        .def("sum", &MultiFab::sum)
+
+        .def("plus", py::overload_cast< Real, int >(&MultiFab::plus))
+        .def("plus", py::overload_cast< Real, int, int, int >(&MultiFab::plus))
+        .def("plus", py::overload_cast< Real, Box const &, int >(&MultiFab::plus))
+        .def("plus", py::overload_cast< Real, Box const &, int, int, int >(&MultiFab::plus))
+        .def("plus", py::overload_cast< MultiFab const &, int, int, int >(&MultiFab::plus))
+
+        .def("minus", py::overload_cast< MultiFab const &, int, int, int >(&MultiFab::minus))
+
+        // renamed: ImportError: overloading a method with both static and instance methods is not supported
+        .def("divi", py::overload_cast< MultiFab const &, int, int, int >(&MultiFab::divide))
+
+        .def("mult", py::overload_cast< Real, int >(&MultiFab::mult))
+        .def("mult", py::overload_cast< Real, int, int, int >(&MultiFab::mult))
+        .def("mult", py::overload_cast< Real, Box const &, int >(&MultiFab::mult))
+        .def("mult", py::overload_cast< Real, Box const &, int, int, int >(&MultiFab::mult))
+
+        .def("invert", py::overload_cast< Real, int >(&MultiFab::invert))
+        .def("invert", py::overload_cast< Real, int, int, int >(&MultiFab::invert))
+        .def("invert", py::overload_cast< Real, Box const &, int >(&MultiFab::invert))
+        .def("invert", py::overload_cast< Real, Box const &, int, int, int >(&MultiFab::invert))
+
+        .def("negate", py::overload_cast< int >(&MultiFab::negate))
+        .def("negate", py::overload_cast< int, int, int >(&MultiFab::negate))
+        .def("negate", py::overload_cast< Box const &, int >(&MultiFab::negate))
+        .def("negate", py::overload_cast< Box const &, int, int, int >(&MultiFab::negate))
+
+        .def("sum_boundary", py::overload_cast< Periodicity const & >(&MultiFab::SumBoundary))
+        .def("sum_boundary", py::overload_cast< int, int, Periodicity const & >(&MultiFab::SumBoundary))
+        .def("sum_boundary", py::overload_cast< int, int, IntVect const&, Periodicity const & >(&MultiFab::SumBoundary))
+
+        /* static (standalone) simple math functions */
+        .def_static("dot", py::overload_cast< MultiFab const &, int, MultiFab const &, int, int, int, bool >(&MultiFab::Dot))
+        .def_static("dot", py::overload_cast< MultiFab const &, int, int, int, bool >(&MultiFab::Dot))
+        //.def_static("dot", py::overload_cast< iMultiFab const&, const MultiFab&, int, MultiFab const&, int, int, int, bool >(&MultiFab::Dot))
+
+        .def_static("add", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, int >(&MultiFab::Add))
+        .def_static("add", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::Add))
+
+        .def_static("subtract", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, int >(&MultiFab::Subtract))
+        .def_static("subtract", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::Subtract))
+
+        .def_static("multiply", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, int >(&MultiFab::Multiply))
+        .def_static("multiply", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::Multiply))
+
+        .def_static("divide", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, int >(&MultiFab::Divide))
+        .def_static("divide", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::Divide))
+
+        .def_static("copy", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, int >(&MultiFab::Copy))
+        .def_static("copy", py::overload_cast< MultiFab &, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::Copy))
+
+        .def_static("swap", py::overload_cast< MultiFab &, MultiFab &, int, int, int, int >(&MultiFab::Swap))
+        .def_static("swap", py::overload_cast< MultiFab &, MultiFab &, int, int, int, IntVect const & >(&MultiFab::Swap))
+
+        .def_static("saxpy", py::overload_cast< MultiFab &, Real, MultiFab const &, int, int, int, int >(&MultiFab::Saxpy))
+        .def_static("saxpy", py::overload_cast< MultiFab &, Real, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::Saxpy))
+
+        .def_static("xpay", py::overload_cast< MultiFab &, Real, MultiFab const &, int, int, int, int >(&MultiFab::Xpay))
+        .def_static("xpay", py::overload_cast< MultiFab &, Real, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::Xpay))
+
+        .def_static("lin_comb", py::overload_cast< MultiFab &, Real, MultiFab const &, int, Real, MultiFab const &, int, int, int, int >(&MultiFab::LinComb))
+        .def_static("lin_comb", py::overload_cast< MultiFab &, Real, MultiFab const &, int, Real, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::LinComb))
+
+        .def_static("add_product", py::overload_cast< MultiFab &, MultiFab const &, int, MultiFab const &, int, int, int, int >(&MultiFab::AddProduct))
+        .def_static("add_product", py::overload_cast< MultiFab &, MultiFab const &, int, MultiFab const &, int, int, int, IntVect const & >(&MultiFab::AddProduct))
+
+        /* simple data validity checks */
+        .def("contains_nan", py::overload_cast< bool >(&MultiFab::contains_nan, py::const_))
+        .def("contains_nan", py::overload_cast< int, int, int, bool >(&MultiFab::contains_nan, py::const_))
+        .def("contains_nan", py::overload_cast< int, int, IntVect const &, bool >(&MultiFab::contains_nan, py::const_))
+
+        .def("contains_inf", py::overload_cast< bool >(&MultiFab::contains_inf, py::const_))
+        .def("contains_inf", py::overload_cast< int, int, int, bool >(&MultiFab::contains_inf, py::const_))
+        .def("contains_inf", py::overload_cast< int, int, IntVect const &, bool >(&MultiFab::contains_inf, py::const_))
+
+        /* masks & ownership */
+        // TODO:
+        // - OverlapMask -> std::unique_ptr<MultiFab>
+        // - OwnerMask -> std::unique_ptr<iMultiFab>
+
+        /* Syncs */
+        .def("average_sync", &MultiFab::AverageSync)
+        .def("weighted_sync", &MultiFab::WeightedSync)
+        .def("override_sync", py::overload_cast< Periodicity const & >(&MultiFab::OverrideSync))
+        //.def("override_sync", py::overload_cast< iMultiFab const &, Periodicity const & >(&MultiFab::OverrideSync))
+
+        /* Init & Finalize */
+        .def_static("initialize", &MultiFab::Initialize )
+        .def_static("finalize", &MultiFab::Finalize )
+
+        /* data access in Box index space */
+        //.def("__iter__")
+        //.def("array", [](MultiFab & mf, MFIter mfi) {
+        //    // return Array4Real...
+        //})
+    ;
+}

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -20,6 +20,7 @@ void init_AMReX(py::module&);
 void init_Box(py::module &);
 void init_Dim3(py::module&);
 void init_IntVect(py::module &);
+void init_MultiFab(py::module &);
 
 PYBIND11_MODULE(amrex_pybind, m) {
     m.doc() = R"pbdoc(
@@ -38,6 +39,7 @@ PYBIND11_MODULE(amrex_pybind, m) {
     init_Dim3(m);
     init_IntVect(m);
     init_Box(m);
+    init_MultiFab(m);
 
     // API runtime version
     //   note PEP-440 syntax: x.y.zaN but x.y.z.devN

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 The AMReX Community
+/* Copyright 2021-2022 The AMReX Community
  *
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -17,6 +17,7 @@ namespace py = pybind11;
 
 // forward declarations of exposed classes
 void init_AMReX(py::module&);
+void init_Array4(py::module&);
 void init_Box(py::module &);
 void init_BoxArray(py::module &);
 void init_Dim3(py::module&);
@@ -43,6 +44,7 @@ PYBIND11_MODULE(amrex_pybind, m) {
     init_AMReX(m);
     init_Dim3(m);
     init_IntVect(m);
+    init_Array4(m);
     init_Box(m);
     init_BoxArray(m);
     init_MultiFab(m);

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -18,7 +18,9 @@ namespace py = pybind11;
 // forward declarations of exposed classes
 void init_AMReX(py::module&);
 void init_Box(py::module &);
+void init_BoxArray(py::module &);
 void init_Dim3(py::module&);
+void init_DistributionMapping(py::module&);
 void init_IntVect(py::module &);
 void init_MultiFab(py::module &);
 
@@ -31,7 +33,10 @@ PYBIND11_MODULE(amrex_pybind, m) {
             .. autosummary::
                :toctree: _generate
                Box
+               BoxArray
+               Dim3
                IntVect
+               MultiFab
     )pbdoc";
 
     // note: order from parent to child classes
@@ -39,7 +44,9 @@ PYBIND11_MODULE(amrex_pybind, m) {
     init_Dim3(m);
     init_IntVect(m);
     init_Box(m);
+    init_BoxArray(m);
     init_MultiFab(m);
+    init_DistributionMapping(m);
 
     // API runtime version
     //   note PEP-440 syntax: x.y.zaN but x.y.z.devN

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import itertools
 import pytest
 import amrex
 
@@ -26,3 +27,12 @@ def distmap(boxarr):
     """DistributionMapping for MultiFab creation"""
     dm = amrex.DistributionMapping(boxarr)
     return dm
+
+@pytest.fixture(params=list(itertools.product([1,3],[0,1])))
+def mfab(boxarr, distmap, request):
+    """MultiFab for tests"""
+    num_components = request.param[0]
+    num_ghost = request.param[1]
+    mfab = amrex.MultiFab(boxarr, distmap, num_components, num_ghost)
+    mfab.set_val(0.0, 0, num_components)
+    return mfab

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,18 @@ def amrex_init():
     amrex.initialize(["amrex.verbose=-1"])
     yield
     amrex.finalize()
+
+@pytest.fixture(scope='module')
+def boxarr():
+    """BoxArray for MultiFab creation"""
+    #bx = amrex.Box.new((0, 0, 0), (63, 63, 63))
+    bx = amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(63, 63, 63))
+    ba = amrex.BoxArray(bx)
+    ba.max_size(32)
+    return ba
+
+@pytest.fixture(scope='module')
+def distmap(boxarr):
+    """DistributionMapping for MultiFab creation"""
+    dm = amrex.DistributionMapping(boxarr)
+    return dm

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+import amrex
+
+def test_array4_empty():
+    empty = amrex.Array4_double()
+
+    # Check properties
+    assert(empty.size == 0)
+    assert(empty.nComp == 0)
+
+    # assign empty
+    emptyc = amrex.Array4_double(empty)
+    # Check properties
+    assert(emptyc.size == 0)
+    assert(emptyc.nComp == 0)
+
+def test_array4():
+    # from numpy (also a non-owning view)
+    x = np.ones((2, 3, 4,))
+    arr = amrex.Array4_double(x)
+
+    x[1, 1, 1] = 42
+    # TypeError: 'amrex.amrex_pybind.Array4_double' object is not subscriptable
+    # assert(arr[1, 1, 1] == 42)
+
+    # copy to numpy
+    c_arr2np = np.array(arr, copy=True)
+    assert(c_arr2np.ndim == 3)
+    #assert(c_arr2np.ndim == 4)
+    assert(c_arr2np.dtype == np.dtype("double"))
+    np.testing.assert_array_equal(x, c_arr2np)
+    assert(c_arr2np[1, 1, 1] == 42)
+
+    # view to numpy
+    v_arr2np = np.array(arr, copy=False)
+    assert(v_arr2np.ndim == 3)
+    #assert(c_arr2np.ndim == 4)
+    assert(v_arr2np.dtype == np.dtype("double"))
+    np.testing.assert_array_equal(x, v_arr2np)
+    assert(v_arr2np[1, 1, 1] == 42)
+
+    # change original buffer once more
+    x[1, 1, 1] = 43
+    assert(v_arr2np[1, 1, 1] == 43)
+
+    # copy array4 (view)
+    c_arr = amrex.Array4_double(arr)
+    v_carr2np = np.array(c_arr, copy=False)
+    x[1, 1, 1] = 44
+    assert(v_carr2np[1, 1, 1] == 44)
+
+    # from cupy
+
+    # to numpy
+
+    # to cupy
+
+    return
+
+    # Check indexing
+    assert(obj[0] == 1)
+    assert(obj[1] == 2)
+    assert(obj[2] == 3)
+    assert(obj[-1] == 3)
+    assert(obj[-2] == 2)
+    assert(obj[-3] == 1)
+    with pytest.raises(IndexError):
+        obj[-4]
+    with pytest.raises(IndexError):
+        obj[3]
+
+    # Check assignment
+    obj[0] = 2
+    obj[1] = 3
+    obj[2] = 4
+    assert(obj[0] == 2)
+    assert(obj[1] == 3)
+    assert(obj[2] == 4)
+
+#def test_iv_conversions():
+#    obj = amrex.IntVect.max_vector().numpy()
+#    assert(isinstance(obj, np.ndarray))
+#    assert(obj.dtype == np.int32)

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -26,6 +26,7 @@ def test_array4(capsys):
     with capsys.disabled():
         print(arr.__array_interface__)
     assert(arr.nComp == 1)
+    return
 
     x[1, 1, 1] = 42
     # TypeError: 'amrex.amrex_pybind.Array4_double' object is not subscriptable

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -22,6 +22,7 @@ def test_array4(capsys):
     x = np.ones((2, 3, 4,))
     with capsys.disabled():
         print(x.__array_interface__)
+        print(x.dtype)
     arr = amrex.Array4_double(x)
     with capsys.disabled():
         print(arr.__array_interface__)
@@ -30,6 +31,9 @@ def test_array4(capsys):
     x[1, 1, 1] = 42
     # TypeError: 'amrex.amrex_pybind.Array4_double' object is not subscriptable
     # assert(arr[1, 1, 1] == 42)
+    
+    # hack:
+    return
 
     # copy to numpy
     c_arr2np = np.array(arr, copy=True)  # segfaults on Windows

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -23,6 +23,7 @@ def test_array4():
     print(f"\nx: {x.__array_interface__} {x.dtype}")
     arr = amrex.Array4_double(x)
     print(f"arr: {arr.__array_interface__}")
+    print(arr)
     assert(arr.nComp == 1)
 
     # change original array

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -17,15 +17,12 @@ def test_array4_empty():
     assert(emptyc.size == 0)
     assert(emptyc.nComp == 0)
 
-def test_array4(capsys):
+def test_array4():
     # from numpy (also a non-owning view)
     x = np.ones((2, 3, 4,))
-    with capsys.disabled():
-        print(x.__array_interface__)
-        print(x.dtype)
+    print(f"\nx: {x.__array_interface__} {x.dtype}")
     arr = amrex.Array4_double(x)
-    with capsys.disabled():
-        print(arr.__array_interface__)
+    print(f"arr: {arr.__array_interface__}")
     assert(arr.nComp == 1)
 
     # change original array
@@ -41,8 +38,7 @@ def test_array4(capsys):
     c_arr2np = np.array(arr, copy=True)  # segfaults on Windows
     assert(c_arr2np.ndim == 4)
     assert(c_arr2np.dtype == np.dtype("double"))
-    with capsys.disabled():
-        print(c_arr2np.__array_interface__)
+    print(f"c_arr2np: {c_arr2np.__array_interface__}")
     np.testing.assert_array_equal(x, c_arr2np[0, :, :, :])
     assert(c_arr2np[0, 1, 1, 1] == 42)
 

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -28,7 +28,7 @@ def test_array4():
     # assert(arr[1, 1, 1] == 42)
 
     # copy to numpy
-    c_arr2np = np.array(arr, copy=True)
+    c_arr2np = np.array(arr, copy=True)  # segfaults on Windows
     assert(c_arr2np.ndim == 4)
     assert(c_arr2np.dtype == np.dtype("double"))
     np.testing.assert_array_equal(x, c_arr2np[:, :, :, 0])

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -31,9 +31,6 @@ def test_array4(capsys):
     x[1, 1, 1] = 42
     # TypeError: 'amrex.amrex_pybind.Array4_double' object is not subscriptable
     # assert(arr[1, 1, 1] == 42)
-    
-    # hack:
-    return
 
     # copy to numpy
     c_arr2np = np.array(arr, copy=True)  # segfaults on Windows

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -20,7 +20,9 @@ def test_array4_empty():
 def test_array4():
     # from numpy (also a non-owning view)
     x = np.ones((2, 3, 4,))
+    print(x.__array_interface__)
     arr = amrex.Array4_double(x)
+    print(arr.__array_interface__)
     assert(arr.nComp == 1)
 
     x[1, 1, 1] = 42

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -26,7 +26,6 @@ def test_array4(capsys):
     with capsys.disabled():
         print(arr.__array_interface__)
     assert(arr.nComp == 1)
-    return
 
     x[1, 1, 1] = 42
     # TypeError: 'amrex.amrex_pybind.Array4_double' object is not subscriptable
@@ -36,25 +35,27 @@ def test_array4(capsys):
     c_arr2np = np.array(arr, copy=True)  # segfaults on Windows
     assert(c_arr2np.ndim == 4)
     assert(c_arr2np.dtype == np.dtype("double"))
-    np.testing.assert_array_equal(x, c_arr2np[:, :, :, 0])
-    assert(c_arr2np[1, 1, 1] == 42)
+    with capsys.disabled():
+        print(c_arr2np.__array_interface__)
+    np.testing.assert_array_equal(x, c_arr2np[0, :, :, :])
+    assert(c_arr2np[0, 1, 1, 1] == 42)
 
     # view to numpy
     v_arr2np = np.array(arr, copy=False)
     assert(c_arr2np.ndim == 4)
     assert(v_arr2np.dtype == np.dtype("double"))
-    np.testing.assert_array_equal(x, v_arr2np[:, :, :, 0])
-    assert(v_arr2np[1, 1, 1] == 42)
+    np.testing.assert_array_equal(x, v_arr2np[0, :, :, :])
+    assert(v_arr2np[0, 1, 1, 1] == 42)
 
     # change original buffer once more
     x[1, 1, 1] = 43
-    assert(v_arr2np[1, 1, 1] == 43)
+    assert(v_arr2np[0, 1, 1, 1] == 43)
 
     # copy array4 (view)
     c_arr = amrex.Array4_double(arr)
     v_carr2np = np.array(c_arr, copy=False)
     x[1, 1, 1] = 44
-    assert(v_carr2np[1, 1, 1] == 44)
+    assert(v_carr2np[0, 1, 1, 1] == 44)
 
     # from cupy
 

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -17,12 +17,14 @@ def test_array4_empty():
     assert(emptyc.size == 0)
     assert(emptyc.nComp == 0)
 
-def test_array4():
+def test_array4(capsys):
     # from numpy (also a non-owning view)
     x = np.ones((2, 3, 4,))
-    print(x.__array_interface__)
+    with capsys.disabled():
+        print(x.__array_interface__)
     arr = amrex.Array4_double(x)
-    print(arr.__array_interface__)
+    with capsys.disabled():
+        print(arr.__array_interface__)
     assert(arr.nComp == 1)
 
     x[1, 1, 1] = 42

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -21,6 +21,7 @@ def test_array4():
     # from numpy (also a non-owning view)
     x = np.ones((2, 3, 4,))
     arr = amrex.Array4_double(x)
+    assert(arr.nComp == 1)
 
     x[1, 1, 1] = 42
     # TypeError: 'amrex.amrex_pybind.Array4_double' object is not subscriptable
@@ -28,18 +29,16 @@ def test_array4():
 
     # copy to numpy
     c_arr2np = np.array(arr, copy=True)
-    assert(c_arr2np.ndim == 3)
-    #assert(c_arr2np.ndim == 4)
+    assert(c_arr2np.ndim == 4)
     assert(c_arr2np.dtype == np.dtype("double"))
-    np.testing.assert_array_equal(x, c_arr2np)
+    np.testing.assert_array_equal(x, c_arr2np[:, :, :, 0])
     assert(c_arr2np[1, 1, 1] == 42)
 
     # view to numpy
     v_arr2np = np.array(arr, copy=False)
-    assert(v_arr2np.ndim == 3)
-    #assert(c_arr2np.ndim == 4)
+    assert(c_arr2np.ndim == 4)
     assert(v_arr2np.dtype == np.dtype("double"))
-    np.testing.assert_array_equal(x, v_arr2np)
+    np.testing.assert_array_equal(x, v_arr2np[:, :, :, 0])
     assert(v_arr2np[1, 1, 1] == 42)
 
     # change original buffer once more

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -28,9 +28,14 @@ def test_array4(capsys):
         print(arr.__array_interface__)
     assert(arr.nComp == 1)
 
+    # change original array
     x[1, 1, 1] = 42
-    # TypeError: 'amrex.amrex_pybind.Array4_double' object is not subscriptable
-    # assert(arr[1, 1, 1] == 42)
+    # check values in Array4 view changed
+    assert(arr[1, 1, 1] == 42)
+    assert(arr[1, 1, 1, 0] == 42)  # with component
+    # check existing values stayed
+    assert(arr[0, 0, 0] == 1)
+    assert(arr[3, 2, 1] == 1)
 
     # copy to numpy
     c_arr2np = np.array(arr, copy=True)  # segfaults on Windows

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -33,6 +33,7 @@ def box():
 #    assert(bx.num_pts == 129 * 128 * 128)
 #    assert(bx.volume == 128**3)
 
+'''
 @pytest.mark.parametrize("dir", [-1, 0, 1, 2])
 def test_surrounding_nodes(box, dir):
     """Surrounding nodes"""
@@ -67,3 +68,4 @@ def test_enclosed_cells(box, dir):
         assert(bx.volume == 128**3)
         nx[dir] -= 1
         np.testing.assert_allclose(bx.hi_vect, nx)
+'''

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+import amrex
+
+@pytest.fixture
+def box():
+    #return amrex.Box((0, 0, 0), (127, 127, 127))
+    return amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(127, 127, 127))
+
+#def test_num_pts(box):
+#    np.testing.assert_allclose(box.lo_vect, [0, 0, 0])
+#    np.testing.assert_allclose(box.hi_vect, [127, 127, 127])
+#    assert(box.num_pts == 2**21)
+#    assert(box.volume == 2**21)
+
+#def test_grow(box):
+#    """box.grow"""
+#    bx = box.grow(3)
+#    np.testing.assert_allclose(bx.lo_vect, [-3, -3, -3])
+#    np.testing.assert_allclose(bx.hi_vect, [130, 130, 130])
+#    assert(bx.num_pts == (134**3))
+
+#def test_convert(box):
+#    """Conversion to node"""
+#    bx = box.convert(amrex.CellIndex.NODE, amrex.CellIndex.NODE, amrex.CellIndex.NODE)
+#    assert(bx.num_pts == 129**3)
+#    assert(bx.volume == 128**3)
+
+#    bx = box.convert(amrex.CellIndex.NODE, amrex.CellIndex.CELL, amrex.CellIndex.CELL)
+#    np.testing.assert_allclose(bx.hi_vect, [128, 127, 127])
+#    assert(bx.num_pts == 129 * 128 * 128)
+#    assert(bx.volume == 128**3)
+
+@pytest.mark.parametrize("dir", [-1, 0, 1, 2])
+def test_surrounding_nodes(box, dir):
+    """Surrounding nodes"""
+    nx = np.array(box.hi_vect)
+    bx = box.surrounding_nodes(dir=dir)
+
+    if dir < 0:
+        assert(bx.num_pts == 129**3)
+        assert(bx.volume == 128**3)
+        nx += 1
+        np.testing.assert_allclose(bx.hi_vect, nx)
+    else:
+        assert(bx.num_pts == 129 * 128 * 128)
+        assert(bx.volume == 128**3)
+        nx[dir] += 1
+        np.testing.assert_allclose(bx.hi_vect, nx)
+
+@pytest.mark.parametrize("dir", [-1, 0, 1, 2])
+def test_enclosed_cells(box, dir):
+    """Enclosed cells"""
+    bxn = box.convert(amrex.CellIndex.NODE, amrex.CellIndex.NODE, amrex.CellIndex.NODE)
+    nx = np.array(bxn.hi_vect)
+    bx = bxn.enclosed_cells(dir)
+
+    if dir < 0:
+        assert(bx.num_pts == 128**3)
+        assert(bx.volume == 128**3)
+        nx -= 1
+        np.testing.assert_allclose(bx.hi_vect, nx)
+    else:
+        assert(bx.num_pts == 129 * 129 * 128)
+        assert(bx.volume == 128**3)
+        nx[dir] -= 1
+        np.testing.assert_allclose(bx.hi_vect, nx)

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -57,7 +57,8 @@ def test_mfab_loop(mfab, nghost):
 
 def test_mfab_simple(mfab):
     assert(mfab.is_all_cell_centered)
-    assert(all(not mfab.is_nodal(i) for i in [-1, 0, 1, 2]))
+    #assert(all(not mfab.is_nodal(i) for i in [-1, 0, 1, 2]))  # -1??
+    assert(all(not mfab.is_nodal(i) for i in [0, 1, 2]))
 
     for i in range(mfab.num_comp):
         mfab.set_val(-10 * (i + 1), i, 1)

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+import itertools
+import numpy as np
+import pytest
+import amrex
+
+
+#@pytest.fixture(params=list(itertools.product([1,3],[0,1])))
+def mfab1(boxarr, distmap, request):
+    """MultiFab for tests"""
+    num_components = 3 #request.param[0]
+    num_ghost = 1 #request.param[1]
+    mfab = amrex.MultiFab(boxarr, distmap, num_components, num_ghost)
+    mfab.set_val(0.0, 0, num_components)
+    return mfab # issue here when used as fixture
+
+@pytest.mark.parametrize("nghost", [0, 1])
+def test_mfab_loop(boxarr, distmap, nghost):
+    mfab = amrex.MultiFab(boxarr, distmap, 3, nghost)
+    # Looping
+    for mfi in mfab:
+        bx = mfi.tilebox()
+        marr = mfab.array(mfi) # Array4: add __array_interface__ here
+
+        for i, j, k in bx:
+            mar[i, j, k, 0] = 10.0 * i
+            mar[i, j, k, 1] = 10.0 * j
+            mar[i, j, k, 2] = 10.0 * k
+            print(i,j,k)
+
+def test_mfab_simple(boxarr, distmap, request):
+    mfab = mfab1(boxarr, distmap, request)
+    assert(mfab.is_cell_centered)
+    assert(all(not mfab.is_nodal(i) for i in [-1, 0, 1, 2]))
+
+    for i in range(mfab.num_comp):
+        mfab.set_val(-10 * (i + 1), i, 1)
+    mfab.abs(0, mfab.num_comp)
+    for i in range(mfab.num_comp):
+        assert(mfab.max(i) == (10 * (i + 1))) # Assert: None == 10 for i=0
+        assert(mfab.min(i) == (10 * (i + 1)))
+
+    mfab.plus(20.0, 0, mfab.num_comp)
+    for i in range(mfab.num_comp):
+        np.testing.assert_allclose(mfab.max(i), 20.0 + (10 * (i + 1)))
+        np.testing.assert_allclose(mfab.min(i), 20.0 + (10 * (i + 1)))
+
+    mfab.mult(10.0, 0, mfab.num_comp)
+    for i in range(mfab.num_comp):
+        np.testing.assert_allclose(mfab.max(i), 10.0 * (20.0 + (10 * (i + 1))))
+        np.testing.assert_allclose(mfab.min(i), 10.0 * (20.0 + (10 * (i + 1))))
+    mfab.invert(10.0, 0, mfab.num_comp)
+    for i in range(mfab.num_comp):
+        np.testing.assert_allclose(mfab.max(i), 1.0 / (20.0 + (10 * (i + 1))))
+        np.testing.assert_allclose(mfab.min(i), 1.0 / (20.0 + (10 * (i + 1))))
+'''
+@pytest.mark.parametrize("nghost", [0, 1])
+def test_mfab_ops(boxarr, distmap, nghost):
+    src = amrex.MultiFab(boxarr, distmap, 3, nghost)
+    dst = amrex.MultiFab(boxarr, distmap, 1, nghost)
+
+    src.set_val(10.0, 0, 1)
+    src.set_val(20.0, 1, 1)
+    src.set_val(30.0, 2, 1)
+    dst.set_val(0.0, 0, 1)
+
+    dst.add(src, 2, 0, 1, nghost)
+    dst.subtract(src, 1, 0, 1, nghost)
+    dst.multiply(src, 0, 0, 1, nghost)
+    dst.divide(src, 1, 0, 1, nghost)
+    np.testing.assert_allclose(dst.min(0), 5.0)
+    np.testing.assert_allclose(dst.max(0), 5.0)
+
+    dst.xpay(2.0, src, 0, 0, 1, nghost)
+    dst.saxpy(2.0, src, 1, 0, 1, nghost)
+    np.testing.assert_allclose(dst.min(0), 60.0)
+    np.testing.assert_allclose(dst.max(0), 60.0)
+
+    dst.lin_comb(6.0, src, 1,
+                 1.0, src, 2, 0, 1, nghost)
+    np.testing.assert_allclose(dst.min(0), 150.0)
+    np.testing.assert_allclose(dst.max(0), 150.0)
+'''

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -9,7 +9,7 @@ import amrex
 def test_mfab_loop(mfab, nghost):
     for mfi in mfab:
         print(mfi)
-        #bx = mfi.tilebox()
+        bx = mfi.tilebox()
         #marr = mfab.array(mfi) # Array4: add __array_interface__ here
 
         #for i, j, k in bx:

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -9,15 +9,14 @@ import amrex
 def test_mfab_loop(mfab, nghost):
     for mfi in mfab:
         print(mfi)
-        bx = mfi.tilebox()
-        marr = mfab.array(mfi) # Array4: add __array_interface__ here
+        #bx = mfi.tilebox()
+        #marr = mfab.array(mfi) # Array4: add __array_interface__ here
 
-        for i, j, k in bx:
-            mar[i, j, k, 0] = 10.0 * i
-            mar[i, j, k, 1] = 10.0 * j
-            mar[i, j, k, 2] = 10.0 * k
-            print(i,j,k)
-        assert(mar[1, 2, 3, 1] == 42)
+        #for i, j, k in bx:
+        #   mar[i, j, k, 0] = 10.0 * i
+        #    mar[i, j, k, 1] = 10.0 * j
+        #    mar[i, j, k, 2] = 10.0 * k
+        #    print(i,j,k)
 
 
 def test_mfab_simple(mfab):

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -10,13 +10,28 @@ def test_mfab_loop(mfab, nghost):
     for mfi in mfab:
         print(mfi)
         bx = mfi.tilebox()
-        #marr = mfab.array(mfi) # Array4: add __array_interface__ here
+        marr = mfab.array(mfi) # Array4: add __array_interface__ here
 
-        #for i, j, k in bx:
-        #   mar[i, j, k, 0] = 10.0 * i
-        #    mar[i, j, k, 1] = 10.0 * j
-        #    mar[i, j, k, 2] = 10.0 * k
-        #    print(i,j,k)
+        print(mfab)
+        print(mfab.num_comp)
+        print(mfab.size)
+        print(marr.size)
+        print(marr.nComp)
+
+        # slow, index by index assignment
+        for i, j, k in bx:
+            #print(i,j,k)
+            marr[i, j, k] = 10.0 * i
+            #marr[i, j, k, 0] = 10.0 * i
+            #marr[i, j, k, 1] = 10.0 * j
+            #marr[i, j, k, 2] = 10.0 * k
+
+        # fast, range based assignment
+        # TODO
+
+        # challenge: offset from our index space for...
+        # extra test: numpy assignment
+        # extra test: cupy assignment
 
 
 def test_mfab_simple(mfab):

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -62,8 +62,15 @@ def test_mfab_loop(mfab, nghost):
 
         #   all components and all indices set at once to 42
         marr_np[:, :, :, :] = 42.
+
+        # values in start & end still match?
         assert(marr_np[0, 0, 0, 0] == marr[bx.small_end])
         assert(marr_np[-1, -1, -1, -1] == marr[bx.big_end])
+
+        # all values for all indices match between multifab & numpy view?
+        for n in range(mfab.num_comp):
+            for i, j, k in bx:
+                assert(marr[i, j, k, n] == 42.)
 
         # separate test: cupy assignment & reading
         #   TODO

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -20,7 +20,7 @@ def test_mfab_loop(mfab, nghost):
 
 
 def test_mfab_simple(mfab):
-    assert(mfab.is_cell_centered)
+    assert(mfab.is_all_cell_centered)
     assert(all(not mfab.is_nodal(i) for i in [-1, 0, 1, 2]))
 
     for i in range(mfab.num_comp):


### PR DESCRIPTION
Reimplementation of the successful MFiter concepts from: https://github.com/sayerhs/pyamrex for `MultiFab`, avoiding copies. Reimplementation of `yield` continuations with an iterator.

Start new concepts for `Array4` - first via `__array_interface__`:  #17 / https://github.com/AMReX-Codes/pyamrex/issues/9#issuecomment-778679635

- we will make Array4(Real/Int) createable only by MultiFabs (`amrex::Box` indexing semantics by default for everything: index `-1` is ghost)
- add explicit `asarray` / `as_numpy` / `as_cupy` functions for non-owning data from it: (`numpy`/Python Buffer Interface semantics for everything: index `-1` is end of array)
- make data copies explicit or fail if coming from device (check also pytorch & tensorflow interfaces for good vibes)

Refs.:
- https://github.com/sayerhs/pyamrex/blob/master/amrex/amrex_base.pyx#L502-L511
- https://github.com/sayerhs/pyamrex/blob/master/amrex/cpp/multifab.pxi
- https://sayerhs.github.io/pyamrex/index.html#amrex.amrex_base.MultiFab
```py
# assume a MultiFab mfab with 3 components
ngv = mfab.nGrowVect

# Looping
for mfi in mfab:
    bx = mfi.tilebox().grow(ngv)
    marr = mfab.array(mfi) # Array4: added __array_interface__ here

    # index by index assignment
    # - this is AMReX Array4, F-order indices
    # - even though we iterate by fastest varying index, such loops are naturally very slow in Python
    for i, j, k in bx:
        mar[i, j, k, 0] = 10.0 * i
        mar[i, j, k, 1] = 10.0 * j
        mar[i, j, k, 2] = 10.0 * k

    # numpy representation: non-copying view, including the
    # guard/ghost region
    #   note: in numpy, indices are in C-order!
    marr_np = np.array(marr, copy=False)

    # all components at all indices set at once to 42
    marr_np[:, :, :, :] = 42.
    # first component at all indices set at once to 12
    marr_np[0, :, :, :] = 12.

    # check the values at start/end are the same between MultiFab and numpy view in it: first component
    assert(marr_np[0, 0, 0, 0] == marr[bx.small_end])
    assert(marr_np[0, -1, -1, -1] == marr[bx.big_end])
```