### PR TITLE
CI: Clang-14 w/ libc++

### DIFF
--- a/.github/workflows/dependencies/dependencies_clang14_libcpp.sh
+++ b/.github/workflows/dependencies/dependencies_clang14_libcpp.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+sudo apt-get update
+
+sudo apt-get install -y  \
+    build-essential      \
+    clang                \
+    lld                  \
+    libopenmpi-dev       \
+    openmpi-bin

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -78,6 +78,28 @@ jobs:
       run: |
         python3 -m pytest tests/
 
+  clang14:
+    name: Clang@14.0 w/ libc++ w/ MPI
+    runs-on: ubuntu-22.04
+    env:
+      CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -fno-operator-names -Wno-pass-failed -stdlib=libc++"
+      LDFLAGS: "-fuse-ld=lld"
+      CXX: "clang++"
+      CC: "clang"
+    if: github.event.pull_request.draft == false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_clang14_libcpp.sh
+    - name: Build & Install
+      run: |
+        python3 -m pip install -U pip pytest
+        python3 -m pip install -v .
+        python3 -c "import amrex; print(amrex.__version__)"
+    - name: Unit tests
+      run: |
+        python3 -m pytest tests/
+
   nvcc11:
     name: CUDA@11.2 GNU@9.3.0
     runs-on: ubuntu-20.04

--- a/requirements_mpi.txt
+++ b/requirements_mpi.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+mpi4py>=2.1.0


### PR DESCRIPTION
Add a new CI test with a different C++ standard library (LLVM).

For fun, also use a different linker (`lld` from LLVM).