### PR TITLE
Add More `Box` Methods

### DIFF
--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -88,6 +88,23 @@ void init_Box(py::module &m) {
         .def(py::init< IntVect const &, IntVect const &, IndexType >(),
              py::arg("small"), py::arg("big"), py::arg("t")
         )
+        .def(py::init(
+                [](const std::array<int, AMREX_SPACEDIM>& small,
+                   const std::array<int, AMREX_SPACEDIM>& big){
+                    return Box(IntVect{small}, IntVect{big});
+                }
+             ),
+             py::arg("small"), py::arg("big")
+        )
+        .def(py::init(
+                [](const std::array<int, AMREX_SPACEDIM>& small,
+                   const std::array<int, AMREX_SPACEDIM>& big,
+                   IndexType t){
+                    return Box(IntVect{small}, IntVect{big}, t);
+                }
+             ),
+             py::arg("small"), py::arg("big"), py::arg("t")
+        )
 
         .def_property_readonly("lo_vect", [](Box const & bx){ return bx.smallEnd(); })
         .def_property_readonly("hi_vect", [](Box const & bx){ return bx.bigEnd(); })

--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -79,27 +79,33 @@ void init_Box(py::module &m) {
             }
         )
 
-        .def(py::init< IntVect const &, IntVect const & >())
-        .def(py::init< IntVect const &, IntVect const &, IntVect const & >())
-        //.def(py::init< IntVect const &, IntVect const &, IndexType >())
+        .def(py::init< IntVect const &, IntVect const & >(),
+             py::arg("small"), py::arg("big")
+        )
+        .def(py::init< IntVect const &, IntVect const &, IntVect const & >(),
+             py::arg("small"), py::arg("big"), py::arg("typ")
+        )
+        .def(py::init< IntVect const &, IntVect const &, IndexType >(),
+             py::arg("small"), py::arg("big"), py::arg("t")
+        )
 
         .def_property_readonly("small_end", [](Box const & bx){ return bx.smallEnd(); })
         .def_property_readonly("big_end", [](Box const & bx){ return bx.bigEnd(); })
         /*
         .def_property("small_end",
-            &Box::smallEnd,
+            py::overload_cast<>(&Box::smallEnd, py::const_),
             py::overload_cast< IntVect const & >(&Box::setSmall))
         .def_property("big_end",
             &Box::bigEnd,
             &Box::setBig)
-
+        */
         .def_property("type",
             py::overload_cast<>(&Box::type, py::const_),
             &Box::setType)
 
         .def_property_readonly("ix_type", &Box::ixType)
         .def_property_readonly("size", &Box::size)
-        */
+
         .def("length",
             py::overload_cast<>(&Box::length, py::const_),
             "Return IntVect of lengths of the Box")
@@ -108,7 +114,7 @@ void init_Box(py::module &m) {
             "Return the length of the Box in given direction.")
         .def("numPts", &Box::numPts,
              "Return the number of points in the Box.")
-            /*
+
         .def_property_readonly("is_empty", &Box::isEmpty)
         .def_property_readonly("ok", &Box::ok)
         .def_property_readonly("cell_centered", &Box::cellCentered)
@@ -127,10 +133,10 @@ void init_Box(py::module &m) {
             py::overload_cast< IntVect const & >(&Box::contains, py::const_))
         .def("strictly_contains",
             py::overload_cast< IntVect const & >(&Box::strictly_contains, py::const_))
-        //.def("intersects", &Box::intersects)
-        //.def("same_size", &Box::sameSize)
-        //.def("same_type", &Box::sameType)
-        //.def("normalize", &Box::normalize)
+        .def("intersects", &Box::intersects)
+        .def("same_size", &Box::sameSize)
+        .def("same_type", &Box::sameType)
+        .def("normalize", &Box::normalize)
         // longside
         // shortside
         // index
@@ -138,7 +144,6 @@ void init_Box(py::module &m) {
         // atOffset3d
         // setRange
         // shiftHalf
-        */
         .def("shift", [](Box & bx, IntVect const& iv) { return bx.shift(iv); })
 
         .def(py::self + IntVect())
@@ -151,21 +156,43 @@ void init_Box(py::module &m) {
         .def("convert",
              py::overload_cast< IntVect const & >(&Box::convert))
 
-        .def("grow", [](Box & bx, IntVect const& iv) { return bx.grow(iv); })
+        .def("grow",
+             py::overload_cast< int >(&Box::grow),
+             py::arg("n_cell")
+        )
+        .def("grow",
+             py::overload_cast< IntVect const & >(&Box::grow),
+             py::arg("n_cells")
+        )
+        .def("grow",
+             py::overload_cast< int, int >(&Box::grow),
+             py::arg("idir"), py::arg("n_cell")
+        )
+        .def("grow",
+             py::overload_cast< Direction, int >(&Box::grow),
+             py::arg("d"), py::arg("n_cell")
+        )
 
-        //.def("surrounding_nodes",
-        //     py::overload_cast< >(&Box::surroundingNodes))
-        //.def("surrounding_nodes",
-        //     py::overload_cast< int >(&Box::surroundingNodes),
-        //     py::arg("dir"))
-        //.def("surrounding_nodes",
-        //     py::overload_cast< Direction >(&Box::surroundingNodes),
-        //     py::arg("d"))
+        .def("surrounding_nodes",
+             py::overload_cast< >(&Box::surroundingNodes))
+        .def("surrounding_nodes",
+             py::overload_cast< int >(&Box::surroundingNodes),
+             py::arg("dir"))
+        .def("surrounding_nodes",
+             py::overload_cast< Direction >(&Box::surroundingNodes),
+             py::arg("d"))
 
-        // enclosedCells
+        .def("enclosed_cells",
+             py::overload_cast< >(&Box::enclosedCells))
+        .def("enclosed_cells",
+             py::overload_cast< int >(&Box::enclosedCells),
+             py::arg("dir"))
+        .def("enclosed_cells",
+             py::overload_cast< Direction >(&Box::enclosedCells),
+             py::arg("d"))
+
         // minBox
         // chop
-        // grow
         // growLo
         // growHi
         // refine

--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -89,6 +89,8 @@ void init_Box(py::module &m) {
              py::arg("small"), py::arg("big"), py::arg("t")
         )
 
+        .def_property_readonly("lo_vect", [](Box const & bx){ return bx.smallEnd(); })
+        .def_property_readonly("hi_vect", [](Box const & bx){ return bx.bigEnd(); })
         .def_property_readonly("small_end", [](Box const & bx){ return bx.smallEnd(); })
         .def_property_readonly("big_end", [](Box const & bx){ return bx.bigEnd(); })
         /*
@@ -123,11 +125,6 @@ void init_Box(py::module &m) {
         .def_property_readonly("volume", &Box::volume)
         .def_property_readonly("the_unit_box", &Box::TheUnitBox)
         .def_property_readonly("is_square", &Box::isSquare)
-
-        // loVect3d
-        // hiVect3d
-        .def_property_readonly("lo_vect", &Box::loVect)
-        .def_property_readonly("hi_vect", &Box::hiVect)
 
         .def("contains",
             py::overload_cast< IntVect const & >(&Box::contains, py::const_))

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -77,6 +77,11 @@ void init_IntVect(py::module &m) {
                  return v[ii] = val;
              })
 
+        .def("__len__", [](IntVect const &) { return AMREX_SPACEDIM; })
+        .def("__iter__", [](IntVect const & v) {
+            return py::make_iterator(v.begin(), v.end());
+        }, py::keep_alive<0, 1>()) /* Keep vector alive while iterator is used */
+
         .def("__eq__",
              py::overload_cast<int>(&IntVect::operator==, py::const_))
         .def("__eq__",

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -43,7 +43,7 @@ void init_IntVect(py::module &m) {
         .def(py::init<AMREX_D_DECL(int, int, int)>())
 #endif
         .def(py::init<int>())
-        .def(py::init<const std::array<int,AMREX_SPACEDIM>&>())
+        .def(py::init<const std::array<int, AMREX_SPACEDIM>&>())
 
         .def_property_readonly("sum", &IntVect::sum)
         .def_property_readonly("max",

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -6,8 +6,7 @@ import amrex
 
 @pytest.fixture
 def box():
-    #return amrex.Box((0, 0, 0), (127, 127, 127))
-    return amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(127, 127, 127))
+    return amrex.Box((0, 0, 0), (127, 127, 127))
 
 def test_length(box):
     print(box.length())
@@ -23,7 +22,6 @@ def test_length(box):
     assert(ncells == box.numPts())
 
 def test_num_pts(box):
-    print("box.lo_vect=", box.lo_vect)
     np.testing.assert_allclose(box.lo_vect, [0, 0, 0])
     np.testing.assert_allclose(box.hi_vect, [127, 127, 127])
     assert(box.num_pts == 2**21)
@@ -48,20 +46,19 @@ def test_grow(box):
 #    assert(bx.volume == 128**3)
 
 
-@pytest.mark.parametrize("dir", [-1, 0, 1, 2])
+@pytest.mark.parametrize("dir", [None, 0, 1, 2])
 def test_surrounding_nodes(box, dir):
     """Surrounding nodes"""
     nx = np.array(box.hi_vect)
-    print('nx=', nx)
-    bx = box.surrounding_nodes(dir=dir)
-    print('bx=', bx)
 
-    if dir < 0:
+    if dir is None:
+        bx = box.surrounding_nodes()
         assert(bx.num_pts == 129**3)
         assert(bx.volume == 128**3)
         nx += 1
         np.testing.assert_allclose(bx.hi_vect, nx)
     else:
+        bx = box.surrounding_nodes(dir=dir)
         assert(bx.num_pts == 129 * 128 * 128)
         assert(bx.volume == 128**3)
         nx[dir] += 1

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -22,18 +22,18 @@ def test_length(box):
     print('ncells from box', box.numPts())
     assert(ncells == box.numPts())
 
-#def test_num_pts(box):
-#    np.testing.assert_allclose(box.lo_vect, [0, 0, 0])
-#    np.testing.assert_allclose(box.hi_vect, [127, 127, 127])
-#    assert(box.num_pts == 2**21)
-#    assert(box.volume == 2**21)
+def test_num_pts(box):
+    np.testing.assert_allclose(box.lo_vect, [0, 0, 0])
+    np.testing.assert_allclose(box.hi_vect, [127, 127, 127])
+    assert(box.num_pts == 2**21)
+    assert(box.volume == 2**21)
 
-#def test_grow(box):
-#    """box.grow"""
-#    bx = box.grow(3)
-#    np.testing.assert_allclose(bx.lo_vect, [-3, -3, -3])
-#    np.testing.assert_allclose(bx.hi_vect, [130, 130, 130])
-#    assert(bx.num_pts == (134**3))
+def test_grow(box):
+    """box.grow"""
+    bx = box.grow(3)
+    np.testing.assert_allclose(bx.lo_vect, [-3, -3, -3])
+    np.testing.assert_allclose(bx.hi_vect, [130, 130, 130])
+    assert(bx.num_pts == (134**3))
 
 #def test_convert(box):
 #    """Conversion to node"""

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -23,6 +23,7 @@ def test_length(box):
     assert(ncells == box.numPts())
 
 def test_num_pts(box):
+    print("box.lo_vect=", box.lo_vect)
     np.testing.assert_allclose(box.lo_vect, [0, 0, 0])
     np.testing.assert_allclose(box.hi_vect, [127, 127, 127])
     assert(box.num_pts == 2**21)
@@ -46,12 +47,14 @@ def test_grow(box):
 #    assert(bx.num_pts == 129 * 128 * 128)
 #    assert(bx.volume == 128**3)
 
-'''
+
 @pytest.mark.parametrize("dir", [-1, 0, 1, 2])
 def test_surrounding_nodes(box, dir):
     """Surrounding nodes"""
     nx = np.array(box.hi_vect)
+    print('nx=', nx)
     bx = box.surrounding_nodes(dir=dir)
+    print('bx=', bx)
 
     if dir < 0:
         assert(bx.num_pts == 129**3)
@@ -63,7 +66,7 @@ def test_surrounding_nodes(box, dir):
         assert(bx.volume == 128**3)
         nx[dir] += 1
         np.testing.assert_allclose(bx.hi_vect, nx)
-
+'''
 @pytest.mark.parametrize("dir", [-1, 0, 1, 2])
 def test_enclosed_cells(box, dir):
     """Enclosed cells"""

--- a/tests/test_intvect.py
+++ b/tests/test_intvect.py
@@ -126,3 +126,12 @@ def test_iv_conversions():
     obj = iv.numpy()
     del iv
     assert(obj[0] == 2)
+
+def test_iv_iter():
+    a0 = amrex.IntVect(4)
+    b0 = amrex.IntVect(2)
+
+    a1 = [x//2 for x in a0]
+    b1 = [x for x in b0]
+
+    np.testing.assert_allclose(a1, b1)


### PR DESCRIPTION
Add more methods to `Box`.

- [x] I think `hi_vect`/`lo_vect` are equal to `small_end`/`big_end` and need to be reimplemented to return not an `int*` - which results in returning a scalar of the first value - but an array
- [x] We should implement that `IntVect` can be either casted to a list or be iterated

## To Do

- [x] I don't understand why the `test_surrounding_nodes` does not pass though.