### PR TITLE
pybind11: v2.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pyAMReX depends on the following popular third party software.
 - a mature [C++17](https://en.wikipedia.org/wiki/C%2B%2B17) compiler, e.g., GCC 8, Clang 7, NVCC 11.0, MSVC 19.15 or newer
 - [CMake 3.20.0+](https://cmake.org)
 - [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
-- [pybind11](https://github.com/pybind/pybind11/) 2.9.1+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
+- [pybind11](https://github.com/pybind/pybind11/) 2.10.1+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
   - [Python](https://python.org) 3.7+
   - [Numpy](https://numpy.org) 1.15+
 

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -38,7 +38,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     elseif(NOT pyAMReX_pybind11_internal)
-        find_package(pybind11 2.9.1 CONFIG REQUIRED)
+        find_package(pybind11 2.10.1 CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -53,7 +53,7 @@ option(pyAMReX_pybind11_internal "Download & build pybind11" ON)
 set(pyAMReX_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(pyAMReX_pybind11_internal)")
-set(pyAMReX_pybind11_branch "v2.9.1"
+set(pyAMReX_pybind11_branch "v2.10.1"
     CACHE STRING
     "Repository branch for pyAMReX_pybind11_repo if(pyAMReX_pybind11_internal)")
 


### PR DESCRIPTION
This release adds a work-around for compiler bugs in Nvidia `nvcc` version 11.4 - 11.8, e.g., as used on Perlmutter (NERSC).

- https://github.com/pybind/pybind11/issues/4193
- https://github.com/pybind/pybind11/pull/4220