### PR TITLE
Windows CTest: Set Paths on pytest

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         python3 -m pip install -U pip setuptools wheel pytest
         python3 -m pip install -U cmake
+        python3 -m pip install -r requirements.txt
 
         cmake -S . -B build               `
               -T "ClangCl"                `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   msvc:
-    name: MSVC w/o MPI (static)
+    name: MSVC w/o MPI static release
     runs-on: windows-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -28,7 +28,7 @@ jobs:
       run: python3 -m pytest tests
 
   clang:
-    name: Clang w/o MPI (shared)
+    name: Clang w/o MPI shared debug
     runs-on: windows-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -37,7 +37,7 @@ jobs:
       with:
         python-version: '3.x'
     - uses: seanmiddleditch/gha-setup-ninja@master
-    - name: Build & Install
+    - name: Build
       run: |
         python3 -m pip install -U pip setuptools wheel pytest
         python3 -m pip install -U cmake
@@ -51,15 +51,12 @@ jobs:
 
         cmake --build build --config Debug -j 2
         if(!$?) { Exit $LASTEXITCODE }
+    - name: Unit tests
+      run: |
+        ctest --test-dir build -C Debug --output-on-failure
+    - name: Install
+      run: |
         cmake --build build --config Debug --target install
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build --config Debug --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
-
-    - name: Add install .dll location to the PATH
-      shell: bash
-      run: echo "C:\\Program Files (x86)\\pyAMReX\\bin" >> $GITHUB_PATH
-
-    - name: Unit tests
-      run: |
-        ctest --test-dir build -C Debug --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,9 @@ if(pyAMReX_BUILD_TESTING)
         WORKING_DIRECTORY
             ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
     )
+
+    # set PYTHONPATH and PATH (for .dll files)
+    pyamrex_test_set_pythonpath(pytest.AMReX)
 endif()
 
 

--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -121,6 +121,32 @@ macro(pyamrex_set_default_install_dirs_python)
 endmacro()
 
 
+# function to set the PYTHONPATH and PATH (for .dll files) on a test
+# this avoids that we need to install our python packages to run ctest
+#
+function(pyamrex_test_set_pythonpath test_name)
+    if(WIN32)
+        string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
+        string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")  # DLLs
+        string(REGEX REPLACE "/" "\\\\" WIN_PYTHON_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
+        # shared library note:
+        #   For Windows Python 3.8+, this also needs to be injected via
+        #   os.add_dll_directory.
+        #   https://github.com/python/cpython/issues/80266
+        #   https://docs.python.org/3.8/library/os.html#os.add_dll_directory
+        set_property(TEST ${test_name}
+            APPEND PROPERTY ENVIRONMENT
+                "PYTHONPATH=${WIN_PYTHON_OUTPUT_DIRECTORY}\;${WIN_PYTHONPATH}"
+                "PATH=$<TARGET_FILE_DIR:pyAMReX>\;${WIN_PATH}"
+        )
+    else()
+        set_property(TEST ${test_name}
+            APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
+        )
+    endif()
+endfunction()
+
+
 # change the default CMAKE_BUILD_TYPE
 # the default in CMake is Debug for historic reasons
 #

--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -137,7 +137,7 @@ function(pyamrex_test_set_pythonpath test_name)
         set_property(TEST ${test_name}
             APPEND PROPERTY ENVIRONMENT
                 "PYTHONPATH=${WIN_PYTHON_OUTPUT_DIRECTORY}\;${WIN_PYTHONPATH}"
-                "PATH=$<TARGET_FILE_DIR:pyAMReX>\;${WIN_PATH}"
+                "PATH=$<TARGET_FILE_DIR:pyAMReX>\;$<TARGET_FILE_DIR:AMReX::amrex>\;${WIN_PATH}"
         )
     else()
         set_property(TEST ${test_name}


### PR DESCRIPTION
Make sure `ctest` finds dependent shared `.dll` files without further env hints or prior installation step.

Follow-up to #91