### PR TITLE
Support Shared AMReX Lib

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,6 +50,7 @@ jobs:
         cmake -S . -B build               \
               -DCMAKE_BUILD_TYPE=Debug    \
               -DCMAKE_VERBOSE_MAKEFILE=ON \
+              -DBUILD_SHARED_LIBS=ON      \
               -DAMReX_MPI=ON
         cmake --build build --target pip_install -j 2
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,11 +62,11 @@ jobs:
 
         llvm-objdump -p  "C:\Program Files (x86)\pyAMReX\bin\amrex.dll"
 
-        Get-Childitem -Path C:\* -Recurse -Filter "*python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll"
-
     - name: Unit tests
       run: |
         $env:Path += "C:\Program Files (x86)\pyAMReX\bin"
         (Get-Command ctest).Path
         gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
         cdb -c "g;q" ctest --test-dir build -C Debug --output-on-failure
+
+        Get-Childitem -Path C:\Program Files (x86)\* -Recurse -Filter "*python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         python-version: '3.x'
     - uses: seanmiddleditch/gha-setup-ninja@master
+
     - name: Build & Install
       run: |
         python3 -m pip install -U pip setuptools wheel pytest
@@ -62,13 +63,20 @@ jobs:
 
         llvm-objdump -p  "C:\Program Files (x86)\pyAMReX\bin\amrex.dll"
 
+    - name: Add debugger to the PATH
+      shell: bash
+      run: |
+        echo "C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64" >> $GITHUB_PATH
+
+    - name: Add install .dll location to the PATH
+      shell: bash
+      run: |
+        echo "C:\\Program Files (x86)\\pyAMReX\\bin" >> $GITHUB_PATH
+
     - name: Unit tests
       run: |
-        $env:Path += "C:\Program Files (x86)\pyAMReX\bin"
-        $env:Path += "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\"
         (Get-Command ctest).Path
+        gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
         cdb -c "g;q" ctest --test-dir build -C Debug --output-on-failure
 
-        Get-Childitem -Path C:\Program Files (x86)\* -Recurse -Filter "*python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll"
-
-#        gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
+#        Get-Childitem -Path C:\Program Files (x86)\* -Recurse -Filter "*python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Unit tests
       run: |
-        set PATH="C:/Program Files (x86)/pyAMReX/bin/;%PATH%"
+        $env:Path += "C:\Program Files (x86)\pyAMReX\bin"
         (Get-Command ctest).Path
         gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
         cdb -c "g;q" ctest --test-dir build -C Debug --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,11 +60,13 @@ jobs:
         cmake --build build --config Debug --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
 
-        llvm-objdump -p  C:/Program Files (x86)/pyAMReX/bin/amrex.dll
+        llvm-objdump -p  "C:\Program Files (x86)\pyAMReX\bin\amrex.dll"
 
-        Get-Childitem -Path C:\* -Recurse -Filter *python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll
+        Get-Childitem -Path C:\* -Recurse -Filter "*python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll"
 
     - name: Unit tests
       run: |
         set PATH="C:/Program Files (x86)/pyAMReX/bin/;%PATH%"
-        ctest --test-dir build -C Debug --output-on-failure
+        (Get-Command ctest).Path
+        gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
+        cdb -c "g;q" ctest --test-dir build -C Debug --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,10 +52,14 @@ jobs:
 
         cmake --build build --config Debug -j 2
         if(!$?) { Exit $LASTEXITCODE }
+
+        dumpbin /dependents build\lib\site-packages\amrex\amrex_pybind.cp311-win_amd64.pyd
+
         cmake --build build --config Debug --target install
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build --config Debug --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
     - name: Unit tests
       run: |
+        set PATH="C:/Program Files (x86)/pyAMReX/bin/;%PATH%"
         ctest --test-dir build -C Debug --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,8 @@ jobs:
         $env:Path += "C:\Program Files (x86)\pyAMReX\bin"
         $env:Path += "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\"
         (Get-Command ctest).Path
-        gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
         cdb -c "g;q" ctest --test-dir build -C Debug --output-on-failure
 
         Get-Childitem -Path C:\Program Files (x86)\* -Recurse -Filter "*python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll"
+
+#        gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   msvc:
-    name: MSVC w/o MPI
+    name: MSVC w/o MPI (static)
     runs-on: windows-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -28,7 +28,7 @@ jobs:
       run: python3 -m pytest tests
 
   clang:
-    name: Clang w/o MPI
+    name: Clang w/o MPI (shared)
     runs-on: windows-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,8 +25,7 @@ jobs:
         python3 -c "import amrex; print(amrex.__version__)"
     - name: Unit tests
       shell: cmd
-      run: |
-        python3 -m pytest tests
+      run: python3 -m pytest tests
 
   clang:
     name: Clang w/o MPI
@@ -38,7 +37,6 @@ jobs:
       with:
         python-version: '3.x'
     - uses: seanmiddleditch/gha-setup-ninja@master
-
     - name: Build & Install
       run: |
         python3 -m pip install -U pip setuptools wheel pytest
@@ -61,22 +59,10 @@ jobs:
         cmake --build build --config Debug --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
 
-        llvm-objdump -p  "C:\Program Files (x86)\pyAMReX\bin\amrex.dll"
-
-    - name: Add debugger to the PATH
-      shell: bash
-      run: |
-        echo "C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64" >> $GITHUB_PATH
-
     - name: Add install .dll location to the PATH
       shell: bash
-      run: |
-        echo "C:\\Program Files (x86)\\pyAMReX\\bin" >> $GITHUB_PATH
+      run: echo "C:\\Program Files (x86)\\pyAMReX\\bin" >> $GITHUB_PATH
 
     - name: Unit tests
       run: |
-        (Get-Command ctest).Path
-        gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
-        cdb -c "g;q" ctest --test-dir build -C Debug --output-on-failure
-
-#        Get-Childitem -Path C:\Program Files (x86)\* -Recurse -Filter "*python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll"
+        ctest --test-dir build -C Debug --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,9 +51,6 @@ jobs:
 
         cmake --build build --config Debug -j 2
         if(!$?) { Exit $LASTEXITCODE }
-
-        llvm-objdump -p build\lib\site-packages\amrex\amrex_pybind.cp311-win_amd64.pyd
-
         cmake --build build --config Debug --target install
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build --config Debug --target pip_install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,12 +53,17 @@ jobs:
         cmake --build build --config Debug -j 2
         if(!$?) { Exit $LASTEXITCODE }
 
-        dumpbin /dependents build\lib\site-packages\amrex\amrex_pybind.cp311-win_amd64.pyd
+        llvm-objdump -p build\lib\site-packages\amrex\amrex_pybind.cp311-win_amd64.pyd
 
         cmake --build build --config Debug --target install
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build --config Debug --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
+
+        llvm-objdump -p  C:/Program Files (x86)/pyAMReX/bin/amrex.dll
+
+        Get-Childitem -Path C:\* -Recurse -Filter *python311.dll, *amrex.dll, *MSVCP140D.dll, KERNEL32.dll, VCRUNTIME140D.dll, VCRUNTIME140_1D.dll, ucrtbased.dll
+
     - name: Unit tests
       run: |
         set PATH="C:/Program Files (x86)/pyAMReX/bin/;%PATH%"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Unit tests
       run: |
         $env:Path += "C:\Program Files (x86)\pyAMReX\bin"
+        $env:Path += "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\"
         (Get-Command ctest).Path
         gflags /i C:\hostedtoolcache\windows\Python\3.11.1\x64\Scripts\ctest.exe +sls
         cdb -c "g;q" ctest --test-dir build -C Debug --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,12 +46,15 @@ jobs:
         cmake -S . -B build               `
               -T "ClangCl"                `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
+              -DBUILD_SHARED_LIBS=ON      `
               -DAMReX_MPI=OFF
         if(!$?) { Exit $LASTEXITCODE }
 
         cmake --build build --config Debug -j 2
         if(!$?) { Exit $LASTEXITCODE }
-        cmake --build build --config Debug --target pip_install -j 2
+        cmake --build build --config Debug --target install
+        if(!$?) { Exit $LASTEXITCODE }
+        cmake --build build --config Debug --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
     - name: Unit tests
       run: |

--- a/src/amrex/__init__.py
+++ b/src/amrex/__init__.py
@@ -1,3 +1,24 @@
+import os
+
+# Python 3.8+ on Windows: DLL search paths for dependent
+# shared libraries
+# Refs.:
+# - https://github.com/python/cpython/issues/80266
+# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
+if os.name == "nt":
+    # add anything in the current directory
+    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
+    os.add_dll_directory(pwd)
+    # add anything in PATH
+    paths = os.environ.get("PATH", "")
+    for p in paths.split(";"):
+        print(f"p={p}")
+        if os.path.exists(p):
+            os.add_dll_directory(p)
+        else:
+            print("  ... does NOT exist")
+
+# import core bindings to C++
 from . import amrex_pybind
 from .amrex_pybind import *  # noqa
 

--- a/src/amrex/__init__.py
+++ b/src/amrex/__init__.py
@@ -12,11 +12,8 @@ if os.name == "nt":
     # add anything in PATH
     paths = os.environ.get("PATH", "")
     for p in paths.split(";"):
-        print(f"p={p}")
         if os.path.exists(p):
             os.add_dll_directory(p)
-        else:
-            print("  ... does NOT exist")
 
 # import core bindings to C++
 from . import amrex_pybind


### PR DESCRIPTION
- [x] CI: Add a Linux and Windows build that each build a shared AMReX library.
- [x] fix issues: For Windows Python 3.8+, this shared `libamrex.dll` needs to be injected via `PATH` and `os.add_dll_directory`
  - https://github.com/python/cpython/issues/80266
  - https://docs.python.org/3.8/library/os.html#os.add_dll_directory