### PR TITLE
pytest fixtures: per function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ if amrex.Config.have_mpi:
     from mpi4py import MPI
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="function")
 def amrex_init():
     amrex.initialize(
         [
@@ -29,21 +29,21 @@ def amrex_init():
     amrex.finalize()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def std_real_box():
     """Standard RealBox for common problem domains"""
     rb = amrex.RealBox(0, 0, 0, 1.0, 1.0, 1.0)
     return rb
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def std_box():
     """Standard Box for tests"""
     bx = amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(63, 63, 63))
     return bx
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def std_geometry(std_box, std_real_box):
     """Standard Geometry"""
     coord = 1  # RZ
@@ -52,7 +52,7 @@ def std_geometry(std_box, std_real_box):
     return gm
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def boxarr(std_box):
     """BoxArray for MultiFab creation"""
     ba = amrex.BoxArray(std_box)
@@ -60,14 +60,14 @@ def boxarr(std_box):
     return ba
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def distmap(boxarr):
     """DistributionMapping for MultiFab creation"""
     dm = amrex.DistributionMapping(boxarr)
     return dm
 
 
-@pytest.fixture(params=list(itertools.product([1, 3], [0, 1])))
+@pytest.fixture(scope="function", params=list(itertools.product([1, 3], [0, 1])))
 def mfab(boxarr, distmap, request):
     """MultiFab for tests"""
     num_components = request.param[0]

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -6,7 +6,7 @@ import pytest
 import amrex
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def box():
     return amrex.Box((0, 0, 0), (127, 127, 127))
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -9,17 +9,17 @@ from amrex import Geometry as Gm
 # TODO: return coord?
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def box():
     return amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(127, 127, 127))
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def real_box():
     return amrex.RealBox([0, 0, 0], [1, 2, 5])
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def geometry(box, real_box):
     coord = 1
     is_periodic = [0, 0, 1]

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -11,13 +11,13 @@ def Npart():
     return 21
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def empty_particle_container(std_geometry, distmap, boxarr):
     pc = amrex.ParticleContainer_1_1_2_1(std_geometry, distmap, boxarr)
     return pc
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def std_particle():
     myt = amrex.ParticleInitType_1_1_2_1()
     myt.real_struct_data = [0.5]
@@ -27,7 +27,7 @@ def std_particle():
     return myt
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
     pc = amrex.ParticleContainer_1_1_2_1(std_geometry, distmap, boxarr)
     myt = amrex.ParticleInitType_1_1_2_1()


### PR DESCRIPTION
Make sure we init and finalize AMReX and all fixture objects for each test function. This is important, since objects like MultiFabs use the memory Arenas of a current AMReX session.

Needed for a clean shutdown of new tests in #30