### PR TITLE
Init: Fix Use-after-Free

### DIFF
--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -82,16 +82,21 @@ void init_AMReX(py::module& m)
     m.def("initialize",
           [](const py::list args) {
               Vector<std::string> cargs{"amrex"};
-              Vector<char*> argv{&cargs.back()[0]};
+              Vector<char*> argv;
 
               // Populate the "command line"
-              for (const auto& v: args) {
+              for (const auto& v: args)
                   cargs.push_back(v.cast<std::string>());
-                  argv.push_back(&cargs.back()[0]);
-              }
-
+              for (auto& v: cargs)
+                  argv.push_back(&v[0]);
               int argc = argv.size();
+
+              // note: +1 since there is an extra char-string array element,
+              //       that ANSII C requires to be a simple NULL entry
+              //       https://stackoverflow.com/a/39096006/2719194
+              argv.push_back(NULL);
               char** tmp = argv.data();
+
               const bool build_parm_parse = (cargs.size() > 1);
               // TODO: handle version with MPI
               return Initialize(argc, tmp, build_parm_parse);


### PR DESCRIPTION
Fix a use-after-free in init and add the ANSII C NULL padding (same as https://github.com/ECP-WarpX/WarpX/pull/2726).

When pushing back extra arguments, un-reserved vectors resize and thus change memory locations.

Found via address+undefined sanitizers.