### PR TITLE
add length to Box, fix RealBox init

### DIFF
--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -99,8 +99,14 @@ void init_Box(py::module &m) {
 
         .def_property_readonly("ix_type", &Box::ixType)
         .def_property_readonly("size", &Box::size)
-        .def_property_readonly("length",
-            py::overload_cast<>(&Box::length, py::const_))
+        */
+        .def("length",
+            py::overload_cast<>(&Box::length, py::const_),
+            "Return IntVect of lengths of the Box")
+        .def("length",
+            py::overload_cast<int>(&Box::length, py::const_),
+            "Return the length of the Box in given direction.")
+            /*
         .def_property_readonly("is_empty", &Box::isEmpty)
         .def_property_readonly("ok", &Box::ok)
         .def_property_readonly("cell_centered", &Box::cellCentered)

--- a/src/Base/RealBox.cpp
+++ b/src/Base/RealBox.cpp
@@ -46,6 +46,8 @@ void init_RealBox(py::module &m) {
 
 
         .def(py::init())
+        .def(py::init<AMREX_D_DECL(Real, Real, Real),
+             AMREX_D_DECL(Real, Real, Real)>())
         .def(py::init<const std::array<Real,AMREX_SPACEDIM>&, 
                       const std::array<Real,AMREX_SPACEDIM>& >())
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -9,6 +9,10 @@ def box():
     #return amrex.Box((0, 0, 0), (127, 127, 127))
     return amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(127, 127, 127))
 
+def test_length(box):
+    print(box.length())
+    assert(box.length() == amrex.IntVect(128,128,128))
+
 #def test_num_pts(box):
 #    np.testing.assert_allclose(box.lo_vect, [0, 0, 0])
 #    np.testing.assert_allclose(box.hi_vect, [127, 127, 127])

--- a/tests/test_realbox.py
+++ b/tests/test_realbox.py
@@ -26,7 +26,7 @@ def test_realbox_contains():
     assert(not rb1.contains(point1))
     assert(rb1.contains(point2))
 
-    rb2 = amrex.RealBox([0.1,0.2,0.3],[0.3,1,1.])
+    rb2 = amrex.RealBox(0.1,0.2,0.3, 0.3,1,1.)
     rb3 = amrex.RealBox([4,5.,6.],[5.,5.5, 7.])
     assert(rb1.contains(rb2) )
     assert(not rb1.contains(rb3))


### PR DESCRIPTION
- Add length() to Box
- Add a test function to test_box.py
- Fix RealBox initialization with 6 reals (not two lists of 3 reals each)
- Fix corresponding test