### PR TITLE
Pip: `PYBIND11_INTERNAL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ If you are using the pip-driven install, selected [AMReX CMake options](https://
 | `AMREX_REPO`                 | `https://github.com/AMReX-Codes/amrex.git` | Repository URI to pull and build AMReX from                  |
 | `AMREX_BRANCH`               | `development`                              | Repository branch for `AMREX_REPO`                           |
 | `AMREX_INTERNAL`             | **ON**/OFF                                 | Needs a pre-installed AMReX library if set to `OFF`          |
+| `PYBIND11_INTERNAL`          | **ON**/OFF                                 | Needs a pre-installed pybind11 library if set to `OFF`       |
 | `CMAKE_BUILD_PARALLEL_LEVEL` | 2                                          | Number of parallel build threads                             |
 | `PYAMREX_LIBDIR`             | *None*                                     | If set, search for pre-built a pyAMReX library               |
 | `PYINSTALLOPTIONS`           | *None*                                     | Additional options for ``pip install``, e.g., ``-v --user``  |

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ class CMakeBuild(build_ext):
             '-DpyAMReX_amrex_internal=' + AMReX_internal,
             '-DpyAMReX_amrex_repo=' + AMReX_repo,
             '-DpyAMReX_amrex_branch=' + AMReX_branch,
+            '-DpyAMReX_pybind11_internal=' + pybind11_internal,
             # PEP-440 conformant version from package
             "-DpyAMReX_VERSION_INFO=" + self.distribution.get_version(),
             #        see PICSAR and openPMD below
@@ -195,6 +196,7 @@ AMReX_internal = os.environ.get('AMREX_INTERNAL', 'ON')
 AMReX_repo = os.environ.get('AMREX_REPO',
     'https://github.com/AMReX-Codes/amrex.git')
 AMReX_branch = os.environ.get('AMREX_BRANCH', 'development')
+pybind11_internal = os.environ.get('PYBIND11_INTERNAL', 'ON')
 
 # https://cmake.org/cmake/help/v3.0/command/if.html
 if AMReX_MPI.upper() in ['1', 'ON', 'TRUE', 'YES']:


### PR DESCRIPTION
Expose the CMake option `pyAMReX_pybind11_internal` to `pip` via the environment variable `PYBIND11_INTERNAL`.

This is a preparation for Spack packaging.