### PR TITLE
CI: GCC 10.1 on Ubuntu 22.04

### DIFF
--- a/.github/workflows/dependencies/dependencies_gcc10.sh
+++ b/.github/workflows/dependencies/dependencies_gcc10.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020 The AMReX Community
+# Copyright 2020-2022 The AMReX Community
 #
 # License: BSD-3-Clause-LBNL
 # Authors: Axel Huebl
 
 set -eu -o pipefail
 
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
 
   gcc10:
     name: GNU@10.1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     if: github.event.pull_request.draft == false
     steps:


### PR DESCRIPTION
The Ubuntu PPA `ppa:ubuntu-toolchain-r/test` keeps timing out, so we update the base image to avoid it.