### PR TITLE
pybind11: v2.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pyAMReX depends on the following popular third party software.
 - a mature [C++14](https://en.wikipedia.org/wiki/C%2B%2B14) compiler: e.g. g++ 5.0+, clang 5.0+, VS 2017+
 - [CMake 3.18.0+](https://cmake.org)
 - [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
-- [pybind11](https://github.com/pybind/pybind11/) 2.6.2+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
+- [pybind11](https://github.com/pybind/pybind11/) 2.9.1+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
   - [Python](https://python.org) 3.6+
   - [Numpy](https://numpy.org) 1.15+
 

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -34,7 +34,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     else()
-        find_package(pybind11 2.6.2 CONFIG REQUIRED)
+        find_package(pybind11 2.9.1 CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -49,7 +49,7 @@ option(pyAMReX_pybind11_internal "Download & build pybind11" ON)
 set(pyAMReX_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(pyAMReX_pybind11_internal)")
-set(pyAMReX_pybind11_branch "v2.6.2"
+set(pyAMReX_pybind11_branch "v2.9.1"
     CACHE STRING
     "Repository branch for pyAMReX_pybind11_repo if(pyAMReX_pybind11_internal)")
 


### PR DESCRIPTION
Update `pybind11` to use the latest release (or newer).

We did a major rehaul in the last releases, fixing many issues.