### PR TITLE
Clean Pip Staging Directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,19 +15,30 @@ import subprocess
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from distutils.command.build import build
+from distutils.command.clean import clean
 from distutils.version import LooseVersion
 
 
 class CopyPreBuild(build):
     def initialize_options(self):
         build.initialize_options(self)
-        # We just overwrite this because the default "build/lib" clashes with
-        # directories many developers have in their source trees;
+        # We just overwrite this because the default "build" (and "build/lib")
+        # clashes with directories many developers have in their source trees;
         # this can create confusing results with "pip install .", which clones
         # the whole source tree by default
-        self.build_lib = '_tmppythonbuild'
+        self.build_base = '_tmppythonbuild'
 
     def run(self):
+        # remove existing build directory
+        #   by default, this stays around. we want to make sure generated
+        #   files like libwarpx.(2d|3d|rz).(so|pyd) are always only the
+        #   ones we want to package and not ones from an earlier wheel's stage
+        c = clean(self.distribution)
+        c.all = True
+        c.finalize_options()
+        c.run()
+
+        # call superclass
         build.run(self)
 
         # matches: amrex_pybind.*.(so|pyd)


### PR DESCRIPTION
he distutils staging (`build` -> `_tmppythonbuild`) directory that pip uses to collect build artifacts is not by default cleaned between multiple `pip` runs.

This can be confusing when we recompile, because old `amrex_pybind*` files can be still in it that are not present in our own `build/lib/`.

This cleans that staging directory before builds now. It also sets the whole `build_base` so that no artifact lands in the default, which was `build/`.

First seen in https://github.com/ECP-WarpX/WarpX/pull/2954