### PR TITLE
CI: Reenable Clang on Win

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,9 +20,7 @@ jobs:
       run: |
         python3 -m pytest tests
 
-  # Build libamrex and all tutorials
   clang:
-    if: ${{ false }}  # disable for now
     name: Clang w/o MPI
     runs-on: windows-latest
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,40 +12,37 @@ jobs:
       with:
         python-version: '3.x'
     - name: Build & Install
-      shell: cmd
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
-
         python3 -m pip install -U pip pytest
         python3 -m pip install -v .
-        if errorlevel 1 exit 1
-
         python3 -c "import amrex; print(amrex.__version__)"
-        if errorlevel 1 exit 1
     - name: Unit tests
       shell: cmd
       run: |
         python3 -m pytest tests
-        if errorlevel 1 exit 1
 
   clang:
     name: Clang w/o MPI
     runs-on: windows-latest
+    env: {PYAMREX_LIBDIR: build/lib/site-packages/amrex/Release/}
     steps:
     - uses: actions/checkout@v2
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build & Install
       run: |
-        C:\hostedtoolcache\windows\Python\3.10.2\x64\python3.exe `
-            -m pip install -U pip setuptools wheel pytest
+        python3 -m pip install -U pip setuptools wheel pytest
 
         cmake -S . -B build               `
               -T "ClangCl"                `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
-              -DAMReX_MPI=OFF
+              -DAMReX_MPI=OFF             `
+              -DPython_EXECUTABLE=C:\\hostedtoolcache\\windows\\python\\3.9.10\\x64\\python3.exe
 
-        cmake --build build --config RelWithDebInfo --target pip_install -j 2
-
+        cmake --build build --config Release -j 2
+        python3 -m pip install -v .
     - name: Unit tests
       run: |
-        ctest --test-dir build -C RelWithDebInfo --output-on-failure
+        ctest --test-dir build -C Release --output-on-failure
+
+# C:\\hostedtoolcache\\windows\\python\\3.9.10\\x64\\python3.exe
+# C:\\hostedtoolcache\\windows\\Python\\3.10.2\\x64\\python3.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,5 +43,5 @@ jobs:
         cmake --build build --config RelWithDebInfo --target pip_install -j 2
         if errorlevel 1 exit 1
 
-        ctest --test-dir build --config RelWithDebInfo --output-on-failure
+        ctest --test-dir build -C RelWithDebInfo --output-on-failure
         if errorlevel 1 exit 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,13 +12,21 @@ jobs:
       with:
         python-version: '3.x'
     - name: Build & Install
+      shell: cmd
       run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+
         python3 -m pip install -U pip pytest
         python3 -m pip install -v .
+        if errorlevel 1 exit 1
+
         python3 -c "import amrex; print(amrex.__version__)"
+        if errorlevel 1 exit 1
     - name: Unit tests
+      shell: cmd
       run: |
         python3 -m pytest tests
+        if errorlevel 1 exit 1
 
   clang:
     name: Clang w/o MPI
@@ -27,22 +35,17 @@ jobs:
     - uses: actions/checkout@v2
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build & Install
-      shell: cmd
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
-
-        C:\hostedtoolcache\windows\Python\3.10.2\x64\python3.exe ^
+        C:\hostedtoolcache\windows\Python\3.10.2\x64\python3.exe `
             -m pip install -U pip setuptools wheel pytest
-        if errorlevel 1 exit 1
 
-        cmake -S . -B build               ^
-              -T "ClangCl"                ^
-              -DCMAKE_VERBOSE_MAKEFILE=ON ^
+        cmake -S . -B build               `
+              -T "ClangCl"                `
+              -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DAMReX_MPI=OFF
-        if errorlevel 1 exit 1
 
         cmake --build build --config RelWithDebInfo --target pip_install -j 2
-        if errorlevel 1 exit 1
 
+    - name: Unit tests
+      run: |
         ctest --test-dir build -C RelWithDebInfo --output-on-failure
-        if errorlevel 1 exit 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,8 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
 
-        python3 -m pip install -U pip setuptools wheel pytest
+        C:\hostedtoolcache\windows\Python\3.10.2\x64\python3.exe ^
+            -m pip install -U pip setuptools wheel pytest
         if errorlevel 1 exit 1
 
         cmake -S . -B build               ^

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ add_custom_target(pip_wheel
     ${CMAKE_COMMAND} -E rm -f "amrex*.whl"
     COMMAND
         ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=$<TARGET_FILE_DIR:pyAMReX>
-            python3 -m pip wheel -v --no-build-isolation --use-feature=in-tree-build ${pyAMReX_SOURCE_DIR}
+            ${Python_EXECUTABLE} -m pip wheel -v --no-build-isolation --use-feature=in-tree-build ${pyAMReX_SOURCE_DIR}
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS
@@ -220,7 +220,7 @@ add_custom_target(pip_wheel
 
 # this will also upgrade/downgrade dependencies, e.g., when the version of numpy changes
 add_custom_target(pip_install_requirements
-    python3 -m pip install ${PYINSTALLOPTIONS} -r "${pyAMReX_SOURCE_DIR}/requirements.txt"
+    ${Python_EXECUTABLE} -m pip install ${PYINSTALLOPTIONS} -r "${pyAMReX_SOURCE_DIR}/requirements.txt"
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
 )
@@ -230,7 +230,7 @@ add_custom_target(pip_install_requirements
 # because otherwise pip would also force reinstall all dependencies.
 add_custom_target(pip_install
     ${CMAKE_COMMAND} -E env AMREX_MPI=${AMReX_MPI}
-        python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "amrex*.whl"
+        ${Python_EXECUTABLE} -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "amrex*.whl"
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ add_custom_target(pip_install_requirements
 # because otherwise pip would also force reinstall all dependencies.
 add_custom_target(pip_install
     ${CMAKE_COMMAND} -E env AMREX_MPI=${AMReX_MPI}
-        python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "${pyAMReX_BINARY_DIR}/amrex*whl"
+        python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "${pyAMReX_BINARY_DIR}/amrex-21.2-py3-none-any.whl"
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,8 @@ add_custom_target(pip_install_requirements
 # the package does not change, but the code did change. We need --no-deps,
 # because otherwise pip would also force reinstall all dependencies.
 add_custom_target(pip_install
-    python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "${pyAMReX_BINARY_DIR}/amrex*whl"
+    ${CMAKE_COMMAND} -E env AMREX_MPI=${AMReX_MPI}
+        python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "${pyAMReX_BINARY_DIR}/amrex*whl"
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ set(PYINSTALLOPTIONS "" CACHE STRING
 
 # build the wheel by re-using the shared library we build
 add_custom_target(pip_wheel
-    ${CMAKE_COMMAND} -E rm -f "${pyAMReX_BINARY_DIR}/amrex*whl"
+    ${CMAKE_COMMAND} -E rm -f "amrex*.whl"
     COMMAND
         ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=$<TARGET_FILE_DIR:pyAMReX>
             python3 -m pip wheel -v --no-build-isolation --use-feature=in-tree-build ${pyAMReX_SOURCE_DIR}
@@ -230,7 +230,7 @@ add_custom_target(pip_install_requirements
 # because otherwise pip would also force reinstall all dependencies.
 add_custom_target(pip_install
     ${CMAKE_COMMAND} -E env AMREX_MPI=${AMReX_MPI}
-        python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "${pyAMReX_BINARY_DIR}/amrex-21.2-py3-none-any.whl"
+        python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "amrex*.whl"
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS


### PR DESCRIPTION
Follow-up to #22

Find out what that `pip` error is that caused:
```
1>CUSTOMBUILD : error : Invalid requirement: 'D:/a/pyamrex/pyamrex/build/amrex*whl' [D:\a\pyamrex\pyamrex\build\pip_install.vcxproj]
1>C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(245,5): error MSB8066: Custom build for 'D:\a\pyamrex\pyamrex\build\CMakeFiles\11a9edf0178d3b2f41770be0f8309962\pip_install.rule;D:\a\pyamrex\pyamrex\CMakeLists.txt' exited with code 1. [D:\a\pyamrex\pyamrex\build\pip_install.vcxproj]
1>Done Building Project "D:\a\pyamrex\pyamrex\build\pip_install.vcxproj" (default targets) -- FAILED.

Build FAILED.
```