### PR TITLE
CMake: 3.20+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.20.0)
 project(pyAMReX VERSION 22.06)
 
 include(${pyAMReX_SOURCE_DIR}/cmake/pyAMReXFunctions.cmake)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you just want to use CMake to build the project, jump into sections *1. Intro
 pyAMReX depends on the following popular third party software.
 
 - a mature [C++17](https://en.wikipedia.org/wiki/C%2B%2B17) compiler, e.g., GCC 7, Clang 7, NVCCC 11.0, MSVC 19.15 or newer
-- [CMake 3.18.0+](https://cmake.org)
+- [CMake 3.20.0+](https://cmake.org)
 - [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
 - [pybind11](https://github.com/pybind/pybind11/) 2.9.1+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
   - [Python](https://python.org) 3.6+
@@ -81,7 +81,7 @@ brew update
 brew install ccache cmake libomp mpi4py numpy open-mpi python
 ```
 
-Now, `cmake --version` should be at version 3.18.0 or newer.
+Now, `cmake --version` should be at version 3.20.0 or newer.
 
 Or go:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.15.0,<4.0.0"
+    "cmake>=3.20.0,<4.0.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError(
-                "CMake 3.18.0+ must be installed to build the following " +
+                "CMake 3.20.0+ must be installed to build the following " +
                 "extensions: " +
                 ", ".join(e.name for e in self.extensions))
 
@@ -78,8 +78,8 @@ class CMakeBuild(build_ext):
             r'version\s*([\d.]+)',
             out.decode()
         ).group(1))
-        if cmake_version < '3.18.0':
-            raise RuntimeError("CMake >= 3.18.0 is required")
+        if cmake_version < '3.20.0':
+            raise RuntimeError("CMake >= 3.20.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
Require CMake 3.20 or newer.
This is mainly to simplify CUDA builds and ditch to maintain legacy logic that is handled better in newer CMake versions.

We already upgrade downstream projects like WarpX/ImpactX the same way