### PR TITLE
Work-Around: pybind11 type aliases on Win

### DIFF
--- a/src/Particle/ArrayOfStructs.cpp
+++ b/src/Particle/ArrayOfStructs.cpp
@@ -132,6 +132,10 @@ void make_ArrayOfStructs(py::module &m)
     make_ArrayOfStructs<NReal, NInt, amrex::ManagedArenaAllocator> (m, "managed");
     make_ArrayOfStructs<NReal, NInt, amrex::AsyncArenaAllocator> (m, "async");
 #endif
+#ifdef _WIN32
+    // work-around for https://github.com/pybind/pybind11/pull/4319
+    make_ArrayOfStructs<NReal, NInt, amrex::DefaultAllocator> (m, "default");
+#endif
 }
 
 void init_ArrayOfStructs(py::module& m) {

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -8,6 +8,7 @@
 #include "Base/Iterator.H"
 
 #include <AMReX_BoxArray.H>
+#include <AMReX_GpuAllocators.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_ParIter.H>
 #include <AMReX_Particles.H>
@@ -35,11 +36,12 @@ void make_Base_Iterators (py::module &m, std::string allocstr)
     constexpr int NArrayReal = container::NArrayReal;
     constexpr int NArrayInt = container::NArrayInt;
 
-    std::string particle_it_base_name = std::string("ParIterBase_") +
-            std::to_string(NStructReal) + "_" + std::to_string(NStructInt) + "_" +
-            std::to_string(NArrayReal) + "_" + std::to_string(NArrayInt) + "_" +
-            allocstr;
-    if (is_const) particle_it_base_name = "Const" + particle_it_base_name;
+    std::string particle_it_base_name = std::string("Par");
+    if (is_const) particle_it_base_name += "Const";
+    particle_it_base_name += "IterBase_" +
+        std::to_string(NStructReal) + "_" + std::to_string(NStructInt) + "_" +
+        std::to_string(NArrayReal) + "_" + std::to_string(NArrayInt) + "_" +
+        allocstr;
     py::class_<iterator_base, MFIter>(m, particle_it_base_name.c_str())
         .def(py::init<container&, int>(),
             py::arg("particle_container"), py::arg("level"))
@@ -350,10 +352,12 @@ void make_ParticleContainer_and_Iterators (py::module &m)
     make_ParticleInitData<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt>(m);
 
     // see Src/Base/AMReX_GpuContainers.H
+    //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
+    //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
-                                         std::allocator>(m, "std");
+                                         std::allocator>(m, "std");            // CPU DefaultAllocator
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
-                                         amrex::ArenaAllocator>(m, "arena");
+                                         amrex::ArenaAllocator>(m, "arena");   // GPU DefaultAllocator
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::PinnedArenaAllocator>(m, "pinned");
 #ifdef AMREX_USE_GPU
@@ -363,5 +367,11 @@ void make_ParticleContainer_and_Iterators (py::module &m)
                                          amrex::ManagedArenaAllocator>(m, "managed");
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::AsyncArenaAllocator>(m, "async");
+#endif
+
+#ifdef _WIN32
+    // work-around for https://github.com/pybind/pybind11/pull/4319
+    make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
+                                         amrex::DefaultAllocator>(m, "default");
 #endif
 }

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -354,10 +354,24 @@ void make_ParticleContainer_and_Iterators (py::module &m)
     // see Src/Base/AMReX_GpuContainers.H
     //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
     //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
+
+    //   work-around for https://github.com/pybind/pybind11/pull/4581
+    //make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
+    //                                     std::allocator>(m, "std");            // CPU DefaultAllocator
+    //make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
+    //                                     amrex::ArenaAllocator>(m, "arena");   // GPU DefaultAllocator
+#ifdef AMREX_USE_GPU
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
-                                         std::allocator>(m, "std");            // CPU DefaultAllocator
+                                         std::allocator>(m, "std");
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
-                                         amrex::ArenaAllocator>(m, "arena");   // GPU DefaultAllocator
+                                         amrex::DefaultAllocator>(m, "default");   // amrex::ArenaAllocator
+#else
+    make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
+                                         amrex::DefaultAllocator>(m, "default");   // std::allocator
+    make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
+                                         amrex::ArenaAllocator>(m, "arena");
+#endif
+    //   end work-around
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::PinnedArenaAllocator>(m, "pinned");
 #ifdef AMREX_USE_GPU
@@ -367,11 +381,5 @@ void make_ParticleContainer_and_Iterators (py::module &m)
                                          amrex::ManagedArenaAllocator>(m, "managed");
     make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
                                          amrex::AsyncArenaAllocator>(m, "async");
-#endif
-
-#ifdef _WIN32
-    // work-around for https://github.com/pybind/pybind11/pull/4319
-    make_ParticleContainer_and_Iterators<T_NStructReal, T_NStructInt, T_NArrayReal, T_NArrayInt,
-                                         amrex::DefaultAllocator>(m, "default");
 #endif
 }

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -126,6 +126,11 @@ void make_ParticleTile(py::module &m)
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::AsyncArenaAllocator>(m, "async");
 #endif
+#ifdef _WIN32
+    // work-around for https://github.com/pybind/pybind11/pull/4319
+    make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
+                      amrex::DefaultAllocator>(m, "default");
+#endif
 }
 
 void init_ParticleTile(py::module& m) {

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -5,6 +5,7 @@
  */
 #include <AMReX_Config.H>
 #include <AMReX_BoxArray.H>
+#include <AMReX_GpuAllocators.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_ParticleTile.H>
 
@@ -112,10 +113,26 @@ void make_ParticleTile(py::module &m)
     make_ParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>(m);
 
     // see Src/Base/AMReX_GpuContainers.H
+    //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
+    //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
+
+    //   work-around for https://github.com/pybind/pybind11/pull/4581
+    //make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
+    //                  std::allocator>(m, "std");
+    //make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
+    //                  amrex::ArenaAllocator>(m, "arena");
+#ifdef AMREX_USE_GPU
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       std::allocator>(m, "std");
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
+                      amrex::DefaultAllocator>(m, "default");  // amrex::ArenaAllocator
+#else
+    make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
+                      amrex::DefaultAllocator>(m, "default");  // std::allocator
+    make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::ArenaAllocator>(m, "arena");
+#endif
+    //   end work-around
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::PinnedArenaAllocator>(m, "pinned");
 #ifdef AMREX_USE_GPU
@@ -125,11 +142,6 @@ void make_ParticleTile(py::module &m)
                       amrex::ManagedArenaAllocator>(m, "managed");
     make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
                       amrex::AsyncArenaAllocator>(m, "async");
-#endif
-#ifdef _WIN32
-    // work-around for https://github.com/pybind/pybind11/pull/4319
-    make_ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt,
-                      amrex::DefaultAllocator>(m, "default");
 #endif
 }
 

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -54,6 +54,10 @@ void make_StructOfArrays(py::module &m)
     make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator>(m, "managed");
     make_StructOfArrays<NReal, NInt, amrex::AsyncArenaAllocator>(m, "async");
 #endif
+#ifdef _WIN32
+    // work-around for https://github.com/pybind/pybind11/pull/4319
+    make_StructOfArrays<NReal, NInt, amrex::DefaultAllocator>(m, "default");
+#endif
 }
 
 void init_StructOfArrays(py::module& m) {

--- a/tests/test_aos.py
+++ b/tests/test_aos.py
@@ -7,7 +7,7 @@ import amrex
 
 
 def test_aos_init():
-    aos = amrex.ArrayOfStructs_2_1_std()
+    aos = amrex.ArrayOfStructs_2_1_default()
 
     assert aos.numParticles() == 0
     assert aos.numTotalParticles() == aos.numRealParticles() == 0
@@ -15,7 +15,7 @@ def test_aos_init():
 
 
 def test_aos_push_pop():
-    aos = amrex.ArrayOfStructs_2_1_std()
+    aos = amrex.ArrayOfStructs_2_1_default()
     p1 = amrex.Particle_2_1()
     p1.set_rdata([1.5, 2.2])
     p1.set_idata([3])
@@ -50,7 +50,7 @@ def test_aos_push_pop():
 
 
 def test_array_interface():
-    aos = amrex.ArrayOfStructs_2_1_std()
+    aos = amrex.ArrayOfStructs_2_1_default()
     p1 = amrex.Particle_2_1()
     p1.setPos([1, 2, 3])
     p1.set_rdata([4.5, 5.2])

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -13,7 +13,7 @@ def Npart():
 
 @pytest.fixture(scope="function")
 def empty_particle_container(std_geometry, distmap, boxarr):
-    pc = amrex.ParticleContainer_1_1_2_1_std(std_geometry, distmap, boxarr)
+    pc = amrex.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
     return pc
 
 
@@ -29,7 +29,7 @@ def std_particle():
 
 @pytest.fixture(scope="function")
 def particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
-    pc = amrex.ParticleContainer_1_1_2_1_std(std_geometry, distmap, boxarr)
+    pc = amrex.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
     myt = amrex.ParticleInitType_1_1_2_1()
     myt.real_struct_data = [0.5]
     myt.int_struct_data = [5]
@@ -62,17 +62,17 @@ def test_particleInitType():
 def test_n_particles(particle_container, Npart):
     pc = particle_container
     assert pc.OK()
-    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_std.NStructReal == 1
-    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_std.NStructInt == 1
-    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_std.NArrayReal == 2
-    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_std.NArrayInt == 1
+    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_default.NStructReal == 1
+    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_default.NStructInt == 1
+    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_default.NArrayReal == 2
+    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_default.NArrayInt == 1
     assert (
         pc.NumberOfParticlesAtLevel(0) == np.sum(pc.NumberOfParticlesInGrid(0)) == Npart
     )
 
 
 def test_pc_init():
-    pc = amrex.ParticleContainer_1_1_2_1_std()
+    pc = amrex.ParticleContainer_1_1_2_1_default()
 
     print("bytespread", pc.ByteSpread())
     print("capacity", pc.PrintCapacity())
@@ -93,10 +93,10 @@ def test_pc_init():
     print("define particle container")
     pc.Define(gm, dm, ba)
     assert pc.OK()
-    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_std.NStructReal == 1
-    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_std.NStructInt == 1
-    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_std.NArrayReal == 2
-    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_std.NArrayInt == 1
+    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_default.NStructReal == 1
+    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_default.NStructInt == 1
+    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_default.NArrayReal == 2
+    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_default.NArrayInt == 1
 
     print("bytespread", pc.ByteSpread())
     print("capacity", pc.PrintCapacity())
@@ -123,7 +123,7 @@ def test_pc_init():
 
     print("Iterate particle boxes & set values")
     lvl = 0
-    for pti in amrex.ParIter_1_1_2_1_std(pc, level=lvl):
+    for pti in amrex.ParIter_1_1_2_1_default(pc, level=lvl):
         print("...")
         assert pti.num_particles == 1
         assert pti.num_real_particles == 1
@@ -151,7 +151,7 @@ def test_pc_init():
         assert np.allclose(int_arrays[0], np.array([2]))
 
     # read-only
-    for pti in amrex.ParConstIter_1_1_2_1_std(pc, level=lvl):
+    for pti in amrex.ParConstIter_1_1_2_1_default(pc, level=lvl):
         assert pti.num_particles == 1
         assert pti.num_real_particles == 1
         assert pti.num_neighbor_particles == 0

--- a/tests/test_particleTile.py
+++ b/tests/test_particleTile.py
@@ -15,7 +15,7 @@ def test_ptile_data():
 
 
 def test_ptile_funs():
-    pt = amrex.ParticleTile_1_1_2_1_std()
+    pt = amrex.ParticleTile_1_1_2_1_default()
 
     assert pt.empty() and pt.size() == 0
     assert pt.numParticles() == pt.numRealParticles() == pt.numNeighborParticles() == 0
@@ -35,7 +35,7 @@ def test_ptile_funs():
 
 ################
 def test_ptile_pushback_ptiledata():
-    pt = amrex.ParticleTile_1_1_2_1_std()
+    pt = amrex.ParticleTile_1_1_2_1_default()
     p = amrex.Particle_1_1(1.0, 2.0, 3, 4.0, 5)
     sp = amrex.Particle_3_2(5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11, 12)
     pt.push_back(p)
@@ -62,7 +62,7 @@ def test_ptile_pushback_ptiledata():
 
 @pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_access():
-    pt = amrex.ParticleTile_1_1_2_1_std()
+    pt = amrex.ParticleTile_1_1_2_1_default()
     sp1 = amrex.Particle_3_2()
     pt.push_back(sp1)
     pt.push_back(sp1)
@@ -81,7 +81,7 @@ def test_ptile_access():
 
 
 def test_ptile_soa():
-    pt = amrex.ParticleTile_1_1_2_1_std()
+    pt = amrex.ParticleTile_1_1_2_1_default()
 
     pt.push_back_real(1, 2.1)
     pt.push_back_real([1.1, 1.3])
@@ -120,7 +120,7 @@ def test_ptile_soa():
 
 @pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_aos():
-    pt = amrex.ParticleTile_1_1_2_1_std()
+    pt = amrex.ParticleTile_1_1_2_1_default()
     p1 = amrex.Particle_1_1()
     p2 = amrex.Particle_1_1()
     p1.x = 3.0

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -7,7 +7,7 @@ import amrex
 
 
 def test_soa_init():
-    soa = amrex.StructOfArrays_2_1_std()
+    soa = amrex.StructOfArrays_2_1_default()
     print("--test init --")
     print("num real components", soa.NumRealComps())
     print("num int components", soa.NumIntComps())
@@ -51,7 +51,7 @@ def test_soa_init():
 
 
 def test_soa_from_tile():
-    pt = amrex.ParticleTile_1_1_2_1_std()
+    pt = amrex.ParticleTile_1_1_2_1_default()
     p = amrex.Particle_1_1(1.0, 2.0, 3, rdata_0=4.0, idata_1=5)
     sp = amrex.Particle_3_2(
         5.0, 6.0, 7.0, rdata_0=8.0, rdata_1=9.0, rdata_2=10.0, idata_0=11, idata_1=12


### PR DESCRIPTION
`amrex::DefaultAllocator` is not properly resolved as the same type on Windows in pybind11.

X-ref:
- #108
- https://github.com/ECP-WarpX/impactx/pull/315
- https://github.com/pybind/pybind11/pull/4319
- https://github.com/pybind/pybind11/pull/4581