### PR TITLE
C++17 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ if(POLICY CMP0105)
 endif()
 
 
+# C++ Standard in Superbuilds #################################################
+#
+# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# openPMD-api until they increase their requirement.
+set_cxx17_superbuild()
+
+
 # CCache Support ##############################################################
 #
 # this is an optional tool that stores compiled object files; allows fast

--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -1,3 +1,31 @@
+# Set C++17 for the whole build if not otherwise requested
+#
+# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# openPMD-api until they increase their requirement.
+#
+macro(set_cxx17_superbuild)
+    if(NOT DEFINED CMAKE_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD 17)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
+        set(CMAKE_CXX_EXTENSIONS OFF)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    endif()
+
+    if(NOT DEFINED CMAKE_CUDA_STANDARD)
+        set(CMAKE_CUDA_STANDARD 17)
+    endif()
+    if(NOT DEFINED CMAKE_CUDA_EXTENSIONS)
+        set(CMAKE_CUDA_EXTENSIONS OFF)
+    endif()
+    if(NOT DEFINED CMAKE_CUDA_STANDARD_REQUIRED)
+        set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    endif()
+endmacro()
+
+
 # find the CCache tool and use it if found
 #
 macro(set_ccache)


### PR DESCRIPTION
Seen in #19:
```
  In file included from /home/runner/work/pyamrex/pyamrex/build/temp.linux-x86_64-3.6/3/_deps/fetchedamrex-src/Src/Base/AMReX_FabArray.H:13:
  /home/runner/work/pyamrex/pyamrex/build/temp.linux-x86_64-3.6/3/_deps/fetchedamrex-src/Src/Base/AMReX_FabFactory.H:52:5: error: use of the 'nodiscard' attribute is a C++17 extension [-Werror,-Wc++17-extensions]
      AMREX_NODISCARD
      ^
  /home/runner/work/pyamrex/pyamrex/build/temp.linux-x86_64-3.6/3/_deps/fetchedamrex-src/Src/Base/AMReX_Extension.H:185:30: note: expanded from macro 'AMREX_NODISCARD'
  #   define AMREX_NODISCARD [[nodiscard]]
                               ^
```

and no need to restrict us to C++14 anyway here :)