### PR TITLE
Fix: MultiFab Iterator (first)

### DIFF
--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -37,7 +37,7 @@ void init_MultiFab(py::module &m) {
 
     py::class_< FArrayBox >(m, "FArrayBox");
 
-    py::class_< MFIter >(m, "MFIter")
+    py::class_< MFIter >(m, "MFIter", py::dynamic_attr())
         .def("__repr__",
              [](MFIter const & mfi) {
                  std::string r = "<amrex.MFIter (";
@@ -55,17 +55,17 @@ void init_MultiFab(py::module &m) {
         //.def(py::init< iMultiFab const & >())
         //.def(py::init< iMultiFab const &, MFItInfo const & >())
 
-        //.def("__iter__",
-        //     [](MFIter & mfi) -> MFIter & {
-        //        return mfi;
-        //     },
-        //     py::return_value_policy::reference_internal
-        //)
         .def("__next__",
              [](MFIter & mfi) -> MFIter & {
-                static bool first_or_done = true;
-                if (first_or_done)
+                py::object self = py::cast(mfi);
+                if (!py::hasattr(self, "first_or_done"))
+                    self.attr("first_or_done") = true;
+
+                bool first_or_done = self.attr("first_or_done").cast<bool>();
+                if (first_or_done) {
                     first_or_done = false;
+                    self.attr("first_or_done") = first_or_done;
+                }
                 else
                     ++mfi;
                 if( !mfi.isValid() )

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -59,16 +59,23 @@ void init_MultiFab(py::module &m) {
         //     [](MFIter & mfi) -> MFIter & {
         //        return mfi;
         //     },
-        //     py::return_value_policy::reference
+        //     py::return_value_policy::reference_internal
         //)
         .def("__next__",
              [](MFIter & mfi) -> MFIter & {
-                ++mfi;
+                static bool first_or_done = true;
+                if (first_or_done)
+                    first_or_done = false;
+                else
+                    ++mfi;
                 if( !mfi.isValid() )
+                {
+                    first_or_done = true;
                     throw py::stop_iteration();
+                }
                 return mfi;
              },
-             py::return_value_policy::reference
+             py::return_value_policy::reference_internal
         )
 
         .def("tilebox", py::overload_cast< >(&MFIter::tilebox, py::const_))
@@ -207,7 +214,8 @@ void init_MultiFab(py::module &m) {
         .def("norm2", py::overload_cast< Vector<int> const & >(&MultiFab::norm2, py::const_))
 
         /* simple math */
-        .def("sum", &MultiFab::sum)
+        .def("sum", &MultiFab::sum,
+            py::arg("comp"), py::arg("local")=false)
 
         .def("abs",
             [](MultiFab & mf, int comp, int num_comp) { mf.abs(comp, num_comp); })

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -55,6 +55,7 @@ void init_MultiFab(py::module &m) {
         //.def(py::init< iMultiFab const & >())
         //.def(py::init< iMultiFab const &, MFItInfo const & >())
 
+        // eq. to void operator++()
         .def("__next__",
              [](MFIter & mfi) -> MFIter & {
                 py::object self = py::cast(mfi);
@@ -82,24 +83,27 @@ void init_MultiFab(py::module &m) {
         .def("tilebox", py::overload_cast< IntVect const & >(&MFIter::tilebox, py::const_))
         .def("tilebox", py::overload_cast< IntVect const &, IntVect const & >(&MFIter::tilebox, py::const_))
 
-        /*
-        Box nodaltilebox()
-        Box nodaltilebox(int dir)
-        Box growntilebox()
-        Box growntilebox(const IntVect&)
-        Box grownnodaltilebox()
-        Box grownnodaltilebox(int dir)
-        Box grownnodaltilebox(int dir, int ng)
-        Box grownnodaltilebox(int dir, const IntVect&)
+        .def("validbox", &MFIter::validbox)
+        .def("fabbox", &MFIter::fabbox)
 
-        Box validbox()
-        Box fabbox()
+        .def("nodaltilebox",
+            py::overload_cast< int >(&MFIter::nodaltilebox, py::const_),
+            py::arg("dir") = -1)
 
-        void operator++()
-        bint isValid()
-        int index()
-        int length()
-        */
+        .def("growntilebox",
+            py::overload_cast< const IntVect& >(&MFIter::growntilebox, py::const_),
+            py::arg("ng") = -1000000)
+
+        .def("grownnodaltilebox",
+            py::overload_cast< int, int >(&MFIter::grownnodaltilebox, py::const_),
+            py::arg("int") = -1, py::arg("ng") = -1000000)
+        .def("grownnodaltilebox",
+            py::overload_cast< int, const IntVect& >(&MFIter::grownnodaltilebox, py::const_),
+            py::arg("int"), py::arg("ng"))
+
+        .def_property_readonly("is_valid", &MFIter::isValid)
+        .def_property_readonly("index", &MFIter::index)
+        .def_property_readonly("length", &MFIter::length)
     ;
 
     py::class_< FabArray<FArrayBox>, FabArrayBase >(m, "FabArray_FArrayBox")

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -142,3 +142,13 @@ def test_mfab_ops(boxarr, distmap, nghost):
     np.testing.assert_allclose(dst.min(0), 150.0)
     np.testing.assert_allclose(dst.max(0), 150.0)
 
+@pytest.mark.parametrize("nghost", [0, 1])
+def test_mfab_mfiter(mfab, nghost):
+    assert(iter(mfab).is_valid)
+    assert(iter(mfab).length == 8)
+
+    cnt = 0
+    for mfi in mfab:
+        cnt +=1
+
+    assert(iter(mfab).length == cnt)


### PR DESCRIPTION
Python iterates by calling initially:
- `__iter__`
- `__next__`

This means we need to handle the first iterator element explicitly, otherwise we will jump directly to the 2nd element. We do this now the same way as pybind11 does this, via a little state:
  https://github.com/pybind/pybind11/blob/v2.10.0/include/pybind11/pybind11.h#L2269-L2282