### PR TITLE
add name to namespace for Config

### DIFF
--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -11,8 +11,8 @@
 namespace py = pybind11;
 using namespace amrex;
 
-namespace {
-struct Config {};
+namespace amrex {
+   struct Config {};
 }
 
 void init_AMReX(py::module& m)


### PR DESCRIPTION
This is a fix for a bug that was observed when loading `pyImpactX`.  The `amrex` and `impactx` `Config` objects were both described in anonymous namespaces causing a conflict.  Here the namespace is explicitly named so that the `Config` object is `amrex.Config`.