### PR TITLE
CI: Cancel on Update, Skip Drafts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,12 +2,17 @@ name: linux
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-linux
+  cancel-in-progress: true
+
 jobs:
   # Build and install libamrex as AMReX CMake project
   gcc7:
     name: GNU@7.5
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -25,6 +30,7 @@ jobs:
     name: GNU@10.1
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -51,6 +57,7 @@ jobs:
     name: Clang@6.0 w/o MPI
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -fno-operator-names -Wno-pass-failed"}
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -70,6 +77,7 @@ jobs:
     name: CUDA@11.2 GNU@9.3.0
     runs-on: ubuntu-20.04
     env: {CXXFLAGS: "-fno-operator-names"}
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,10 @@ name: macos
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-macos
+  cancel-in-progress: true
+
 env:
   CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -fno-operator-names -Wno-pass-failed"
 
@@ -9,6 +13,7 @@ jobs:
   appleclang:
     name: AppleClang@12.0 w/o MPI
     runs-on: macos-latest
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,10 +2,15 @@ name: windows
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-windows
+  cancel-in-progress: true
+
 jobs:
   msvc:
     name: MSVC w/o MPI
     runs-on: windows-latest
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -25,6 +30,7 @@ jobs:
     name: Clang w/o MPI
     runs-on: windows-latest
     env: {PYAMREX_LIBDIR: build/lib/site-packages/amrex/Debug/}
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2
     - uses: seanmiddleditch/gha-setup-ninja@master


### PR DESCRIPTION
This updates the CI to safe time & resources:
- cancel running GitHub actions if a new commit is pushed to a PR or branch and
- do not run GitHub actions if the PR is in draft state.