### PR TITLE
Particles: CUDA Array Interface

### DIFF
--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -159,7 +159,7 @@ void make_Array4(py::module &m, std::string typestr)
         // __array_function__ feature requires NumPy 1.16 or later.
 
 
-        // Nvidia GPUs: __cuda_array_interface__ v2
+        // Nvidia GPUs: __cuda_array_interface__ v3
         // https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html
         .def_property_readonly("__cuda_array_interface__", [](Array4<T> const & a4) {
             auto d = array_interface(a4);

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -38,10 +38,11 @@ namespace
 }
 
 template <class T, class Allocator = std::allocator<T> >
-void make_PODVector(py::module &m, std::string typestr)
+void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
 {
     using PODVector_type = PODVector<T, Allocator>;
-    auto const podv_name = std::string("PODVector_").append(typestr);
+    auto const podv_name = std::string("PODVector_").append(typestr)
+                           .append("_").append(allocstr);
 
     py::class_<PODVector_type>(m, podv_name.c_str())
         .def("__repr__",
@@ -108,6 +109,18 @@ void make_PODVector(py::module &m, std::string typestr)
         .def("__setitem__", [](PODVector_type & podvector, int const v, T const value){ podvector[v] = value; })
         .def("__getitem__", [](PODVector_type & pv, int const v){ return pv[v]; })
     ;
+}
+
+template <class T>
+void make_PODVector(py::module &m, std::string typestr)
+{
+    // see Src/Base/AMReX_GpuContainers.H
+    make_PODVector<T, std::allocator<T>> (m, typestr, "std");
+    make_PODVector<T, amrex::ArenaAllocator<T>> (m, typestr, "arena");
+    make_PODVector<T, amrex::DeviceArenaAllocator<T>> (m, typestr, "device");
+    make_PODVector<T, amrex::ManagedArenaAllocator<T>> (m, typestr, "managed");
+    make_PODVector<T, amrex::PinnedArenaAllocator<T>> (m, typestr, "pinned");
+    make_PODVector<T, amrex::AsyncArenaAllocator<T>> (m, typestr, "async");
 }
 
 void init_PODVector(py::module& m) {

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -117,10 +117,12 @@ void make_PODVector(py::module &m, std::string typestr)
     // see Src/Base/AMReX_GpuContainers.H
     make_PODVector<T, std::allocator<T>> (m, typestr, "std");
     make_PODVector<T, amrex::ArenaAllocator<T>> (m, typestr, "arena");
+    make_PODVector<T, amrex::PinnedArenaAllocator<T>> (m, typestr, "pinned");
+#ifdef AMREX_USE_GPU
     make_PODVector<T, amrex::DeviceArenaAllocator<T>> (m, typestr, "device");
     make_PODVector<T, amrex::ManagedArenaAllocator<T>> (m, typestr, "managed");
-    make_PODVector<T, amrex::PinnedArenaAllocator<T>> (m, typestr, "pinned");
     make_PODVector<T, amrex::AsyncArenaAllocator<T>> (m, typestr, "async");
+#endif
 }
 
 void init_PODVector(py::module& m) {

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -16,10 +16,31 @@
 namespace py = pybind11;
 using namespace amrex;
 
+namespace
+{
+    /** CPU: __array_interface__ v3
+     *
+     * https://numpy.org/doc/stable/reference/arrays.interface.html
+     */
+    template <class T, class Allocator = std::allocator<T> >
+    py::dict
+    array_interface(PODVector<T, Allocator> const & podvector)
+    {
+        auto d = py::dict();
+        bool const read_only = false;
+        d["data"] = py::make_tuple(std::intptr_t(podvector.dataPtr()), read_only);
+        d["shape"] = py::make_tuple(podvector.size());
+        d["strides"] = py::none();
+        d["typestr"] = py::format_descriptor<T>::format();
+        d["version"] = 3;
+        return d;
+    }
+}
+
 template <class T, class Allocator = std::allocator<T> >
 void make_PODVector(py::module &m, std::string typestr)
 {
-    using PODVector_type=PODVector<T, Allocator>;
+    using PODVector_type = PODVector<T, Allocator>;
     auto const podv_name = std::string("PODVector_").append(typestr);
 
     py::class_<PODVector_type>(m, podv_name.c_str())
@@ -60,12 +81,26 @@ void make_PODVector(py::module &m, std::string typestr)
         // swap
 
         .def_property_readonly("__array_interface__", [](PODVector_type const & podvector) {
-            auto d = py::dict();
-            bool const read_only = false;
-            d["data"] = py::make_tuple(std::intptr_t(podvector.dataPtr()), read_only);
-            d["shape"] = py::make_tuple(podvector.size());
-            d["strides"] = py::none();
-            d["typestr"] = py::format_descriptor<T>::format();
+            return array_interface(podvector);
+        })
+        .def_property_readonly("__cuda_array_interface__", [](PODVector_type const & podvector) {
+            // Nvidia GPUs: __cuda_array_interface__ v3
+            // https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html
+            auto d = array_interface(podvector);
+
+            // data:
+            // Because the user of the interface may or may not be in the same context, the most common case is to use cuPointerGetAttribute with CU_POINTER_ATTRIBUTE_DEVICE_POINTER in the CUDA driver API (or the equivalent CUDA Runtime API) to retrieve a device pointer that is usable in the currently active context.
+            // TODO For zero-size arrays, use 0 here.
+
+            // None or integer
+            // An optional stream upon which synchronization must take place at the point of consumption, either by synchronizing on the stream or enqueuing operations on the data on the given stream. Integer values in this entry are as follows:
+            //   0: This is disallowed as it would be ambiguous between None and the default stream, and also between the legacy and per-thread default streams. Any use case where 0 might be given should either use None, 1, or 2 instead for clarity.
+            //   1: The legacy default stream.
+            //   2: The per-thread default stream.
+            //   Any other integer: a cudaStream_t represented as a Python integer.
+            //   When None, no synchronization is required.
+            d["stream"] = py::none();
+
             d["version"] = 3;
             return d;
         })

--- a/src/Base/Vector.cpp
+++ b/src/Base/Vector.cpp
@@ -20,11 +20,31 @@
 namespace py = pybind11;
 using namespace amrex;
 
+namespace
+{
+    /** CPU: __array_interface__ v3
+     *
+     * https://numpy.org/doc/stable/reference/arrays.interface.html
+     */
+    template <class T, class Allocator = std::allocator<T> >
+    py::dict
+    array_interface(Vector<T, Allocator> const & vector)
+    {
+        auto d = py::dict();
+        bool const read_only = false;
+        d["data"] = py::make_tuple(std::intptr_t(vector.dataPtr()), read_only);
+        d["shape"] = py::make_tuple(vector.size());
+        d["strides"] = py::none();
+        d["typestr"] = py::format_descriptor<T>::format();
+        d["version"] = 3;
+        return d;
+    }
+}
 
 template <class T, class Allocator = std::allocator<T> >
 void make_Vector(py::module &m, std::string typestr)
 {
-    using Vector_type=Vector<T, Allocator>;
+    using Vector_type = Vector<T, Allocator>;
     auto const v_name = std::string("Vector_").append(typestr);
 
     py::class_<Vector_type>(m, v_name.c_str())
@@ -47,15 +67,30 @@ void make_Vector(py::module &m, std::string typestr)
         .def("size", &Vector_type::size)
 
         .def_property_readonly("__array_interface__", [](Vector_type const & vector) {
-            auto d = py::dict();
-            bool const read_only = false;
-            d["data"] = py::make_tuple(std::intptr_t(vector.dataPtr()), read_only);
-            d["shape"] = py::make_tuple(vector.size());
-            d["strides"] = py::none();
-            d["typestr"] = py::format_descriptor<T>::format();
+            return array_interface(vector);
+        })
+        .def_property_readonly("__cuda_array_interface__", [](Vector_type const & vector) {
+            // Nvidia GPUs: __cuda_array_interface__ v3
+            // https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html
+            auto d = array_interface(vector);
+
+            // data:
+            // Because the user of the interface may or may not be in the same context, the most common case is to use cuPointerGetAttribute with CU_POINTER_ATTRIBUTE_DEVICE_POINTER in the CUDA driver API (or the equivalent CUDA Runtime API) to retrieve a device pointer that is usable in the currently active context.
+            // TODO For zero-size arrays, use 0 here.
+
+            // None or integer
+            // An optional stream upon which synchronization must take place at the point of consumption, either by synchronizing on the stream or enqueuing operations on the data on the given stream. Integer values in this entry are as follows:
+            //   0: This is disallowed as it would be ambiguous between None and the default stream, and also between the legacy and per-thread default streams. Any use case where 0 might be given should either use None, 1, or 2 instead for clarity.
+            //   1: The legacy default stream.
+            //   2: The per-thread default stream.
+            //   Any other integer: a cudaStream_t represented as a Python integer.
+            //   When None, no synchronization is required.
+            d["stream"] = py::none();
+
             d["version"] = 3;
             return d;
         })
+
         // setter & getter
         .def("__setitem__", [](Vector_type & vector, int const idx, T const value){ vector[idx] = value; })
         .def("__getitem__", [](Vector_type & v, int const idx){ return v[idx]; })

--- a/src/Particle/ArrayOfStructs.cpp
+++ b/src/Particle/ArrayOfStructs.cpp
@@ -126,10 +126,12 @@ void make_ArrayOfStructs(py::module &m)
     // see Src/Base/AMReX_GpuContainers.H
     make_ArrayOfStructs<NReal, NInt, std::allocator> (m, "std");
     make_ArrayOfStructs<NReal, NInt, amrex::ArenaAllocator> (m, "arena");
+    make_ArrayOfStructs<NReal, NInt, amrex::PinnedArenaAllocator> (m, "pinned");
+#ifdef AMREX_USE_GPU
     make_ArrayOfStructs<NReal, NInt, amrex::DeviceArenaAllocator> (m, "device");
     make_ArrayOfStructs<NReal, NInt, amrex::ManagedArenaAllocator> (m, "managed");
-    make_ArrayOfStructs<NReal, NInt, amrex::PinnedArenaAllocator> (m, "pinned");
     make_ArrayOfStructs<NReal, NInt, amrex::AsyncArenaAllocator> (m, "async");
+#endif
 }
 
 void init_ArrayOfStructs(py::module& m) {

--- a/src/Particle/ArrayOfStructs.cpp
+++ b/src/Particle/ArrayOfStructs.cpp
@@ -14,6 +14,51 @@
 namespace py = pybind11;
 using namespace amrex;
 
+namespace
+{
+    /** CPU: __array_interface__ v3
+     *
+     * https://numpy.org/doc/stable/reference/arrays.interface.html
+     */
+    template <int NReal, int NInt,
+              template<class> class Allocator=DefaultAllocator>
+    py::dict
+    array_interface(ArrayOfStructs<NReal, NInt> const & aos)
+    {
+        using ParticleType = Particle<NReal, NInt>;
+        using RealType      = typename ParticleType::RealType;
+
+        auto d = py::dict();
+        bool const read_only = false;
+        d["data"] = py::make_tuple(std::intptr_t(aos.dataPtr()), read_only);
+        d["shape"] = py::make_tuple(aos.size());
+        d["strides"] = py::make_tuple(sizeof(ParticleType));
+        d["typestr"] = "|V" + std::to_string(sizeof(ParticleType));
+        py::list descr;
+        descr.append(py::make_tuple("x", py::format_descriptor<RealType>::format()));
+#if (AMREX_SPACEDIM >= 2)
+        descr.append(py::make_tuple("y", py::format_descriptor<RealType>::format()));
+#endif
+#if (AMREX_SPACEDIM >= 3)
+        descr.append(py::make_tuple("z", py::format_descriptor<RealType>::format()));
+#endif
+        if (NReal > 0) {
+            for(int ii=0; ii < NReal; ii++) {
+                descr.append(py::make_tuple("rdata_"+std::to_string(ii),py::format_descriptor<RealType>::format()));
+            }
+        }
+        descr.append(py::make_tuple("cpuid", py::format_descriptor<uint64_t>::format()) );
+        if (NInt > 0) {
+            for(int ii=0; ii < NInt; ++ii) {
+                descr.append(py::make_tuple("idata_"+std::to_string(ii),py::format_descriptor<int>::format()));
+            }
+        }
+
+        d["descr"] = descr;
+        d["version"] = 3;
+        return d;
+    }
+}
 
 template <int NReal, int NInt,
           template<class> class Allocator=DefaultAllocator>
@@ -21,7 +66,6 @@ void make_ArrayOfStructs(py::module &m)
 {
     using AOSType = ArrayOfStructs<NReal, NInt>;
     using ParticleType  = Particle<NReal, NInt>;
-    using RealType      = typename ParticleType::RealType;
 
     auto const aos_name = std::string("ArrayOfStructs_").append(std::to_string(NReal) + "_" + std::to_string(NInt));
     py::class_<AOSType>(m, aos_name.c_str())
@@ -41,35 +85,29 @@ void make_ArrayOfStructs(py::module &m)
         .def("push_back", &AOSType::push_back)
         .def("pop_back", &AOSType::pop_back)
         .def("back", py::overload_cast<>(&AOSType::back),"get back member.  Problem!!!!! this is perfo")
+
         // setter & getter
         .def_property_readonly("__array_interface__", [](AOSType const & aos) {
-            auto d = py::dict();
-            bool const read_only = false;
-            d["data"] = py::make_tuple(std::intptr_t(aos.dataPtr()), read_only);
-            d["shape"] = py::make_tuple(aos.size());
-            d["strides"] = py::make_tuple(sizeof(ParticleType));
-            d["typestr"] = "|V" + std::to_string(sizeof(ParticleType));
-            py::list descr;
-            descr.append(py::make_tuple("x", py::format_descriptor<RealType>::format()));
-#if (AMREX_SPACEDIM >= 2)
-            descr.append(py::make_tuple("y", py::format_descriptor<RealType>::format()));
-#endif
-#if (AMREX_SPACEDIM >= 3)
-            descr.append(py::make_tuple("z", py::format_descriptor<RealType>::format()));
-#endif
-            if (NReal > 0) {
-                for(int ii=0; ii < NReal; ii++) {
-                    descr.append(py::make_tuple("rdata_"+std::to_string(ii),py::format_descriptor<RealType>::format()));
-                }
-            }
-            descr.append(py::make_tuple("cpuid", py::format_descriptor<uint64_t>::format()) );
-            if (NInt > 0) {
-                for(int ii=0; ii < NInt; ++ii) {
-                    descr.append(py::make_tuple("idata_"+std::to_string(ii),py::format_descriptor<int>::format()));
-                }
-            }
+            return array_interface(aos);
+        })
+        .def_property_readonly("__cuda_array_interface__", [](AOSType const & aos) {
+            // Nvidia GPUs: __cuda_array_interface__ v3
+            // https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html
+            auto d = array_interface(aos);
 
-            d["descr"] = descr;
+            // data:
+            // Because the user of the interface may or may not be in the same context, the most common case is to use cuPointerGetAttribute with CU_POINTER_ATTRIBUTE_DEVICE_POINTER in the CUDA driver API (or the equivalent CUDA Runtime API) to retrieve a device pointer that is usable in the currently active context.
+            // TODO For zero-size arrays, use 0 here.
+
+            // None or integer
+            // An optional stream upon which synchronization must take place at the point of consumption, either by synchronizing on the stream or enqueuing operations on the data on the given stream. Integer values in this entry are as follows:
+            //   0: This is disallowed as it would be ambiguous between None and the default stream, and also between the legacy and per-thread default streams. Any use case where 0 might be given should either use None, 1, or 2 instead for clarity.
+            //   1: The legacy default stream.
+            //   2: The per-thread default stream.
+            //   Any other integer: a cudaStream_t represented as a Python integer.
+            //   When None, no synchronization is required.
+            d["stream"] = py::none();
+
             d["version"] = 3;
             return d;
         })

--- a/src/Particle/ParticleContainer.cpp
+++ b/src/Particle/ParticleContainer.cpp
@@ -353,13 +353,15 @@ void make_ParticleContainer_and_Iterators (py::module &m)
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::ArenaAllocator>(m, "arena");
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
+                                         amrex::PinnedArenaAllocator>(m, "pinned");
+#ifdef AMREX_USE_GPU
+    make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::DeviceArenaAllocator>(m, "device");
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::ManagedArenaAllocator>(m, "managed");
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
-                                         amrex::PinnedArenaAllocator>(m, "pinned");
-    make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::AsyncArenaAllocator>(m, "async");
+#endif
 }
 
 void init_ParticleContainer(py::module& m) {

--- a/src/Particle/ParticleContainer.cpp
+++ b/src/Particle/ParticleContainer.cpp
@@ -370,6 +370,5 @@ void init_ParticleContainer(py::module& m) {
     make_ParticleContainer_and_Iterators< 1, 1, 2, 1> (m);
     make_ParticleContainer_and_Iterators< 0, 0, 4, 0> (m);   // HiPACE++ 22.07
     make_ParticleContainer_and_Iterators< 0, 0, 5, 0> (m);   // ImpactX 22.07
-    make_ParticleContainer_and_Iterators< 0, 0, 7, 0> (m);
     make_ParticleContainer_and_Iterators< 0, 0, 37, 1> (m);  // HiPACE++ 22.07
 }

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -117,13 +117,15 @@ void make_ParticleTile(py::module &m)
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::ArenaAllocator>(m, "arena");
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
+                      amrex::PinnedArenaAllocator>(m, "pinned");
+#ifdef AMREX_USE_GPU
+    make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::DeviceArenaAllocator>(m, "device");
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::ManagedArenaAllocator>(m, "managed");
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
-                      amrex::PinnedArenaAllocator>(m, "pinned");
-    make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::AsyncArenaAllocator>(m, "async");
+#endif
 }
 
 void init_ParticleTile(py::module& m) {

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -60,6 +60,5 @@ void init_StructOfArrays(py::module& m) {
     make_StructOfArrays< 2, 1>(m);
     make_StructOfArrays< 4, 0>(m);  // HiPACE++ 22.07
     make_StructOfArrays< 5, 0>(m);  // ImpactX 22.07
-    make_StructOfArrays< 7, 0>(m);
     make_StructOfArrays<37, 1>(m);  // HiPACE++ 22.07
 }

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -48,10 +48,12 @@ void make_StructOfArrays(py::module &m)
     // see Src/Base/AMReX_GpuContainers.H
     make_StructOfArrays<NReal, NInt, std::allocator>(m, "std");
     make_StructOfArrays<NReal, NInt, amrex::ArenaAllocator>(m, "arena");
+    make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator>(m, "pinned");
+#ifdef AMREX_USE_GPU
     make_StructOfArrays<NReal, NInt, amrex::DeviceArenaAllocator>(m, "device");
     make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator>(m, "managed");
-    make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator>(m, "pinned");
     make_StructOfArrays<NReal, NInt, amrex::AsyncArenaAllocator>(m, "async");
+#endif
 }
 
 void init_StructOfArrays(py::module& m) {

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -17,11 +17,12 @@ using namespace amrex;
 
 template <int NReal, int NInt,
           template<class> class Allocator=DefaultAllocator>
-void make_StructOfArrays(py::module &m)
+void make_StructOfArrays(py::module &m, std::string allocstr)
 {
-    using SOAType = StructOfArrays<NReal, NInt>;
+    using SOAType = StructOfArrays<NReal, NInt, Allocator>;
 
-    auto const soa_name = std::string("StructOfArrays_").append(std::to_string(NReal) + "_" + std::to_string(NInt));
+    auto const soa_name = std::string("StructOfArrays_") + std::to_string(NReal) + "_" +
+                          std::to_string(NInt) + "_" + allocstr;
     py::class_<SOAType>(m, soa_name.c_str())
         .def(py::init())
         .def("define", &SOAType::define)
@@ -41,11 +42,22 @@ void make_StructOfArrays(py::module &m)
     ;
 }
 
+template <int NReal, int NInt>
+void make_StructOfArrays(py::module &m)
+{
+    // see Src/Base/AMReX_GpuContainers.H
+    make_StructOfArrays<NReal, NInt, std::allocator>(m, "std");
+    make_StructOfArrays<NReal, NInt, amrex::ArenaAllocator>(m, "arena");
+    make_StructOfArrays<NReal, NInt, amrex::DeviceArenaAllocator>(m, "device");
+    make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator>(m, "managed");
+    make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator>(m, "pinned");
+    make_StructOfArrays<NReal, NInt, amrex::AsyncArenaAllocator>(m, "async");
+}
 
 void init_StructOfArrays(py::module& m) {
-    make_StructOfArrays< 2, 1 > (m);
-    make_StructOfArrays< 4, 0 > (m);  // HiPACE++ 22.07
-    make_StructOfArrays< 5, 0 > (m);  // ImpactX 22.07
-    make_StructOfArrays< 7, 0 > (m);
-    make_StructOfArrays< 37, 1> (m);  // HiPACE++ 22.07
+    make_StructOfArrays< 2, 1>(m);
+    make_StructOfArrays< 4, 0>(m);  // HiPACE++ 22.07
+    make_StructOfArrays< 5, 0>(m);  // ImpactX 22.07
+    make_StructOfArrays< 7, 0>(m);
+    make_StructOfArrays<37, 1>(m);  // HiPACE++ 22.07
 }

--- a/tests/test_aos.py
+++ b/tests/test_aos.py
@@ -7,7 +7,7 @@ import amrex
 
 
 def test_aos_init():
-    aos = amrex.ArrayOfStructs_2_1()
+    aos = amrex.ArrayOfStructs_2_1_std()
 
     assert aos.numParticles() == 0
     assert aos.numTotalParticles() == aos.numRealParticles() == 0
@@ -15,7 +15,7 @@ def test_aos_init():
 
 
 def test_aos_push_pop():
-    aos = amrex.ArrayOfStructs_2_1()
+    aos = amrex.ArrayOfStructs_2_1_std()
     p1 = amrex.Particle_2_1()
     p1.set_rdata([1.5, 2.2])
     p1.set_idata([3])
@@ -50,7 +50,7 @@ def test_aos_push_pop():
 
 
 def test_array_interface():
-    aos = amrex.ArrayOfStructs_2_1()
+    aos = amrex.ArrayOfStructs_2_1_std()
     p1 = amrex.Particle_2_1()
     p1.setPos([1, 2, 3])
     p1.set_rdata([4.5, 5.2])

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -13,7 +13,7 @@ def Npart():
 
 @pytest.fixture(scope="function")
 def empty_particle_container(std_geometry, distmap, boxarr):
-    pc = amrex.ParticleContainer_1_1_2_1(std_geometry, distmap, boxarr)
+    pc = amrex.ParticleContainer_1_1_2_1_std(std_geometry, distmap, boxarr)
     return pc
 
 
@@ -29,7 +29,7 @@ def std_particle():
 
 @pytest.fixture(scope="function")
 def particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
-    pc = amrex.ParticleContainer_1_1_2_1(std_geometry, distmap, boxarr)
+    pc = amrex.ParticleContainer_1_1_2_1_std(std_geometry, distmap, boxarr)
     myt = amrex.ParticleInitType_1_1_2_1()
     myt.real_struct_data = [0.5]
     myt.int_struct_data = [5]
@@ -62,17 +62,17 @@ def test_particleInitType():
 def test_n_particles(particle_container, Npart):
     pc = particle_container
     assert pc.OK()
-    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1.NStructReal == 1
-    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1.NStructInt == 1
-    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1.NArrayReal == 2
-    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1.NArrayInt == 1
+    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_std.NStructReal == 1
+    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_std.NStructInt == 1
+    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_std.NArrayReal == 2
+    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_std.NArrayInt == 1
     assert (
         pc.NumberOfParticlesAtLevel(0) == np.sum(pc.NumberOfParticlesInGrid(0)) == Npart
     )
 
 
 def test_pc_init():
-    pc = amrex.ParticleContainer_1_1_2_1()
+    pc = amrex.ParticleContainer_1_1_2_1_std()
 
     print("bytespread", pc.ByteSpread())
     print("capacity", pc.PrintCapacity())
@@ -93,10 +93,10 @@ def test_pc_init():
     print("define particle container")
     pc.Define(gm, dm, ba)
     assert pc.OK()
-    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1.NStructReal == 1
-    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1.NStructInt == 1
-    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1.NArrayReal == 2
-    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1.NArrayInt == 1
+    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_std.NStructReal == 1
+    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_std.NStructInt == 1
+    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_std.NArrayReal == 2
+    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_std.NArrayInt == 1
 
     print("bytespread", pc.ByteSpread())
     print("capacity", pc.PrintCapacity())
@@ -123,7 +123,7 @@ def test_pc_init():
 
     print("Iterate particle boxes & set values")
     lvl = 0
-    for pti in amrex.ParIter_1_1_2_1(pc, level=lvl):
+    for pti in amrex.ParIter_1_1_2_1_std(pc, level=lvl):
         print("...")
         assert pti.num_particles == 1
         assert pti.num_real_particles == 1
@@ -151,7 +151,7 @@ def test_pc_init():
         assert np.allclose(int_arrays[0], np.array([2]))
 
     # read-only
-    for pti in amrex.ParConstIter_1_1_2_1(pc, level=lvl):
+    for pti in amrex.ParConstIter_1_1_2_1_std(pc, level=lvl):
         assert pti.num_particles == 1
         assert pti.num_real_particles == 1
         assert pti.num_neighbor_particles == 0

--- a/tests/test_particleTile.py
+++ b/tests/test_particleTile.py
@@ -15,7 +15,7 @@ def test_ptile_data():
 
 
 def test_ptile_funs():
-    pt = amrex.ParticleTile_1_1_2_1()
+    pt = amrex.ParticleTile_1_1_2_1_std()
 
     assert pt.empty() and pt.size() == 0
     assert pt.numParticles() == pt.numRealParticles() == pt.numNeighborParticles() == 0
@@ -35,7 +35,7 @@ def test_ptile_funs():
 
 ################
 def test_ptile_pushback_ptiledata():
-    pt = amrex.ParticleTile_1_1_2_1()
+    pt = amrex.ParticleTile_1_1_2_1_std()
     p = amrex.Particle_1_1(1.0, 2.0, 3, 4.0, 5)
     sp = amrex.Particle_3_2(5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11, 12)
     pt.push_back(p)
@@ -62,7 +62,7 @@ def test_ptile_pushback_ptiledata():
 
 @pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_access():
-    pt = amrex.ParticleTile_1_1_2_1()
+    pt = amrex.ParticleTile_1_1_2_1_std()
     sp1 = amrex.Particle_3_2()
     pt.push_back(sp1)
     pt.push_back(sp1)
@@ -81,7 +81,7 @@ def test_ptile_access():
 
 
 def test_ptile_soa():
-    pt = amrex.ParticleTile_1_1_2_1()
+    pt = amrex.ParticleTile_1_1_2_1_std()
 
     pt.push_back_real(1, 2.1)
     pt.push_back_real([1.1, 1.3])
@@ -120,7 +120,7 @@ def test_ptile_soa():
 
 @pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_aos():
-    pt = amrex.ParticleTile_1_1_2_1()
+    pt = amrex.ParticleTile_1_1_2_1_std()
     p1 = amrex.Particle_1_1()
     p2 = amrex.Particle_1_1()
     p1.x = 3.0

--- a/tests/test_podvector.py
+++ b/tests/test_podvector.py
@@ -7,7 +7,7 @@ import amrex
 
 
 def test_podvector_init():
-    podv = amrex.PODVector_real()
+    podv = amrex.PODVector_real_std()
     print(podv.__array_interface__)
     # podv[0] = 1
     # podv[2] = 3
@@ -28,7 +28,7 @@ def test_podvector_init():
 
 
 def test_array_interface():
-    podv = amrex.PODVector_int()
+    podv = amrex.PODVector_int_std()
     podv.push_back(1)
     podv.push_back(2)
     podv.push_back(1)

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -7,7 +7,7 @@ import amrex
 
 
 def test_soa_init():
-    soa = amrex.StructOfArrays_2_1()
+    soa = amrex.StructOfArrays_2_1_std()
     print("--test init --")
     print("num real components", soa.NumRealComps())
     print("num int components", soa.NumIntComps())
@@ -51,7 +51,7 @@ def test_soa_init():
 
 
 def test_soa_from_tile():
-    pt = amrex.ParticleTile_1_1_2_1()
+    pt = amrex.ParticleTile_1_1_2_1_std()
     p = amrex.Particle_1_1(1.0, 2.0, 3, rdata_0=4.0, idata_1=5)
     sp = amrex.Particle_3_2(
         5.0, 6.0, 7.0, rdata_0=8.0, rdata_1=9.0, rdata_2=10.0, idata_0=11, idata_1=12


### PR DESCRIPTION
Add the `__cuda_array_interface__` to particles.
Similar to #30, related to #9

- [X] PODVector (incl. SoA)
- [X] AoS
- [X] Support allocators for particle data stuctures

Follow-up:
- [ ] goal: make sure https://github.com/ECP-WarpX/impactx/blob/deff1e4aa72f2c1cd207e5503e6b9499cb1f896e/examples/fodo/run_fodo_programmable.py#L59-L101 runs on GPU
  - [ ] wait for cupy? https://github.com/cupy/cupy/issues/2031
  - [ ] rewrite test in numpy or pytorch?
- [ ] add tests