### PR TITLE
CMake: Multi-Config Paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ set_target_properties(pyAMReX PROPERTIES
     # fluffy front-end modules, so we can extend it with pure Python
     ARCHIVE_OUTPUT_NAME amrex_pybind
     LIBRARY_OUTPUT_NAME amrex_pybind
+    COMPILE_PDB_NAME amrex_pybind
     # build output directories - mainly set to run tests from CMake & IDEs
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
@@ -140,11 +141,12 @@ if(isMultiConfig)
         set_target_properties(pyAMReX PROPERTIES
             # build output directories - mainly set to run tests from CMake & IDEs
             # note: same as above, but for Multi-Config generators
-            ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
+            COMPILE_PDB_NAME_${CFG_UPPER} amrex_pybind
+            ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/${CFG}/amrex
+            LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/${CFG}/amrex
+            RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/${CFG}/amrex
+            PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/${CFG}/amrex
+            COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/${CFG}/amrex
         )
     endforeach()
 endif()

--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -125,10 +125,15 @@ endmacro()
 # this avoids that we need to install our python packages to run ctest
 #
 function(pyamrex_test_set_pythonpath test_name)
+    get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     if(WIN32)
         string(REPLACE ";" "\\;" WIN_PYTHONPATH "$ENV{PYTHONPATH}")
         string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")  # DLLs
-        string(REGEX REPLACE "/" "\\\\" WIN_PYTHON_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
+        if(isMultiConfig)
+            string(REGEX REPLACE "/" "\\\\" WIN_PYTHON_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/$<CONFIG>)
+        else()
+            string(REGEX REPLACE "/" "\\\\" WIN_PYTHON_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY})
+        endif()
         # shared library note:
         #   For Windows Python 3.8+, this also needs to be injected via
         #   os.add_dll_directory.
@@ -140,9 +145,15 @@ function(pyamrex_test_set_pythonpath test_name)
                 "PATH=$<TARGET_FILE_DIR:pyAMReX>\;$<TARGET_FILE_DIR:AMReX::amrex>\;${WIN_PATH}"
         )
     else()
-        set_property(TEST ${test_name}
-            APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
-        )
+        if(isMultiConfig)
+            set_property(TEST ${test_name}
+                APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}/$<CONFIG>:$ENV{PYTHONPATH}"
+            )
+        else()
+            set_property(TEST ${test_name}
+                APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
+            )
+        endif()
     endif()
 endfunction()
 


### PR DESCRIPTION
Ensure multi-config generators get their own, unique build paths.