### PR TITLE
AMReX: Turn particles on

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -25,8 +25,7 @@ macro(find_amrex)
         set(AMReX_FORTRAN OFF CACHE INTERNAL "")
         set(AMReX_FORTRAN_INTERFACES OFF CACHE INTERNAL "")
         set(AMReX_BUILD_TUTORIALS OFF CACHE INTERNAL "")
-        # potentially worth changing default:
-        #set(AMReX_PARTICLES ON CACHE INTERNAL "")
+        set(AMReX_PARTICLES ON CACHE INTERNAL "")  # default: OFF
 
         if(pyAMReX_amrex_src)
             list(APPEND CMAKE_MODULE_PATH "${pyAMReX_amrex_src}/Tools/CMake")
@@ -66,7 +65,7 @@ macro(find_amrex)
     else()
         message(STATUS "Searching for pre-installed AMReX ...")
         # https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#importing-amrex-into-your-cmake-project
-        find_package(AMReX 21.02 CONFIG REQUIRED COMPONENTS PIC)
+        find_package(AMReX 21.02 CONFIG REQUIRED COMPONENTS PARTICLES PIC)
         message(STATUS "AMReX: Found version '${AMReX_VERSION}'")
     endif()
 endmacro()

--- a/src/AmrCore/AmrCore.cpp
+++ b/src/AmrCore/AmrCore.cpp
@@ -9,6 +9,9 @@
 #include <AMReX_Config.H>
 #include <AMReX_AmrCore.H>
 #include <AMReX_AmrMesh.H>
+#ifdef AMREX_PARTICLES
+#   include <AMReX_AmrParGDB.H>
+#endif
 
 namespace py = pybind11;
 using namespace amrex;


### PR DESCRIPTION
Particles are by default turned off in AMReX. This turns them on in pyAMReX.