### PR TITLE
ParticleContainer: add finest_level attribute

### DIFF
--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -160,7 +160,7 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         .def_property_readonly_static("NArrayReal", [](const py::object&){return ParticleContainerType::NArrayReal; })
         .def_property_readonly_static("NArrayInt", [](const py::object&){return ParticleContainerType::NArrayInt; })
 
-        .def_property_readonly("finestLevel", &ParticleContainerBase::finestLevel)
+        .def_property_readonly("finest_level", &ParticleContainerBase::finestLevel)
 
         // ParticleContainer ( const ParticleContainer &) = delete;
         // ParticleContainer& operator= ( const ParticleContainer & ) = delete;

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -12,6 +12,7 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_ParIter.H>
 #include <AMReX_Particles.H>
+#include <AMReX_ParticleContainerBase.H>
 #include <AMReX_ParticleContainer.H>
 #include <AMReX_ParticleTile.H>
 #include <AMReX_ArrayOfStructs.H>
@@ -159,6 +160,7 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         .def_property_readonly_static("NArrayReal", [](const py::object&){return ParticleContainerType::NArrayReal; })
         .def_property_readonly_static("NArrayInt", [](const py::object&){return ParticleContainerType::NArrayInt; })
 
+        .def_property_readonly("finestLevel", &ParticleContainerBase::finestLevel)
 
         // ParticleContainer ( const ParticleContainer &) = delete;
         // ParticleContainer& operator= ( const ParticleContainer & ) = delete;

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -173,6 +173,7 @@ def test_pc_init():
             real_arrays = soa.GetRealData()
             int_arrays = soa.GetIntData()
             print(real_arrays[0])
+            print(int_arrays[0])
             # TODO: this does not work yet and is still the original data
             # assert np.allclose(real_arrays[0], np.array([0.55]))
             # assert np.allclose(real_arrays[1], np.array([0.22]))

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -121,11 +121,11 @@ def test_pc_init():
     assert pc.TotalNumberOfParticles() == pc.NumberOfParticlesAtLevel(0) == npart
     assert pc.OK()
 
-    print(f"Finest level = ", pc.finestLevel)
+    print(f"Finest level = ", pc.finest_level)
 
     print("Iterate particle boxes & set values")
     # lvl = 0
-    for lvl in range(pc.finestLevel+1):
+    for lvl in range(pc.finest_level+1):
         print(f'at level {lvl}:')
         for pti in amrex.ParIter_1_1_2_1_default(pc, level=lvl):
             print("...")
@@ -155,7 +155,7 @@ def test_pc_init():
             assert np.allclose(int_arrays[0], np.array([2]))
 
     # read-only
-    for lvl in range(pc.finestLevel+1):
+    for lvl in range(pc.finest_level+1):
         for pti in amrex.ParConstIter_1_1_2_1_default(pc, level=lvl):
             assert pti.num_particles == 1
             assert pti.num_real_particles == 1

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -125,8 +125,8 @@ def test_pc_init():
 
     print("Iterate particle boxes & set values")
     # lvl = 0
-    for lvl in range(pc.finest_level+1):
-        print(f'at level {lvl}:')
+    for lvl in range(pc.finest_level + 1):
+        print(f"at level {lvl}:")
         for pti in amrex.ParIter_1_1_2_1_default(pc, level=lvl):
             print("...")
             assert pti.num_particles == 1
@@ -155,7 +155,7 @@ def test_pc_init():
             assert np.allclose(int_arrays[0], np.array([2]))
 
     # read-only
-    for lvl in range(pc.finest_level+1):
+    for lvl in range(pc.finest_level + 1):
         for pti in amrex.ParConstIter_1_1_2_1_default(pc, level=lvl):
             assert pti.num_particles == 1
             assert pti.num_real_particles == 1

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -121,57 +121,62 @@ def test_pc_init():
     assert pc.TotalNumberOfParticles() == pc.NumberOfParticlesAtLevel(0) == npart
     assert pc.OK()
 
+    print(f"Finest level = ", pc.finestLevel)
+
     print("Iterate particle boxes & set values")
-    lvl = 0
-    for pti in amrex.ParIter_1_1_2_1_default(pc, level=lvl):
-        print("...")
-        assert pti.num_particles == 1
-        assert pti.num_real_particles == 1
-        assert pti.num_neighbor_particles == 0
-        assert pti.level == lvl
-        print(pti.pair_index)
-        print(pti.geom(level=lvl))
+    # lvl = 0
+    for lvl in range(pc.finestLevel+1):
+        print(f'at level {lvl}:')
+        for pti in amrex.ParIter_1_1_2_1_default(pc, level=lvl):
+            print("...")
+            assert pti.num_particles == 1
+            assert pti.num_real_particles == 1
+            assert pti.num_neighbor_particles == 0
+            assert pti.level == lvl
+            print(pti.pair_index)
+            print(pti.geom(level=lvl))
 
-        aos = pti.aos()
-        aos_arr = np.array(aos, copy=False)
-        aos_arr[0]["x"] = 0.30
-        aos_arr[0]["y"] = 0.35
-        aos_arr[0]["z"] = 0.40
+            aos = pti.aos()
+            aos_arr = np.array(aos, copy=False)
+            aos_arr[0]["x"] = 0.30
+            aos_arr[0]["y"] = 0.35
+            aos_arr[0]["z"] = 0.40
 
-        # TODO: this seems to write into a copy of the data
-        soa = pti.soa()
-        real_arrays = soa.GetRealData()
-        int_arrays = soa.GetIntData()
-        real_arrays[0] = [0.55]
-        real_arrays[1] = [0.22]
-        int_arrays[0] = [2]
+            # TODO: this seems to write into a copy of the data
+            soa = pti.soa()
+            real_arrays = soa.GetRealData()
+            int_arrays = soa.GetIntData()
+            real_arrays[0] = [0.55]
+            real_arrays[1] = [0.22]
+            int_arrays[0] = [2]
 
-        assert np.allclose(real_arrays[0], np.array([0.55]))
-        assert np.allclose(real_arrays[1], np.array([0.22]))
-        assert np.allclose(int_arrays[0], np.array([2]))
+            assert np.allclose(real_arrays[0], np.array([0.55]))
+            assert np.allclose(real_arrays[1], np.array([0.22]))
+            assert np.allclose(int_arrays[0], np.array([2]))
 
     # read-only
-    for pti in amrex.ParConstIter_1_1_2_1_default(pc, level=lvl):
-        assert pti.num_particles == 1
-        assert pti.num_real_particles == 1
-        assert pti.num_neighbor_particles == 0
-        assert pti.level == lvl
+    for lvl in range(pc.finestLevel+1):
+        for pti in amrex.ParConstIter_1_1_2_1_default(pc, level=lvl):
+            assert pti.num_particles == 1
+            assert pti.num_real_particles == 1
+            assert pti.num_neighbor_particles == 0
+            assert pti.level == lvl
 
-        aos = pti.aos()
-        aos_arr = np.array(aos, copy=False)
-        assert aos[0].x == 0.30
-        assert aos[0].y == 0.35
-        assert aos[0].z == 0.40
-        assert aos_arr[0]["z"] == 0.40
+            aos = pti.aos()
+            aos_arr = np.array(aos, copy=False)
+            assert aos[0].x == 0.30
+            assert aos[0].y == 0.35
+            assert aos[0].z == 0.40
+            assert aos_arr[0]["z"] == 0.40
 
-        soa = pti.soa()
-        real_arrays = soa.GetRealData()
-        int_arrays = soa.GetIntData()
-        print(real_arrays[0])
-        # TODO: this does not work yet and is still the original data
-        # assert np.allclose(real_arrays[0], np.array([0.55]))
-        # assert np.allclose(real_arrays[1], np.array([0.22]))
-        # assert np.allclose(int_arrays[0], np.array([2]))
+            soa = pti.soa()
+            real_arrays = soa.GetRealData()
+            int_arrays = soa.GetIntData()
+            print(real_arrays[0])
+            # TODO: this does not work yet and is still the original data
+            # assert np.allclose(real_arrays[0], np.array([0.55]))
+            # assert np.allclose(real_arrays[1], np.array([0.22]))
+            # assert np.allclose(int_arrays[0], np.array([2]))
 
 
 def test_particle_init(Npart, particle_container):


### PR DESCRIPTION
This PR exposes the c++ ``finestLevel`` function as a python read-only attribute, ``finest_level``