### PR TITLE
Array4: __cuda_array_interface__ v3

### DIFF
--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -140,6 +140,10 @@ void make_Array4(py::module &m, std::string typestr)
             return a4;
         }))
 
+        /* init from __cuda_array_interface__: non-owning view
+         * TODO
+         */
+
 
         // CPU: __array_interface__ v3
         // https://numpy.org/doc/stable/reference/arrays.interface.html

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -164,9 +164,16 @@ void make_Array4(py::module &m, std::string typestr)
             // Because the user of the interface may or may not be in the same context, the most common case is to use cuPointerGetAttribute with CU_POINTER_ATTRIBUTE_DEVICE_POINTER in the CUDA driver API (or the equivalent CUDA Runtime API) to retrieve a device pointer that is usable in the currently active context.
             // TODO For zero-size arrays, use 0 here.
 
-            // ... TODO: wasn't there some stream or device info?
+            // None or integer
+            // An optional stream upon which synchronization must take place at the point of consumption, either by synchronizing on the stream or enqueuing operations on the data on the given stream. Integer values in this entry are as follows:
+            //   0: This is disallowed as it would be ambiguous between None and the default stream, and also between the legacy and per-thread default streams. Any use case where 0 might be given should either use None, 1, or 2 instead for clarity.
+            //   1: The legacy default stream.
+            //   2: The per-thread default stream.
+            //   Any other integer: a cudaStream_t represented as a Python integer.
+            //   When None, no synchronization is required.
+            d["stream"] = py::none();
 
-            d["version"] = 2;
+            d["version"] = 3;
             return d;
         })
 

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -94,6 +94,7 @@ void init_MultiFab(py::module &m) {
                 if( !mfi.isValid() )
                 {
                     first_or_done = true;
+                    mfi.Finalize();
                     throw py::stop_iteration();
                 }
                 return mfi;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,7 @@ def make_mfab(boxarr, distmap, request):
 
     return create
 
+
 @pytest.mark.skipif(
     amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
@@ -108,5 +109,6 @@ def make_mfab_device(boxarr, distmap, request):
             amrex.MFInfo().set_arena(amrex.The_Device_Arena()),
         )
         mfab.set_val(0.0, 0, num_components)
+        return mfab
 
     return create

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -75,7 +75,7 @@ def test_array4():
 )
 def test_array4_numba():
     # https://numba.pydata.org/numba-doc/dev/cuda/cuda_array_interface.html
-    import numba
+    from numba import cuda
 
     # numba -> AMReX Array4
     x = np.ones(
@@ -87,9 +87,7 @@ def test_array4_numba():
     )  # type: numpy.ndarray
 
     # host-to-device copy
-    x_numba = numba.cuda.to_device(
-        x
-    )  # type: numba.cuda.cudadrv.devicearray.DeviceNDArray
+    x_numba = cuda.to_device(x)  # type: numba.cuda.cudadrv.devicearray.DeviceNDArray
     # x_cupy = cupy.asarray(x_numba)      # type: cupy.ndarray
     x_arr = amrex.Array4_double(x_numba)  # type: amrex.Array4_double
 

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -69,36 +69,83 @@ def test_array4():
     x[1, 1, 1] = 44
     assert v_carr2np[0, 1, 1, 1] == 44
 
-    # from cupy
 
-    # to numpy
+@pytest.mark.skipif(
+    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+)
+def test_array4_numba():
+    # https://numba.pydata.org/numba-doc/dev/cuda/cuda_array_interface.html
+    import numba
 
-    # to cupy
+    # numba -> AMReX Array4
+    x = np.ones(
+        (
+            2,
+            3,
+            4,
+        )
+    )  # type: numpy.ndarray
 
-    return
+    # host-to-device copy
+    x_numba = numba.cuda.to_device(
+        x
+    )  # type: numba.cuda.cudadrv.devicearray.DeviceNDArray
+    # x_cupy = cupy.asarray(x_numba)      # type: cupy.ndarray
+    x_arr = amrex.Array4_double(x_numba)  # type: amrex.Array4_double
 
-    # Check indexing
-    assert obj[0] == 1
-    assert obj[1] == 2
-    assert obj[2] == 3
-    assert obj[-1] == 3
-    assert obj[-2] == 2
-    assert obj[-3] == 1
-    with pytest.raises(IndexError):
-        obj[-4]
-    with pytest.raises(IndexError):
-        obj[3]
+    assert (
+        x_arr.__cuda_array_interface__["data"][0]
+        == x_numba.__cuda_array_interface__["data"][0]
+    )
 
-    # Check assignment
-    obj[0] = 2
-    obj[1] = 3
-    obj[2] = 4
-    assert obj[0] == 2
-    assert obj[1] == 3
-    assert obj[2] == 4
+    # AMReX -> numba
+    # arr_numba = cuda.as_cuda_array(arr4)
+    # ... or as MultiFab test
+    # TODO
 
 
-# def test_iv_conversions():
-#    obj = amrex.IntVect.max_vector().numpy()
-#    assert(isinstance(obj, np.ndarray))
-#    assert(obj.dtype == np.int32)
+@pytest.mark.skipif(
+    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+)
+def test_array4_cupy():
+    # https://docs.cupy.dev/en/stable/user_guide/interoperability.html
+    import cupy as cp
+
+    # cupy -> AMReX Array4
+    x = np.ones(
+        (
+            2,
+            3,
+            4,
+        )
+    )  # TODO: merge into next line and create on device?
+    x_cupy = cp.asarray(x)  # type: cupy.ndarray
+    print(f"x_cupy={x_cupy}")
+    print(x_cupy.__cuda_array_interface__)
+
+    # cupy -> AMReX array4
+    x_arr = amrex.Array4_double(x_cupy)  # type: amrex.Array4_double
+    print(f"x_arr={x_arr}")
+    print(x_arr.__cuda_array_interface__)
+
+    assert (
+        x_arr.__cuda_array_interface__["data"][0]
+        == x_cupy.__cuda_array_interface__["data"][0]
+    )
+
+    # AMReX -> cupy
+    # arr_numba = cuda.as_cuda_array(arr4)
+    # ... or as MultiFab test
+    # TODO
+
+
+@pytest.mark.skipif(
+    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+)
+def test_array4_pytorch():
+    # https://docs.cupy.dev/en/stable/user_guide/interoperability.html#pytorch
+    # arr_torch = torch.as_tensor(arr, device='cuda')
+    # assert(arr_torch.__cuda_array_interface__['data'][0] == arr.__cuda_array_interface__['data'][0])
+    # TODO
+
+    pass

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -263,7 +263,7 @@ def test_mfab_ops_cuda_cupy(make_mfab_device, nghost):
 
         @cp.fuse(kernel_name="set_to_seven")
         def set_to_seven(x):
-            x += 7.0
+            x[...] = 7.0
 
         for mfi in mfab_device:
             bx = mfi.tilebox().grow(ngv)
@@ -271,7 +271,6 @@ def test_mfab_ops_cuda_cupy(make_mfab_device, nghost):
             marr_cupy = cp.array(marr, copy=False)
 
             # write and read into the marr_cupy
-            marr_cupy[()] = 0.0
             set_to_seven(marr_cupy)
 
     # verify

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -153,3 +153,56 @@ def test_mfab_mfiter(make_mfab):
         cnt += 1
 
     assert iter(mfab).length == cnt
+
+
+@pytest.mark.skipif(
+    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+)
+def test_mfab_ops_cuda_numba():
+    # https://numba.pydata.org/numba-doc/dev/cuda/cuda_array_interface.html
+    import numba
+
+    # AMReX -> numba
+    # arr_numba = cuda.as_cuda_array(arr4)
+    # TODO
+
+
+@pytest.mark.skipif(
+    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+)
+def test_mfab_ops_cuda_cupy():
+    # https://docs.cupy.dev/en/stable/user_guide/interoperability.html
+    import cupy as cp
+
+    # AMReX -> cupy
+    # arr_numba = cuda.as_cuda_array(arr4)
+    # TODO
+
+
+@pytest.mark.skipif(
+    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+)
+def test_mfab_ops_cuda_pytorch():
+    # https://docs.cupy.dev/en/stable/user_guide/interoperability.html#pytorch
+    import torch
+
+    # AMReX -> pytorch
+    # arr_torch = torch.as_tensor(arr, device='cuda')
+    # assert(arr_torch.__cuda_array_interface__['data'][0] == arr.__cuda_array_interface__['data'][0])
+    # TODO
+
+
+@pytest.mark.skipif(
+    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+)
+def test_mfab_ops_cuda_cuml():
+    # https://github.com/rapidsai/cuml
+    # https://github.com/rapidsai/cudf
+    #   maybe better for particles as a dataframe test
+    import cudf
+    import cuml
+
+    # AMReX -> RAPIDSAI cuML
+    # arr_cuml = ...
+    # assert(arr_cuml.__cuda_array_interface__['data'][0] == arr.__cuda_array_interface__['data'][0])
+    # TODO

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -196,8 +196,7 @@ def test_mfab_ops_cuda_numba(make_mfab_device):
 @pytest.mark.skipif(
     amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
-@pytest.mark.parametrize("nghost", [0, 1])
-def test_mfab_ops_cuda_cupy(make_mfab_device, nghost):
+def test_mfab_ops_cuda_cupy(make_mfab_device):
     mfab_device = make_mfab_device()
     # https://docs.cupy.dev/en/stable/user_guide/interoperability.html
     import cupy as cp

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -290,10 +290,16 @@ def test_mfab_ops_cuda_pytorch(make_mfab_device):
     # https://docs.cupy.dev/en/stable/user_guide/interoperability.html#pytorch
     import torch
 
-    # AMReX -> pytorch
-    # arr_torch = torch.as_tensor(arr, device='cuda')
-    # assert(arr_torch.__cuda_array_interface__['data'][0] == arr.__cuda_array_interface__['data'][0])
-    # TODO
+    # assign 3: loop through boxes and launch kernel
+    for mfi in mfab_device:
+        marr = mfab_device.array(mfi)
+        marr_torch = torch.as_tensor(marr, device="cuda")
+        marr_torch[:, :, :] = 3
+
+    # Check results
+    shape = 32**3 * 8
+    sum_threes = mfab_device.sum_unique(comp=0, local=False)
+    assert sum_threes == shape * 3
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Start implementing the `__cuda_array_interface__` for zero-copy data exchange on Nvidia CUDA GPUs.

Optional: accessing an external `__cuda_array_interface__` object in non-owning manner as AMReX Array4:
https://github.com/cupy/cupy/blob/a5b24f91d4d77fa03e6a4dd2ac954ff9a04e21f4/cupy/core/core.pyx#L2478-L2514

- [x] `mfab` and `mfab_device` need to become functions, not fixtures. Otherwise they will be cached and outlive `amrex.finalize()`: #81 #84
- [x] Particle Iter & MFIter: Python does not destruct keys by default: add a GPU stream synchronize here? https://github.com/AMReX-Codes/pyamrex/blob/78bbbc752ca3f65e257261385f1e31defb59f85e/src/Base/MultiFab.cpp#L72-L75
depends on https://github.com/AMReX-Codes/amrex/pull/2983 and https://github.com/AMReX-Codes/amrex/pull/2985
`if` and `for` do not create a scope in Python (they do in C++):
```py
In [1]: import numpy as np                                                                                                           

In [2]: x = np.array([1,2,3])                                                   

In [3]: for a in x: 
   ...:     print(a)                                                                
1
2
3

# a is still alive xD
In [4]: a                                                                       
Out[4]: 3
```