### PR TITLE
Windows: Fix `pip_install`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,8 @@ jobs:
       run: .github/workflows/dependencies/dependencies_mac.sh
     - name: Build & Install
       run: |
-        python3 -m pip install -U pip pytest
+        python3 -m pip install -U pip setuptools wheel pytest
+        python3 -m pip install -U cmake
         python3 -m pip install -v .
         python3 -c "import amrex; print(amrex.__version__)"
     - name: Unit tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: macos
+name: 🍏 macOS
 
 on: [push, pull_request]
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: linux
+name: 🐧 Ubuntu
 
 on: [push, pull_request]
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: windows
+name: 🪟 Windows
 
 on: [push, pull_request]
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,8 +18,16 @@ jobs:
         python-version: '3.x'
     - name: Build & Install
       run: |
-        python3 -m pip install -U pip pytest
-        python3 -m pip install -v .
+        python3 -m pip install -U pip setuptools wheel pytest
+        python3 -m pip install -U cmake
+
+        cmake -S . -B build               `
+              -DCMAKE_VERBOSE_MAKEFILE=ON `
+              -DAMReX_MPI=OFF
+
+        cmake --build build --config Debug -j 2
+        cmake --build build --config Debug --target pip_install -j 2
+
         python3 -c "import amrex; print(amrex.__version__)"
     - name: Unit tests
       shell: cmd
@@ -43,12 +51,13 @@ jobs:
         python3 -m pip install -U cmake
 
         cmake -S . -B build               `
+              -G "Ninja"                  `
               -T "ClangCl"                `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DAMReX_MPI=OFF
 
         cmake --build build --config Debug -j 2
-        python3 -m pip install -v .
+        cmake --build build --config Debug --target pip_install -j 2
     - name: Unit tests
       run: |
         ctest --test-dir build -C Debug --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,6 @@ jobs:
         python3 -m pip install -U cmake
 
         cmake -S . -B build               `
-              -G "Ninja"                  `
               -T "ClangCl"                `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DAMReX_MPI=OFF

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,15 +18,8 @@ jobs:
         python-version: '3.x'
     - name: Build & Install
       run: |
-        python3 -m pip install -U pip setuptools wheel pytest
-        python3 -m pip install -U cmake
-
-        cmake -S . -B build               `
-              -DCMAKE_VERBOSE_MAKEFILE=ON `
-              -DAMReX_MPI=OFF
-
-        cmake --build build --config Debug -j 2
-        cmake --build build --config Debug --target pip_install -j 2
+        python3 -m pip install -U pip pytest
+        python3 -m pip install -v .
 
         python3 -c "import amrex; print(amrex.__version__)"
     - name: Unit tests
@@ -37,7 +30,6 @@ jobs:
   clang:
     name: Clang w/o MPI
     runs-on: windows-latest
-    env: {PYAMREX_LIBDIR: build/lib/site-packages/amrex/Debug/}
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,10 +222,10 @@ set(pyAMReX_CUSTOM_TARGET_PREFIX "${_pyAMReX_CUSTOM_TARGET_PREFIX_DEFAULT}"
 
 # build the wheel by re-using the shared library we build
 add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel
-    ${CMAKE_COMMAND} -E rm -f "amrex*.whl"
+    ${CMAKE_COMMAND} -E rm -f -r amrex-whl
     COMMAND
         ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=$<TARGET_FILE_DIR:pyAMReX>
-            ${Python_EXECUTABLE} -m pip wheel -v --no-build-isolation ${pyAMReX_SOURCE_DIR}
+            ${Python_EXECUTABLE} -m pip wheel -v --no-build-isolation --no-deps --wheel-dir=amrex-whl ${pyAMReX_SOURCE_DIR}
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS
@@ -244,7 +244,7 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install_requirements
 # because otherwise pip would also force reinstall all dependencies.
 add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install
     ${CMAKE_COMMAND} -E env AMREX_MPI=${AMReX_MPI}
-        ${Python_EXECUTABLE} -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} "amrex*.whl"
+        ${Python_EXECUTABLE} -m pip install --force-reinstall --no-index --no-deps ${PYINSTALLOPTIONS} --find-links=amrex-whl amrex
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS


### PR DESCRIPTION
The `pip_install` target did not yet work on Windows, because it has no universal wildcard `*` support for our pip install logic.

Fix this by creating the wheel in a sub-directory and installing it by "finding all wheels for `amrex` in a given prefix".