### PR TITLE
Fix: MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,10 @@
-include README.md LEGAL.txt LICENSE.txt
+include README.md LICENSE
 include pyproject.toml
 include requirements.txt
 global-include CMakeLists.txt *.cmake *.in
+recursive-include cmake *
 recursive-include src *
+recursive-include tests *
 
 # see .gitignore
 prune cmake-build*


### PR DESCRIPTION
Add missing files and fix ill-named ones.

Reminder: this file is used to build source packages for `pip`.