### PR TITLE
CMake: Add More Pip Helpers

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -29,6 +29,8 @@ jobs:
         export CXX=$(which clang++)
         export CC=$(which clang)
 
+        python3 -m pip install -U pip setuptools wheel
+
         # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
         #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
         #   https://github.com/open-mpi/ompi/issues/9317
@@ -38,4 +40,4 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
             -DAMReX_GPU_BACKEND=HIP                        \
             -DAMReX_AMD_ARCH=gfx900
-        cmake --build build -j 2
+        cmake --build build --target pip_install -j 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,6 +77,8 @@ jobs:
         export CXX=$(which g++)
         export CUDAHOSTCXX=$(which g++)
 
+        python3 -m pip install -U pip setuptools wheel
+
         cmake -S . -B build             \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_GPU_BACKEND=CUDA    \
@@ -85,7 +87,8 @@ jobs:
             -DAMReX_CUDA_ARCH=8.0       \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
             -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
-        cmake --build build -j 2
+        cmake --build build --target pip_install -j 2
+        ctest --test-dir build --output-on-failure
 
 # TODO: in pybind11
 #   multiple definition of `scalblnl`, `sinhl', `tanhl`, `tanl`, ...

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,15 +13,16 @@ jobs:
         python-version: '3.x'
     - name: Build & Install
       run: |
-        python -m pip install -U pip pytest
-        python -m pip install -v .
-        python -c "import amrex; print(amrex.__version__)"
+        python3 -m pip install -U pip pytest
+        python3 -m pip install -v .
+        python3 -c "import amrex; print(amrex.__version__)"
     - name: Unit tests
       run: |
-        python -m pytest tests
+        python3 -m pytest tests
 
   # Build libamrex and all tutorials
   clang:
+    if: ${{ false }}  # disable for now
     name: Clang w/o MPI
     runs-on: windows-latest
     steps:
@@ -31,11 +32,18 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+
+        python3 -m pip install -U pip setuptools wheel pytest
+        if errorlevel 1 exit 1
+
         cmake -S . -B build               ^
               -T "ClangCl"                ^
               -DCMAKE_VERBOSE_MAKEFILE=ON ^
               -DAMReX_MPI=OFF
         if errorlevel 1 exit 1
 
-        cmake --build build --config RelWithDebInfo -j 2
+        cmake --build build --config RelWithDebInfo --target pip_install -j 2
+        if errorlevel 1 exit 1
+
+        ctest --test-dir build --config RelWithDebInfo --output-on-failure
         if errorlevel 1 exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@
 ##########
 *.pyc
 __pycache__
+_tmppythonbuild/
+pyamrex.egg-info/
 
 #######
 # IDE #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(pyAMReX PRIVATE buildInfo::pyAMReX)
 # add sources
 add_subdirectory(src)
 
-# C++ properties: at least a C++14 capable compiler is needed
+# C++ properties: at least a C++17 capable compiler is needed
 target_compile_features(pyAMReX PUBLIC cxx_std_17)
 set_target_properties(pyAMReX PROPERTIES
     CXX_EXTENSIONS OFF
@@ -126,8 +126,15 @@ set_target_properties(pyAMReX PROPERTIES
     PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
     COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
 )
-pybind11_extension(pyAMReX)
-pybind11_strip(pyAMReX)
+if(EMSCRIPTEN)
+    set_target_properties(pyAMReX PROPERTIES
+        PREFIX "")
+else()
+    pybind11_extension(pyAMReX)
+endif()
+if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+    pybind11_strip(pyAMReX)
+endif()
 
 # AMReX helper function: propagate CUDA specific target & source properties
 if(AMReX_GPU_BACKEND STREQUAL CUDA)
@@ -192,6 +199,42 @@ install(TARGETS ${pyAMReX_INSTALL_TARGET_NAMES}
 #        ${pyAMReX_BINARY_DIR}/pyAMReXConfigVersion.cmake
 #    DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
 #)
+
+
+# pip helpers for the amrex package ###########################################
+#
+set(PYINSTALLOPTIONS "" CACHE STRING
+    "Additional parameters to pass to `pip install`")
+
+# build the wheel by re-using the shared library we build
+add_custom_target(pip_wheel
+    ${CMAKE_COMMAND} -E rm -f "${pyAMReX_BINARY_DIR}/amrex*whl"
+    COMMAND
+        ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=$<TARGET_FILE_DIR:pyAMReX>
+            python3 -m pip wheel -v --no-build-isolation --use-feature=in-tree-build ${pyAMReX_SOURCE_DIR}
+    WORKING_DIRECTORY
+        ${pyAMReX_BINARY_DIR}
+    DEPENDS
+        pyAMReX
+)
+
+# this will also upgrade/downgrade dependencies, e.g., when the version of numpy changes
+add_custom_target(pip_install_requirements
+    python3 -m pip install ${PYINSTALLOPTIONS} -r "${pyAMReX_SOURCE_DIR}/requirements.txt"
+    WORKING_DIRECTORY
+        ${pyAMReX_BINARY_DIR}
+)
+
+# We force-install because in development, it is likely that the version of
+# the package does not change, but the code did change. We need --no-deps,
+# because otherwise pip would also force reinstall all dependencies.
+add_custom_target(pip_install
+    python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "${pyAMReX_BINARY_DIR}/amrex*whl"
+    WORKING_DIRECTORY
+        ${pyAMReX_BINARY_DIR}
+    DEPENDS
+        pyAMReX pip_wheel pip_install_requirements
+)
 
 
 # Tests #######################################################################

--- a/README.md
+++ b/README.md
@@ -131,20 +131,20 @@ On successful installation, you can run the unit tests (assuming `pytest` is
 installed). If `AMREX_MPI=ON`, then please prepend the following commands with `mpiexec -np <NUM_PROCS>`
 
 ```bash
-# Run all tests 
-python -m pytest tests/
+# Run all tests
+python3 -m pytest tests/
 
 # Run tests from a single file
-python -m pytest tests/test_intvect.py
+python3 -m pytest tests/test_intvect.py
 
 # Run a single test (useful during debugging)
-python -m pytest tests/test_intvect.py::test_iv_conversions
+python3 -m pytest tests/test_intvect.py::test_iv_conversions
 ```
 
-If you are iterating on C++ builds, it might be faster to just call CMake:
+If you are iterating on builds, it will faster to rely on ``ccache`` and to let CMake call the ``pip`` install logic:
 ```bash
 cmake -S . -B build
-cmake --build build -j 8  # repeat this step to fix compile errors
+cmake --build build --target pip_install -j 8
 ```
 
 ### Build Options
@@ -163,8 +163,9 @@ If you are using the pip-driven install, selected [AMReX CMake options](https://
 | `AMREX_REPO`                 | `https://github.com/AMReX-Codes/amrex.git` | Repository URI to pull and build AMReX from                  |
 | `AMREX_BRANCH`               | `development`                              | Repository branch for `AMREX_REPO`                           |
 | `AMREX_INTERNAL`             | **ON**/OFF                                 | Needs a pre-installed AMReX library if set to `OFF`          |
-| `AMREX_LIBDIR`               | *None*         (note: not yet implemented) | If set, search for pre-built AMReX C++ libraries (see below) |
 | `CMAKE_BUILD_PARALLEL_LEVEL` | 2                                          | Number of parallel build threads                             |
+| `PYAMREX_LIBDIR`             | *None*                                     | If set, search for pre-built a pyAMReX library               |
+| `PYINSTALLOPTIONS`           | *None*                                     | Additional options for ``pip install``, e.g., ``-v --user``  |
 
 For example, one can also build against a local AMReX copy.
 Assuming AMReX' source is located in `$HOME/src/amrex`, then `export AMREX_SRC=$HOME/src/amrex`.

--- a/setup.py
+++ b/setup.py
@@ -30,18 +30,16 @@ class CopyPreBuild(build):
     def run(self):
         build.run(self)
 
-        # matches: libamrex(2d|3d|rz).(so|pyd)
-        #   note: these naming conventions need to be implemented/matched
-        #   with upstream if we want to support external libs in the future
-        re_libprefix = re.compile(r"libamrex..\.(?:so|pyd)")
+        # matches: amrex_pybind.*.(so|pyd)
+        re_libprefix = re.compile(r"amrex_pybind\..*\.(?:so|pyd)")
         libs_found = []
-        for lib_name in os.listdir(AMREX_libdir):
+        for lib_name in os.listdir(PYAMREX_libdir):
             if re_libprefix.match(lib_name):
-                lib_path = os.path.join(AMREX_libdir, lib_name)
+                lib_path = os.path.join(PYAMREX_libdir, lib_name)
                 libs_found.append(lib_path)
         if len(libs_found) == 0:
-            raise RuntimeError("Error: no pre-build AMReX libraries found in "
-                               "AMREX_libdir='{}'".format(AMREX_libdir))
+            raise RuntimeError("Error: no pre-build pyAMReX libraries found in "
+                               "PYAMREX_libdir='{}'".format(PYAMREX_libdir))
 
         # copy external libs into collection of files in a temporary build dir
         dst_path = os.path.join(self.build_lib, "amrex")
@@ -168,7 +166,7 @@ with open('./README.md', encoding='utf-8') as f:
 # Allow to control options via environment vars.
 #   Work-around for https://github.com/pypa/setuptools/issues/1712
 # Pick up existing AMReX libraries or...
-AMREX_libdir = os.environ.get('AMREX_libdir')
+PYAMREX_libdir = os.environ.get('PYAMREX_LIBDIR')
 
 # ... build AMReX libraries with CMake
 #   note: changed default for SHARED, MPI, TESTING and EXAMPLES
@@ -197,10 +195,10 @@ else:
 cxx_modules = []     # values: amrex_1d, amrex_2d, amrex_3d
 cmdclass = {}        # build extensions
 
-# externally pre-built: pick up pre-built AMReX libraries
-if AMREX_libdir:
+# externally pre-built: pick up pre-built pyAMReX libraries
+if PYAMREX_libdir:
     cmdclass=dict(build=CopyPreBuild)
-# CMake: build AMReX libraries ourselves
+# CMake: build pyAMReX ourselves
 else:
     cmdclass = dict(build_ext=CMakeBuild)
     for dim in [x.lower() for x in AMReX_SPACEDIM.split(';')]:


### PR DESCRIPTION
Add and document more helpers to quickly and iteratively install the Python bindings with a one-liner from CMake:
(after one has _once_ run the configuration one-liner)
```console
cmake --build build --target pip_install -j 4
```

This should accelerate development cycles.

Same as: https://github.com/ECP-WarpX/WarpX/pull/2822