### PR TITLE
Multi-Dim Support

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Configure (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
-          $CMAKE -S . -B build
+          $CMAKE -S . -B build -DAMReX_SPACEDIM="1;2;3"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -37,8 +37,9 @@ jobs:
         #   https://github.com/open-mpi/ompi/issues/9317
         export LDFLAGS="-lopen-pal"
 
-        cmake -S . -B build                                \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_GPU_BACKEND=HIP                        \
-            -DAMReX_AMD_ARCH=gfx900
+        cmake -S . -B build              \
+            -DCMAKE_VERBOSE_MAKEFILE=ON  \
+            -DAMReX_GPU_BACKEND=HIP      \
+            -DAMReX_AMD_ARCH=gfx900      \
+            -DAMReX_SPACEDIM="1;2;3"
         cmake --build build --target pip_install -j 2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,9 @@ jobs:
         python3 -m pip install -U pip setuptools wheel pytest
         python3 -m pip install -U cmake
         python3 -m pip install -v .
-        python3 -c "import amrex; print(amrex.__version__)"
+        python3 -c "import amrex.space1d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space2d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space3d as amr; print(amr.__version__)"
     - name: Unit tests
       run: |
         python3 -m pytest tests/

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,7 +28,9 @@ jobs:
       run: |
         python3 -m pip install -U pip setuptools wheel pytest
         AMREX_MPI=ON python3 -m pip install -v .
-        python3 -c "import amrex; print(amrex.__version__)"
+        python3 -c "import amrex.space1d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space2d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space3d as amr; print(amr.__version__)"
     - name: Unit tests
       run: |
         mpiexec -np 1 python3 -m pytest tests/
@@ -54,7 +56,8 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug    \
               -DCMAKE_VERBOSE_MAKEFILE=ON \
               -DBUILD_SHARED_LIBS=ON      \
-              -DAMReX_MPI=ON
+              -DAMReX_MPI=ON              \
+              -DAMReX_SPACEDIM="1;2;3"
         cmake --build build --target pip_install -j 2
 
     - name: Unit tests
@@ -76,7 +79,9 @@ jobs:
         export CXX=$(which clang++-6.0)
         python3 -m pip install -U pip pytest
         python3 -m pip install -v .
-        python3 -c "import amrex; print(amrex.__version__)"
+        python3 -c "import amrex.space1d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space2d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space3d as amr; print(amr.__version__)"
     - name: Unit tests
       run: |
         python3 -m pytest tests/
@@ -98,7 +103,9 @@ jobs:
       run: |
         python3 -m pip install -U pip pytest
         python3 -m pip install -v .
-        python3 -c "import amrex; print(amrex.__version__)"
+        python3 -c "import amrex.space1d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space2d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space3d as amr; print(amr.__version__)"
     - name: Unit tests
       run: |
         python3 -m pytest tests/
@@ -128,6 +135,7 @@ jobs:
         cmake -S . -B build             \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_GPU_BACKEND=CUDA    \
+            -DAMReX_SPACEDIM="1;2;3"    \
             -DCMAKE_CUDA_STANDARD=17    \
             -DCMAKE_CXX_STANDARD=17     \
             -DAMReX_CUDA_ARCH=8.0       \
@@ -156,6 +164,7 @@ jobs:
 #            -DCMAKE_CXX_COMPILER_VERSION=12.0              \
 #            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
 #            -DAMReX_GPU_BACKEND=SYCL                       \
+#            -DAMReX_SPACEDIM="1;2;3"                       \
 #            -DCMAKE_C_COMPILER=$(which clang)              \
 #            -DCMAKE_CXX_COMPILER=$(which dpcpp)
 #        cmake --build build -j 2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,9 @@ jobs:
         python3 -m pip install -v .
         if(!$?) { Exit $LASTEXITCODE }
 
-        python3 -c "import amrex; print(amrex.__version__)"
+        python3 -c "import amrex.space1d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space2d as amr; print(amr.__version__)"
+        python3 -c "import amrex.space3d as amr; print(amr.__version__)"
     - name: Unit tests
       shell: cmd
       run: python3 -m pytest tests
@@ -47,7 +49,8 @@ jobs:
               -T "ClangCl"                `
               -DCMAKE_VERBOSE_MAKEFILE=ON `
               -DBUILD_SHARED_LIBS=ON      `
-              -DAMReX_MPI=OFF
+              -DAMReX_MPI=OFF             `
+              -DAMReX_SPACEDIM="1;2;3"
         if(!$?) { Exit $LASTEXITCODE }
 
         cmake --build build --config Debug -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,12 @@ set_testing_option(pyAMReX_BUILD_TESTING)  # default: ON (BUILD_TESTING)
 # AMReX
 #   builds AMReX from source (default) or finds an existing install
 include(${pyAMReX_SOURCE_DIR}/cmake/dependencies/AMReX.cmake)
+include(AMReXBuildInfo)  # <AMReX_buildInfo.H>
+
+# for some targets need to be triggered once, so any dim dependency will do
+list(LENGTH AMReX_SPACEDIM list_len)
+math(EXPR list_last "${list_len} - 1")
+list(GET AMReX_SPACEDIM ${list_last} AMReX_SPACEDIM_LAST)
 
 # Python
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
@@ -84,96 +90,98 @@ include(${pyAMReX_SOURCE_DIR}/cmake/dependencies/pybind11.cmake)
 
 # Targets #####################################################################
 #
-# collect all objects for compilation
-add_library(pyAMReX MODULE src/pyAMReX.cpp)
-add_library(pyAMReX::pyAMReX ALIAS pyAMReX)
+foreach(D IN LISTS AMReX_SPACEDIM)
+    # collect all objects for compilation
+    add_library(pyAMReX_${D}d MODULE src/pyAMReX.cpp)
+    add_library(pyAMReX::pyAMReX_${D}d ALIAS pyAMReX_${D}d)
 
-# own headers
-target_include_directories(pyAMReX PUBLIC
-    $<BUILD_INTERFACE:${pyAMReX_SOURCE_DIR}/src>
-)
+    # own headers
+    target_include_directories(pyAMReX_${D}d PUBLIC
+        $<BUILD_INTERFACE:${pyAMReX_SOURCE_DIR}/src>
+    )
 
-# if we include <AMReX_buildInfo.H> we will need to call:
-include(AMReXBuildInfo)
-generate_buildinfo(pyAMReX "${pyAMReX_SOURCE_DIR}")
-target_link_libraries(pyAMReX PRIVATE buildInfo::pyAMReX)
+    # if we include <AMReX_buildInfo.H> we will need to call:
+    generate_buildinfo(pyAMReX_${D}d "${pyAMReX_SOURCE_DIR}")
+    target_link_libraries(pyAMReX_${D}d PRIVATE buildInfo::pyAMReX_${D}d)
+endforeach()
 
 # add sources
 add_subdirectory(src)
 
-# C++ properties: at least a C++17 capable compiler is needed
-target_compile_features(pyAMReX PUBLIC cxx_std_17)
-set_target_properties(pyAMReX PROPERTIES
-    CXX_EXTENSIONS OFF
-    CXX_STANDARD_REQUIRED ON
-)
-
-# link dependencies
-target_link_libraries(pyAMReX PUBLIC AMReX::amrex)
-target_link_libraries(pyAMReX PRIVATE pybind11::module pybind11::lto pybind11::windows_extras)
-
-# binary name: we will encoded 1D, 2D and 3D in here so we can provide a
-# wrapper library that pre-compiled all three geometry variants of AMReX
-#set_pyAMReX_binary_name()
-
-# set Python module properties
-set_target_properties(pyAMReX PROPERTIES
-    # hide symbols for combining multiple pybind11 modules downstream & for
-    # reduced binary size
-    CXX_VISIBILITY_PRESET "hidden"
-    CUDA_VISIBILITY_PRESET "hidden"
-    # name of the pybind-generated python module, which is wrapped in another
-    # fluffy front-end modules, so we can extend it with pure Python
-    ARCHIVE_OUTPUT_NAME amrex_pybind
-    LIBRARY_OUTPUT_NAME amrex_pybind
-    # build output directories - mainly set to run tests from CMake & IDEs
-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-    PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-    COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-)
-get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if(isMultiConfig)
-    foreach(CFG IN LISTS CMAKE_CONFIGURATION_TYPES)
-        string(TOUPPER "${CFG}" CFG_UPPER)
-        set_target_properties(pyAMReX PROPERTIES
-            # build output directories - mainly set to run tests from CMake & IDEs
-            # note: same as above, but for Multi-Config generators
-            ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-            COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex
-        )
-    endforeach()
-endif()
-if(EMSCRIPTEN)
-    set_target_properties(pyAMReX PROPERTIES
-        PREFIX "")
-else()
-    pybind11_extension(pyAMReX)
-endif()
-if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
-    pybind11_strip(pyAMReX)
-endif()
-
-# AMReX helper function: propagate CUDA specific target & source properties
-if(AMReX_GPU_BACKEND STREQUAL CUDA)
-    setup_target_for_cuda_compilation(pyAMReX)
-    target_compile_features(pyAMReX PUBLIC cuda_std_17)
-    set_target_properties(pyAMReX PROPERTIES
-        CUDA_EXTENSIONS OFF
-        CUDA_STANDARD_REQUIRED ON
+# set source language, properties, etc.
+foreach(D IN LISTS AMReX_SPACEDIM)
+    # C++ properties: at least a C++17 capable compiler is needed
+    target_compile_features(pyAMReX_${D}d PUBLIC cxx_std_17)
+    set_target_properties(pyAMReX_${D}d PROPERTIES
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
     )
-endif()
+
+    # link dependencies
+    target_link_libraries(pyAMReX_${D}d PUBLIC AMReX::amrex_${D}d)
+    target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::module pybind11::lto pybind11::windows_extras)
+
+    # set Python module properties
+    set_target_properties(pyAMReX_${D}d PROPERTIES
+        # hide symbols for combining multiple pybind11 modules downstream & for
+        # reduced binary size
+        CXX_VISIBILITY_PRESET "hidden"
+        CUDA_VISIBILITY_PRESET "hidden"
+        # name of the pybind-generated python module, which is wrapped in another
+        # fluffy front-end modules, so we can extend it with pure Python
+        ARCHIVE_OUTPUT_NAME amrex_${D}d_pybind
+        LIBRARY_OUTPUT_NAME amrex_${D}d_pybind
+        # build output directories - mainly set to run tests from CMake & IDEs
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+        PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+        COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+    )
+    get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(isMultiConfig)
+        foreach(CFG IN LISTS CMAKE_CONFIGURATION_TYPES)
+            string(TOUPPER "${CFG}" CFG_UPPER)
+            set_target_properties(pyAMReX_${D}d PROPERTIES
+                # build output directories - mainly set to run tests from CMake & IDEs
+                # note: same as above, but for Multi-Config generators
+                ARCHIVE_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+                LIBRARY_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+                RUNTIME_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+                PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+                COMPILE_PDB_OUTPUT_DIRECTORY_${CFG_UPPER} ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/space${D}d
+            )
+        endforeach()
+    endif()
+    if(EMSCRIPTEN)
+        set_target_properties(pyAMReX_${D}d PROPERTIES
+            PREFIX "")
+    else()
+        pybind11_extension(pyAMReX_${D}d)
+    endif()
+    if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+        pybind11_strip(pyAMReX_${D}d)
+    endif()
+
+    # AMReX helper function: propagate CUDA specific target & source properties
+    if(AMReX_GPU_BACKEND STREQUAL CUDA)
+        setup_target_for_cuda_compilation(pyAMReX_${D}d)
+        target_compile_features(pyAMReX_${D}d PUBLIC cuda_std_17)
+        set_target_properties(pyAMReX_${D}d PROPERTIES
+            CUDA_EXTENSIONS OFF
+            CUDA_STANDARD_REQUIRED ON
+        )
+    endif()
+endforeach()
 
 
 # Defines #####################################################################
 #
 # for module __version__
-target_compile_definitions(pyAMReX PRIVATE
-    PYAMReX_VERSION_INFO=${pyAMReX_VERSION_INFO})
+foreach(D IN LISTS AMReX_SPACEDIM)
+    target_compile_definitions(pyAMReX_${D}d PRIVATE
+        PYAMReX_VERSION_INFO=${pyAMReX_VERSION_INFO})
+endforeach()
 
 
 # Warnings ####################################################################
@@ -197,7 +205,9 @@ set_cxx_warnings()
 #
 
 # headers, libraries and executables
-set(pyAMReX_INSTALL_TARGET_NAMES pyAMReX)
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(pyAMReX_INSTALL_TARGET_NAMES ${pyAMReX_INSTALL_TARGET_NAMES} pyAMReX_${D}d)
+endforeach()
 
 install(TARGETS ${pyAMReX_INSTALL_TARGET_NAMES}
     EXPORT pyAMReXTargets
@@ -207,7 +217,7 @@ install(TARGETS ${pyAMReX_INSTALL_TARGET_NAMES}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-# CMake package file for find_package(pyAMReX::pyAMReX) in depending projects
+# CMake package file for find_package(pyAMReX) in depending projects
 #install(EXPORT pyAMReXTargets
 #    FILE pyAMReXTargets.cmake
 #    NAMESPACE pyAMReX::
@@ -239,12 +249,12 @@ set(pyAMReX_CUSTOM_TARGET_PREFIX "${_pyAMReX_CUSTOM_TARGET_PREFIX_DEFAULT}"
 add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel
     ${CMAKE_COMMAND} -E rm -f -r amrex-whl
     COMMAND
-        ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=$<TARGET_FILE_DIR:pyAMReX>
+        ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=$<TARGET_FILE_DIR:pyAMReX_${AMReX_SPACEDIM_LAST}d>
             ${Python_EXECUTABLE} -m pip wheel -v --no-build-isolation --no-deps --wheel-dir=amrex-whl ${pyAMReX_SOURCE_DIR}
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS
-        pyAMReX
+        ${pyAMReX_INSTALL_TARGET_NAMES}
 )
 
 # this will also upgrade/downgrade dependencies, e.g., when the version of numpy changes
@@ -263,7 +273,9 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS
-        pyAMReX ${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel ${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install_requirements
+        ${pyAMReX_INSTALL_TARGET_NAMES}
+        ${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel
+        ${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install_requirements
 )
 
 
@@ -271,10 +283,10 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install
 #
 if(pyAMReX_BUILD_TESTING)
     # copy Python wrapper library to build directory
-    add_custom_command(TARGET pyAMReX POST_BUILD
+    add_custom_command(TARGET pyAMReX_${AMReX_SPACEDIM_LAST}d POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${pyAMReX_SOURCE_DIR}/src/amrex
-            $<TARGET_FILE_DIR:pyAMReX>
+            $<TARGET_FILE_DIR:pyAMReX_${AMReX_SPACEDIM_LAST}d>/..
     )
 
     add_test(NAME pytest.AMReX

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md LICENSE
 include pyproject.toml
-include requirements.txt
+include requirements.txt requirements_mpi.txt
 global-include CMakeLists.txt *.cmake *.in
 recursive-include cmake *
 recursive-include src *

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ We will add further information here once first development versions are ready f
 *to do*
 
 ```python
-import amrex
+import amrex.space3d as amr
 
-small_end = amrex.Int_Vect()
-big_end = amrex.Int_Vect(2, 3, 4)
+small_end = amr.Int_Vect()
+big_end = amr.Int_Vect(2, 3, 4)
 
-b = amrex.Box(small_end, big_end)
+b = amr.Box(small_end, big_end)
 print(b)
 
 # ...

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -82,7 +82,7 @@ option(pyAMReX_amrex_internal "Download & build AMReX" ON)
 set(pyAMReX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(pyAMReX_amrex_internal)")
-set(pyAMReX_amrex_branch "a393d7ff7e320cefeeb55e31f1b0e0b5ac2d90ca"
+set(pyAMReX_amrex_branch "ac8574131dd152ce40853e17af948360def806f4"
     CACHE STRING
     "Repository branch for pyAMReX_amrex_repo if(pyAMReX_amrex_internal)")
 

--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -137,8 +137,13 @@ function(pyamrex_test_set_pythonpath test_name)
         set_property(TEST ${test_name}
             APPEND PROPERTY ENVIRONMENT
                 "PYTHONPATH=${WIN_PYTHON_OUTPUT_DIRECTORY}\;${WIN_PYTHONPATH}"
-                "PATH=$<TARGET_FILE_DIR:pyAMReX>\;$<TARGET_FILE_DIR:AMReX::amrex>\;${WIN_PATH}"
         )
+        foreach(D IN LISTS AMReX_SPACEDIM)
+            set_property(TEST ${test_name}
+                APPEND PROPERTY ENVIRONMENT
+                    "PATH=$<TARGET_FILE_DIR:pyAMReX_${D}d>\;$<TARGET_FILE_DIR:AMReX::amrex_${D}d>\;${WIN_PATH}"
+            )
+        endforeach()
     else()
         set_property(TEST ${test_name}
             APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_PYTHON_OUTPUT_DIRECTORY}:$ENV{PYTHONPATH}"
@@ -214,21 +219,6 @@ macro(set_cxx_warnings)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -wd4251")
     endif ()
 endmacro()
-
-
-# Set a feature-based binary name for the pyAMReX executable and create a generic
-# pyAMReX symlink to it. Only sets options relevant for users (see summary).
-#
-function(set_pyAMReX_binary_name)
-    #set_target_properties(pyAMReX PROPERTIES OUTPUT_NAME "amrex")
-    if(AMReX_SPACEDIM STREQUAL 3)
-        set_property(TARGET pyAMReX APPEND_STRING PROPERTY OUTPUT_NAME ".3d")
-    elseif(AMReX_SPACEDIM STREQUAL 2)
-        set_property(TARGET pyAMReX APPEND_STRING PROPERTY OUTPUT_NAME ".2d")
-    elseif(AMReX_SPACEDIM STREQUAL 1)
-        set_property(TARGET pyAMReX APPEND_STRING PROPERTY OUTPUT_NAME ".1d")
-    endif()
-endfunction()
 
 
 # Set an MPI_TEST_EXE variable for test runs which runs num_ranks

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ class CopyPreBuild(build):
 
     def run(self):
         # remove existing build directory
-        #   by default, this stays around. we want to make sure generated
-        #   files like libwarpx.(2d|3d|rz).(so|pyd) are always only the
+        #   by default, this stays around. We want to make sure generated
+        #   files like amrex_*d_pybind.*.(so|pyd) are always only the
         #   ones we want to package and not ones from an earlier wheel's stage
         c = clean(self.distribution)
         c.all = True
@@ -41,8 +41,8 @@ class CopyPreBuild(build):
         # call superclass
         build.run(self)
 
-        # matches: amrex_pybind.*.(so|pyd)
-        re_libprefix = re.compile(r"amrex_pybind\..*\.(?:so|pyd)")
+        # matches: amrex_*d_pybind.*.(so|pyd)
+        re_libprefix = re.compile(r"amrex_.d_pybind\..*\.(?:so|pyd)")
         libs_found = []
         for lib_name in os.listdir(PYAMREX_libdir):
             if re_libprefix.match(lib_name):
@@ -175,13 +175,13 @@ with open("./README.md", encoding="utf-8") as f:
 PYAMREX_libdir = os.environ.get("PYAMREX_LIBDIR")
 
 # ... build AMReX libraries with CMake
-#   note: changed default for SHARED, MPI, TESTING and EXAMPLES
+#   note: changed default for SHARED, SPACEDIM, MPI, TESTING and EXAMPLES
 AMReX_OMP = os.environ.get("AMREX_OMP", "OFF")
 AMReX_GPU_BACKEND = os.environ.get("AMREX_GPU_BACKEND", "NONE")
 AMReX_MPI = os.environ.get("AMREX_MPI", "OFF")
 AMReX_PRECISION = os.environ.get("AMREX_PRECISION", "DOUBLE")
-#   already prepared as a list 1;2;3
-AMReX_SPACEDIM = os.environ.get("AMREX_SPACEDIM", "3")
+#   single value or as a list 1;2;3
+AMReX_SPACEDIM = os.environ.get("AMREX_SPACEDIM", "1;2;3")
 BUILD_SHARED_LIBS = os.environ.get("AMREX_BUILD_SHARED_LIBS", "OFF")
 # CMake dependency control (developers & package managers)
 AMReX_src = os.environ.get("AMREX_SRC")

--- a/src/AmrCore/CMakeLists.txt
+++ b/src/AmrCore/CMakeLists.txt
@@ -1,4 +1,6 @@
-target_sources(pyAMReX
-  PRIVATE
-    AmrMesh.cpp
-)
+foreach(D IN LISTS AMReX_SPACEDIM)
+    target_sources(pyAMReX_${D}d
+      PRIVATE
+        AmrMesh.cpp
+    )
+endforeach()

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -1,23 +1,25 @@
-target_sources(pyAMReX
-  PRIVATE
-    AMReX.cpp
-    Arena.cpp
-    Array4.cpp
-    BaseFab.cpp
-    Box.cpp
-    RealBox.cpp
-    BoxArray.cpp
-    CoordSys.cpp
-    Dim3.cpp
-    DistributionMapping.cpp
-    FArrayBox.cpp
-    Geometry.cpp
-    IntVect.cpp
-    RealVect.cpp
-    MultiFab.cpp
-    ParallelDescriptor.cpp
-    ParmParse.cpp
-    Periodicity.cpp
-    PODVector.cpp
-    Vector.cpp
-)
+foreach(D IN LISTS AMReX_SPACEDIM)
+    target_sources(pyAMReX_${D}d
+      PRIVATE
+        AMReX.cpp
+        Arena.cpp
+        Array4.cpp
+        BaseFab.cpp
+        Box.cpp
+        RealBox.cpp
+        BoxArray.cpp
+        CoordSys.cpp
+        Dim3.cpp
+        DistributionMapping.cpp
+        FArrayBox.cpp
+        Geometry.cpp
+        IntVect.cpp
+        RealVect.cpp
+        MultiFab.cpp
+        ParallelDescriptor.cpp
+        ParmParse.cpp
+        Periodicity.cpp
+        PODVector.cpp
+        Vector.cpp
+    )
+endforeach()

--- a/src/Base/RealVect.cpp
+++ b/src/Base/RealVect.cpp
@@ -21,7 +21,7 @@ using namespace amrex;
 
 void init_RealVect(py::module &m) {
 
-     py::class_< RealVect>(m, "RealVect")
+     auto py_realvect = py::class_< RealVect>(m, "RealVect")
           .def("__repr__",
                [](py::object& obj) {
                     py::str py_name = obj.attr("__class__").attr("__name__");
@@ -96,7 +96,9 @@ void init_RealVect(py::module &m) {
           .def(float() * py::self)
           .def(py::self * py::self)
           .def("dotProduct", &RealVect::dotProduct, "Return dot product of this vector with another")
+#if (AMREX_SPACEDIM == 3)
           .def("crossProduct", &RealVect::crossProduct, "Return cross product of this vector with another")
+#endif
           .def("__mul__",
                py::overload_cast<Real>(&RealVect::operator*, py::const_))
 
@@ -129,10 +131,11 @@ void init_RealVect(py::module &m) {
 
           .def("BASISREALV", &BASISREALV, "return basis vector in given coordinate direction")
      ;
+
      m.def("min", [](const RealVect& a, const RealVect& b) {
-               return min(a,b);
-          });
+         return min(a,b);
+     });
      m.def("max", [](const RealVect& a, const RealVect& b) {
-               return max(a,b);
-          });
+         return max(a,b);
+     });
 }

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -1,11 +1,13 @@
-target_sources(pyAMReX
-  PRIVATE
-    Particle.cpp
-    StructOfArrays.cpp
-    ArrayOfStructs.cpp
-    ParticleTile.cpp
-    ParticleContainer.cpp
-    ParticleContainer_HiPACE.cpp
-    ParticleContainer_ImpactX.cpp
-    ParticleContainer_WarpX.cpp
-)
+foreach(D IN LISTS AMReX_SPACEDIM)
+    target_sources(pyAMReX_${D}d
+      PRIVATE
+        Particle.cpp
+        StructOfArrays.cpp
+        ArrayOfStructs.cpp
+        ParticleTile.cpp
+        ParticleContainer.cpp
+        ParticleContainer_HiPACE.cpp
+        ParticleContainer_ImpactX.cpp
+        ParticleContainer_WarpX.cpp
+    )
+endforeach()

--- a/src/Particle/Particle.cpp
+++ b/src/Particle/Particle.cpp
@@ -134,8 +134,11 @@ void make_Particle(py::module &m)
                     std::regex_match(varname, sm, component_separator, std::regex_constants::match_default);
                     int comp = -1;
                     if (varname == "x") { part->m_pos[0] = item.second.cast<ParticleReal>(); }
+#if AMREX_SPACEDIM >= 2
                     if (varname == "y") { part->m_pos[1] = item.second.cast<ParticleReal>(); }
+#elif AMREX_SPACEDIM == 3
                     if (varname == "z") { part->m_pos[2] = item.second.cast<ParticleReal>(); }
+#endif
                     if (sm.size() > 2) {
                         comp = std::stoi(sm[2]);
                         if constexpr (T_NReal > 0) {
@@ -294,10 +297,10 @@ void make_Particle(py::module &m)
         .def("NextID", [](const ParticleType &p) {return p.NextID();})
         .def("NextID", [](const ParticleType &p, Long nextid) { p.NextID(nextid); })
         .def_property("x", [](ParticleType &p){ return p.pos(0);}, [](ParticleType &p, Real val){ p.m_pos[0] = val; })
-#if (AMREX_SPACEDIM >= 2)
+#if AMREX_SPACEDIM >= 2
         .def_property("y", [](ParticleType &p){ return p.pos(1);}, [](ParticleType &p, Real val){ p.m_pos[1] = val; })
 #endif
-#if (AMREX_SPACEDIM == 3)
+#if AMREX_SPACEDIM == 3
         .def_property("z", [](ParticleType &p){ return p.pos(2);}, [](ParticleType &p, Real val){ p.m_pos[2] = val; })
 #endif
     ;

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -72,7 +72,7 @@ void make_ParticleTile(py::module &m, std::string allocstr)
         .def("define", &ParticleTileType::define)
         .def("GetStructOfArrays", py::overload_cast<>(&ParticleTileType::GetStructOfArrays),
             py::return_value_policy::reference_internal)
-        .def("empty", &ParticleTileType::template empty<ParticleType>)
+        .def("empty", &ParticleTileType::empty)
         .def("size", &ParticleTileType::template size<ParticleType>)
         .def("numParticles", &ParticleTileType::template numParticles<ParticleType>)
         .def("numRealParticles", &ParticleTileType::template numRealParticles<ParticleType>)

--- a/src/amrex/__init__.py
+++ b/src/amrex/__init__.py
@@ -1,29 +1,7 @@
-import os
+# -*- coding: utf-8 -*-
 
-# Python 3.8+ on Windows: DLL search paths for dependent
-# shared libraries
-# Refs.:
-# - https://github.com/python/cpython/issues/80266
-# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
-if os.name == "nt":
-    # add anything in the current directory
-    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
-    os.add_dll_directory(pwd)
-    # add anything in PATH
-    paths = os.environ.get("PATH", "")
-    for p in paths.split(";"):
-        if os.path.exists(p):
-            os.add_dll_directory(p)
-
-# import core bindings to C++
-from . import amrex_pybind
-from .amrex_pybind import *  # noqa
-
-__version__ = amrex_pybind.__version__
-__doc__ = amrex_pybind.__doc__
-__license__ = amrex_pybind.__license__
-__author__ = amrex_pybind.__author__
-
-# at this place we can enhance Python classes with additional methods written
-# in pure Python or add some other Python logic
-#
+# __version__ is TODO - only in spaceNd submodules
+__author__ = (
+    "Axel Huebl, Ryan Sandberg, Shreyas Ananthan, Remi Lehe, " "Weiqun Zhang, et al."
+)
+__license__ = "BSD-3-Clause-LBNL"

--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+# Python 3.8+ on Windows: DLL search paths for dependent
+# shared libraries
+# Refs.:
+# - https://github.com/python/cpython/issues/80266
+# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
+if os.name == "nt":
+    # add anything in the current directory
+    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
+    os.add_dll_directory(pwd)
+    # add anything in PATH
+    paths = os.environ.get("PATH", "")
+    for p in paths.split(";"):
+        if os.path.exists(p):
+            os.add_dll_directory(p)
+
+# import core bindings to C++
+from . import amrex_1d_pybind
+from .amrex_1d_pybind import *  # noqa
+
+__version__ = amrex_1d_pybind.__version__
+__doc__ = amrex_1d_pybind.__doc__
+__license__ = amrex_1d_pybind.__license__
+__author__ = amrex_1d_pybind.__author__
+
+# at this place we can enhance Python classes with additional methods written
+# in pure Python or add some other Python logic
+#

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+# Python 3.8+ on Windows: DLL search paths for dependent
+# shared libraries
+# Refs.:
+# - https://github.com/python/cpython/issues/80266
+# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
+if os.name == "nt":
+    # add anything in the current directory
+    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
+    os.add_dll_directory(pwd)
+    # add anything in PATH
+    paths = os.environ.get("PATH", "")
+    for p in paths.split(";"):
+        if os.path.exists(p):
+            os.add_dll_directory(p)
+
+# import core bindings to C++
+from . import amrex_2d_pybind
+from .amrex_2d_pybind import *  # noqa
+
+__version__ = amrex_2d_pybind.__version__
+__doc__ = amrex_2d_pybind.__doc__
+__license__ = amrex_2d_pybind.__license__
+__author__ = amrex_2d_pybind.__author__
+
+# at this place we can enhance Python classes with additional methods written
+# in pure Python or add some other Python logic
+#

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+# Python 3.8+ on Windows: DLL search paths for dependent
+# shared libraries
+# Refs.:
+# - https://github.com/python/cpython/issues/80266
+# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
+if os.name == "nt":
+    # add anything in the current directory
+    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
+    os.add_dll_directory(pwd)
+    # add anything in PATH
+    paths = os.environ.get("PATH", "")
+    for p in paths.split(";"):
+        if os.path.exists(p):
+            os.add_dll_directory(p)
+
+# import core bindings to C++
+from . import amrex_3d_pybind
+from .amrex_3d_pybind import *  # noqa
+
+__version__ = amrex_3d_pybind.__version__
+__doc__ = amrex_3d_pybind.__doc__
+__license__ = amrex_3d_pybind.__license__
+__author__ = amrex_3d_pybind.__author__
+
+# at this place we can enhance Python classes with additional methods written
+# in pure Python or add some other Python logic
+#

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -44,12 +44,19 @@ void init_PODVector(py::module &);
 void init_Vector(py::module &);
 
 
-
-PYBIND11_MODULE(amrex_pybind, m) {
+#if AMREX_SPACEDIM == 1
+PYBIND11_MODULE(amrex_1d_pybind, m) {
+#elif AMREX_SPACEDIM == 2
+PYBIND11_MODULE(amrex_2d_pybind, m) {
+#elif AMREX_SPACEDIM == 3
+PYBIND11_MODULE(amrex_3d_pybind, m) {
+#else
+#  error "AMREX_SPACEDIM must be 1, 2 or 3"
+#endif
     m.doc() = R"pbdoc(
-            amrex_pybind
-            -----------
-            .. currentmodule:: amrex_pybind
+            amrex
+            -----
+            .. currentmodule:: amrex
 
             .. autosummary::
                :toctree: _generate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,15 +4,24 @@ import itertools
 
 import pytest
 
-import amrex
+try:
+    import amrex.space3d as amr
+except ImportError:
+    try:
+        import amrex.space2d as amr
+    except ImportError:
+        try:
+            import amrex.space1d as amr
+        except ImportError:
+            raise ImportError("AMReX: No 1D, 2D or 3D module found!")
 
-if amrex.Config.have_mpi:
+if amr.Config.have_mpi:
     from mpi4py import MPI
 
 
 @pytest.fixture(autouse=True, scope="function")
 def amrex_init():
-    amrex.initialize(
+    amr.initialize(
         [
             # print AMReX status messages
             "amrex.verbose=2",
@@ -26,20 +35,20 @@ def amrex_init():
         ]
     )
     yield
-    amrex.finalize()
+    amr.finalize()
 
 
 @pytest.fixture(scope="function")
 def std_real_box():
     """Standard RealBox for common problem domains"""
-    rb = amrex.RealBox(0, 0, 0, 1.0, 1.0, 1.0)
+    rb = amr.RealBox(0, 0, 0, 1.0, 1.0, 1.0)
     return rb
 
 
 @pytest.fixture(scope="function")
 def std_box():
     """Standard Box for tests"""
-    bx = amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(63, 63, 63))
+    bx = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(63, 63, 63))
     return bx
 
 
@@ -48,14 +57,14 @@ def std_geometry(std_box, std_real_box):
     """Standard Geometry"""
     coord = 1  # RZ
     periodicity = [0, 0, 1]
-    gm = amrex.Geometry(std_box, std_real_box, coord, periodicity)
+    gm = amr.Geometry(std_box, std_real_box, coord, periodicity)
     return gm
 
 
 @pytest.fixture(scope="function")
 def boxarr(std_box):
     """BoxArray for MultiFab creation"""
-    ba = amrex.BoxArray(std_box)
+    ba = amr.BoxArray(std_box)
     ba.max_size(32)
     return ba
 
@@ -63,7 +72,7 @@ def boxarr(std_box):
 @pytest.fixture(scope="function")
 def distmap(boxarr):
     """DistributionMapping for MultiFab creation"""
-    dm = amrex.DistributionMapping(boxarr)
+    dm = amr.DistributionMapping(boxarr)
     return dm
 
 
@@ -71,7 +80,7 @@ def distmap(boxarr):
 def make_mfab(boxarr, distmap, request):
     """MultiFab that is either managed or device:
     The MultiFab object itself is not a fixture because we want to avoid caching
-    it between amrex.initialize/finalize calls of various tests.
+    it between amr.initialize/finalize calls of various tests.
     https://github.com/pytest-dev/pytest/discussions/10387
     https://github.com/pytest-dev/pytest/issues/5642#issuecomment-1279612764
     """
@@ -79,7 +88,7 @@ def make_mfab(boxarr, distmap, request):
     def create():
         num_components = request.param[0]
         num_ghost = request.param[1]
-        mfab = amrex.MultiFab(boxarr, distmap, num_components, num_ghost)
+        mfab = amr.MultiFab(boxarr, distmap, num_components, num_ghost)
         mfab.set_val(0.0, 0, num_components)
         return mfab
 
@@ -87,13 +96,13 @@ def make_mfab(boxarr, distmap, request):
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 @pytest.fixture(scope="function", params=list(itertools.product([1, 3], [0, 1])))
 def make_mfab_device(boxarr, distmap, request):
     """MultiFab that resides purely on the device:
     The MultiFab object itself is not a fixture because we want to avoid caching
-    it between amrex.initialize/finalize calls of various tests.
+    it between amr.initialize/finalize calls of various tests.
     https://github.com/pytest-dev/pytest/discussions/10387
     https://github.com/pytest-dev/pytest/issues/5642#issuecomment-1279612764
     """
@@ -101,12 +110,12 @@ def make_mfab_device(boxarr, distmap, request):
     def create():
         num_components = request.param[0]
         num_ghost = request.param[1]
-        mfab = amrex.MultiFab(
+        mfab = amr.MultiFab(
             boxarr,
             distmap,
             num_components,
             num_ghost,
-            amrex.MFInfo().set_arena(amrex.The_Device_Arena()),
+            amr.MFInfo().set_arena(amr.The_Device_Arena()),
         )
         mfab.set_val(0.0, 0, num_components)
         return mfab

--- a/tests/test_aos.py
+++ b/tests/test_aos.py
@@ -3,11 +3,11 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_aos_init():
-    aos = amrex.ArrayOfStructs_2_1_default()
+    aos = amr.ArrayOfStructs_2_1_default()
 
     assert aos.numParticles() == 0
     assert aos.numTotalParticles() == aos.numRealParticles() == 0
@@ -15,12 +15,12 @@ def test_aos_init():
 
 
 def test_aos_push_pop():
-    aos = amrex.ArrayOfStructs_2_1_default()
-    p1 = amrex.Particle_2_1()
+    aos = amr.ArrayOfStructs_2_1_default()
+    p1 = amr.Particle_2_1()
     p1.set_rdata([1.5, 2.2])
     p1.set_idata([3])
     aos.push_back(p1)
-    p2 = amrex.Particle_2_1()
+    p2 = amr.Particle_2_1()
     p2.set_rdata([2.1, 25.2])
     p2.set_idata([5])
     aos.push_back(p2)
@@ -38,7 +38,7 @@ def test_aos_push_pop():
     assert not aos.empty()
     assert aos.size() == 7
     assert aos[0].get_rdata() == p1.get_rdata()
-    p3 = amrex.Particle_2_1()
+    p3 = amr.Particle_2_1()
     p3.set_rdata([3.14, -3.14])
     p3.set_idata([10])
     aos[0] = p3
@@ -50,13 +50,13 @@ def test_aos_push_pop():
 
 
 def test_array_interface():
-    aos = amrex.ArrayOfStructs_2_1_default()
-    p1 = amrex.Particle_2_1()
+    aos = amr.ArrayOfStructs_2_1_default()
+    p1 = amr.Particle_2_1()
     p1.setPos([1, 2, 3])
     p1.set_rdata([4.5, 5.2])
     p1.set_idata([6])
     aos.push_back(p1)
-    p2 = amrex.Particle_2_1()
+    p2 = amr.Particle_2_1()
     p2.setPos([8, 9, 10])
     p2.set_rdata([11.1, 12.2])
     p2.set_idata([13])
@@ -80,8 +80,8 @@ def test_array_interface():
         and np.isclose(arr[1][6], 13)
     )
 
-    p3 = amrex.Particle_2_1(x=-3)
-    p4 = amrex.Particle_2_1(y=-5)
+    p3 = amr.Particle_2_1(x=-3)
+    p4 = amr.Particle_2_1(y=-5)
     print(arr)
     print(aos[0], aos[1])
     print("-------")
@@ -92,9 +92,7 @@ def test_array_interface():
     assert aos[0].y == arr[0][1] == 0
     assert aos[0].z == arr[0][2] == 0
 
-    shape = (
-        amrex.Config.spacedim + amrex.Particle_2_1.NReal + amrex.Particle_2_1.NInt + 1
-    )
+    shape = amr.Config.spacedim + amr.Particle_2_1.NReal + amr.Particle_2_1.NInt + 1
     for ii in range(shape):
         arr[1][ii] = 0
     arr[1][1] = -5  # np.array([0, -5, 0,0,0,0,0])

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -3,18 +3,18 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_array4_empty():
-    empty = amrex.Array4_double()
+    empty = amr.Array4_double()
 
     # Check properties
     assert empty.size == 0
     assert empty.nComp == 0
 
     # assign empty
-    emptyc = amrex.Array4_double(empty)
+    emptyc = amr.Array4_double(empty)
     # Check properties
     assert emptyc.size == 0
     assert emptyc.nComp == 0
@@ -30,7 +30,7 @@ def test_array4():
         )
     )
     print(f"\nx: {x.__array_interface__} {x.dtype}")
-    arr = amrex.Array4_double(x)
+    arr = amr.Array4_double(x)
     print(f"arr: {arr.__array_interface__}")
     print(arr)
     assert arr.nComp == 1
@@ -64,14 +64,14 @@ def test_array4():
     assert v_arr2np[0, 1, 1, 1] == 43
 
     # copy array4 (view)
-    c_arr = amrex.Array4_double(arr)
+    c_arr = amr.Array4_double(arr)
     v_carr2np = np.array(c_arr, copy=False)
     x[1, 1, 1] = 44
     assert v_carr2np[0, 1, 1, 1] == 44
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_array4_numba():
     # https://numba.pydata.org/numba-doc/dev/cuda/cuda_array_interface.html
@@ -89,7 +89,7 @@ def test_array4_numba():
     # host-to-device copy
     x_numba = cuda.to_device(x)  # type: numba.cuda.cudadrv.devicearray.DeviceNDArray
     # x_cupy = cupy.asarray(x_numba)      # type: cupy.ndarray
-    x_arr = amrex.Array4_double(x_numba)  # type: amrex.Array4_double
+    x_arr = amr.Array4_double(x_numba)  # type: amr.Array4_double
 
     assert (
         x_arr.__cuda_array_interface__["data"][0]
@@ -103,7 +103,7 @@ def test_array4_numba():
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_array4_cupy():
     # https://docs.cupy.dev/en/stable/user_guide/interoperability.html
@@ -122,7 +122,7 @@ def test_array4_cupy():
     print(x_cupy.__cuda_array_interface__)
 
     # cupy -> AMReX array4
-    x_arr = amrex.Array4_double(x_cupy)  # type: amrex.Array4_double
+    x_arr = amr.Array4_double(x_cupy)  # type: amr.Array4_double
     print(f"x_arr={x_arr}")
     print(x_arr.__cuda_array_interface__)
 
@@ -138,7 +138,7 @@ def test_array4_cupy():
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_array4_pytorch():
     # https://docs.cupy.dev/en/stable/user_guide/interoperability.html#pytorch

--- a/tests/test_basefab.py
+++ b/tests/test_basefab.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_basefab():
-    bf = amrex.BaseFab_Real()
+    bf = amr.BaseFab_Real()

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -3,21 +3,21 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 @pytest.fixture(scope="function")
 def box():
-    return amrex.Box((0, 0, 0), (127, 127, 127))
+    return amr.Box((0, 0, 0), (127, 127, 127))
 
 
 def test_length(box):
     print(box.length())
-    assert box.length() == amrex.IntVect(128, 128, 128)
+    assert box.length() == amr.IntVect(128, 128, 128)
 
     domain = box.length()
     ncells = 1
-    for ii in range(amrex.Config.spacedim):
+    for ii in range(amr.Config.spacedim):
         ncells *= domain[ii]
     print("ncells by hand", ncells)
     print("ncells from box", box.numPts())
@@ -49,11 +49,11 @@ def test_slab(box):
 
 # def test_convert(box):
 #    """Conversion to node"""
-#    bx = box.convert(amrex.CellIndex.NODE, amrex.CellIndex.NODE, amrex.CellIndex.NODE)
+#    bx = box.convert(amr.CellIndex.NODE, amr.CellIndex.NODE, amr.CellIndex.NODE)
 #    assert(bx.num_pts == 129**3)
 #    assert(bx.volume == 128**3)
 
-#    bx = box.convert(amrex.CellIndex.NODE, amrex.CellIndex.CELL, amrex.CellIndex.CELL)
+#    bx = box.convert(amr.CellIndex.NODE, amr.CellIndex.CELL, amr.CellIndex.CELL)
 #    np.testing.assert_allclose(bx.hi_vect, [128, 127, 127])
 #    assert(bx.num_pts == 129 * 128 * 128)
 #    assert(bx.volume == 128**3)
@@ -82,7 +82,7 @@ def test_surrounding_nodes(box, dir):
 @pytest.mark.parametrize("dir", [-1, 0, 1, 2])
 def test_enclosed_cells(box, dir):
     """Enclosed cells"""
-    bxn = box.convert(amrex.CellIndex.NODE, amrex.CellIndex.NODE, amrex.CellIndex.NODE)
+    bxn = box.convert(amr.CellIndex.NODE, amr.CellIndex.NODE, amr.CellIndex.NODE)
     nx = np.array(bxn.hi_vect)
     bx = bxn.enclosed_cells(dir)
 

--- a/tests/test_coordsys.py
+++ b/tests/test_coordsys.py
@@ -3,14 +3,14 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
-# import amrex.CoordSys.CoordType as CoordType
+# import amrex.space3d as amr.CoordSys.CoordType as CoordType
 
 
 def test_coordSys_coordType():
-    CType = amrex.CoordSys.CoordType
-    cs = amrex.CoordSys()
+    CType = amr.CoordSys.CoordType
+    cs = amr.CoordSys()
 
     print(cs.ok())
     assert not cs.ok()

--- a/tests/test_dim3.py
+++ b/tests/test_dim3.py
@@ -3,18 +3,18 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_dim3():
-    obj = amrex.Dim3(1, 2, 3)
+    obj = amr.Dim3(1, 2, 3)
     assert obj.x == 1
     assert obj.y == 2
     assert obj.z == 3
 
 
 def test_xdim3():
-    obj = amrex.XDim3(1.0, 2.0, 3.0)
+    obj = amr.XDim3(1.0, 2.0, 3.0)
     np.testing.assert_allclose(obj.x, 1.0)
     np.testing.assert_allclose(obj.y, 2.0)
     np.testing.assert_allclose(obj.z, 3.0)

--- a/tests/test_farraybox.py
+++ b/tests/test_farraybox.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_farraybox():
-    fab = amrex.FArrayBox()
+    fab = amr.FArrayBox()
 
 
 def test_farraybox_io():
-    fab = amrex.FArrayBox()
+    fab = amr.FArrayBox()
 
     # https://docs.python.org/3/library/io.html
     # https://gist.github.com/asford/544323a5da7dddad2c9174490eb5ed06#file-test_ostream_example-py

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -3,40 +3,40 @@
 import numpy as np
 import pytest
 
-import amrex
-from amrex import Geometry as Gm
+import amrex.space3d as amr
+from amrex.space3d import Geometry as Gm
 
 # TODO: return coord?
 
 
 @pytest.fixture(scope="function")
 def box():
-    return amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(127, 127, 127))
+    return amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(127, 127, 127))
 
 
 @pytest.fixture(scope="function")
 def real_box():
-    return amrex.RealBox([0, 0, 0], [1, 2, 5])
+    return amr.RealBox([0, 0, 0], [1, 2, 5])
 
 
 @pytest.fixture(scope="function")
 def geometry(box, real_box):
     coord = 1
     is_periodic = [0, 0, 1]
-    return amrex.Geometry(box, real_box, coord, is_periodic)
+    return amr.Geometry(box, real_box, coord, is_periodic)
 
 
 def test_geometry_data(box, real_box):
-    gd = amrex.GeometryData()
+    gd = amr.GeometryData()
     print(gd.coord)
     assert gd.coord == 0
     print(gd.domain)
     print(gd.domain.small_end)
-    assert gd.domain.small_end == amrex.IntVect(1, 1, 1)
+    assert gd.domain.small_end == amr.IntVect(1, 1, 1)
     print(gd.domain.big_end)
-    assert gd.domain.big_end == amrex.IntVect(0, 0, 0)
+    assert gd.domain.big_end == amr.IntVect(0, 0, 0)
     print(gd.prob_domain)
-    assert amrex.AlmostEqual(gd.prob_domain, amrex.RealBox(0, 0, 0, -1, -1, -1))
+    assert amr.AlmostEqual(gd.prob_domain, amr.RealBox(0, 0, 0, -1, -1, -1))
 
     print(gd.isPeriodic())
     print(gd.is_periodic)
@@ -54,7 +54,7 @@ def test_geometry_data(box, real_box):
         gd.dx = [0.1, 0.2, 0.3]
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_geometry_define(box, real_box):
     gm = Gm()
     coord = 1
@@ -64,7 +64,7 @@ def test_geometry_define(box, real_box):
     assert gm.isPeriodic() == is_periodic
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_probDomain(box, real_box):
     gm = Gm()
     coord = 1
@@ -74,7 +74,7 @@ def test_probDomain(box, real_box):
 
     lo = [0, -1, 1]
     hi = [1, 0, 2]
-    rb = amrex.RealBox(lo, hi)
+    rb = amr.RealBox(lo, hi)
     gm.ProbDomain(rb)
     assert (
         np.isclose(gm.ProbLo(0), lo[0])
@@ -86,7 +86,7 @@ def test_probDomain(box, real_box):
     )
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_size(geometry):
     gm = geometry
 
@@ -96,9 +96,9 @@ def test_size(geometry):
     assert np.isclose(gm.ProbLength(2), 5)
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_domain(box, real_box):
-    bx = amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(127, 127, 127))
+    bx = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(127, 127, 127))
     gm = Gm()
     coord = 1
     is_periodic = [0, 0, 1]
@@ -109,7 +109,7 @@ def test_domain(box, real_box):
     assert gm.Domain().small_end == bx.small_end and gm.Domain().big_end == bx.big_end
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_periodic_queries(box, real_box):
     coord = 1
     is_periodic = [0, 0, 1]
@@ -127,7 +127,7 @@ def test_periodic_queries(box, real_box):
     assert gm.isAllPeriodic()
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_periodicity(geometry):
     gm = geometry
     bx = gm.Domain()
@@ -141,25 +141,25 @@ def test_periodicity(geometry):
         assert error_thrown
 
     assert gm.period(2) == bx.length(2)
-    pdcity = amrex.Periodicity(bx.length() * amrex.IntVect(gm.isPeriodic()))
+    pdcity = amr.Periodicity(bx.length() * amr.IntVect(gm.isPeriodic()))
     assert gm.periodicity() == pdcity
 
-    iv1 = amrex.IntVect(0, 0, 0)
-    iv2 = amrex.IntVect(9, 19, 29)
-    pdcity = amrex.Periodicity(amrex.IntVect(0, 0, 30))
-    bx = amrex.Box(iv1, iv2)
+    iv1 = amr.IntVect(0, 0, 0)
+    iv2 = amr.IntVect(9, 19, 29)
+    pdcity = amr.Periodicity(amr.IntVect(0, 0, 30))
+    bx = amr.Box(iv1, iv2)
     assert gm.periodicity(bx) == pdcity
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_grow(geometry):
     gm = geometry
     gm_grow_pd = gm.growPeriodicDomain(2)
-    assert gm_grow_pd.small_end == amrex.IntVect(0, 0, -2)
-    assert gm_grow_pd.big_end == amrex.IntVect(127, 127, 129)
+    assert gm_grow_pd.small_end == amr.IntVect(0, 0, -2)
+    assert gm_grow_pd.big_end == amr.IntVect(127, 127, 129)
     gm_grow_npd = gm.growNonPeriodicDomain(3)
-    assert gm_grow_npd.small_end == amrex.IntVect(-3, -3, 0)
-    assert gm_grow_npd.big_end == amrex.IntVect(130, 130, 127)
+    assert gm_grow_npd.small_end == amr.IntVect(-3, -3, 0)
+    assert gm_grow_npd.big_end == amr.IntVect(130, 130, 127)
 
 
 def test_data(geometry, box, real_box):
@@ -169,7 +169,7 @@ def test_data(geometry, box, real_box):
     assert gd.domain.small_end == box.small_end == gd.Domain().small_end
     assert gd.domain.big_end == box.big_end == gd.Domain().big_end
 
-    assert amrex.AlmostEqual(gd.prob_domain, real_box)
+    assert amr.AlmostEqual(gd.prob_domain, real_box)
     assert np.allclose(real_box.lo(), gd.prob_domain.lo())
     assert np.allclose(real_box.hi(), gd.prob_domain.hi())
     assert (
@@ -210,31 +210,31 @@ def test_data(geometry, box, real_box):
     assert np.isclose(gd.CellSize(2), 0.0390625)
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_coarsen_refine(geometry):
-    iv1 = amrex.IntVect(-1, -2, -3)
-    iv2 = amrex.IntVect(4, 5, 6)
-    bx = amrex.Box(iv1, iv2)
-    rb = amrex.RealBox(-1, -2, -3, 2, 4, 6)
-    gmc = amrex.Geometry(bx, rb, 1, [0, 0, 1])
-    cv = amrex.IntVect(2, 2, 1)
+    iv1 = amr.IntVect(-1, -2, -3)
+    iv2 = amr.IntVect(4, 5, 6)
+    bx = amr.Box(iv1, iv2)
+    rb = amr.RealBox(-1, -2, -3, 2, 4, 6)
+    gmc = amr.Geometry(bx, rb, 1, [0, 0, 1])
+    cv = amr.IntVect(2, 2, 1)
     gmc.coarsen(cv)
-    assert gmc.Domain().small_end == amrex.IntVect(-1, -1, -3)
-    assert gmc.Domain().big_end == amrex.IntVect(2, 2, 6)
+    assert gmc.Domain().small_end == amr.IntVect(-1, -1, -3)
+    assert gmc.Domain().big_end == amr.IntVect(2, 2, 6)
 
-    gmr = amrex.Geometry(bx, rb, 1, [0, 0, 1])
-    rv = amrex.IntVect(2, 2, 3)
+    gmr = amr.Geometry(bx, rb, 1, [0, 0, 1])
+    rv = amr.IntVect(2, 2, 3)
     gmr.refine(rv)
-    assert gmr.Domain().small_end == amrex.IntVect(-2, -4, -9)
-    assert gmr.Domain().big_end == amrex.IntVect(9, 11, 20)
+    assert gmr.Domain().small_end == amr.IntVect(-2, -4, -9)
+    assert gmr.Domain().big_end == amr.IntVect(9, 11, 20)
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_roundoff_domain():
-    iv1 = amrex.IntVect(-1, -2, -3)
-    iv2 = amrex.IntVect(4, 5, 6)
-    bx = amrex.Box(iv1, iv2)
-    rb = amrex.RealBox(0, 1.0002, 0.00105, 2, 4.2, 5)
+    iv1 = amr.IntVect(-1, -2, -3)
+    iv2 = amr.IntVect(4, 5, 6)
+    bx = amr.Box(iv1, iv2)
+    rb = amr.RealBox(0, 1.0002, 0.00105, 2, 4.2, 5)
 
     gm = Gm(bx, rb, 1, [0, 0, 1])
 
@@ -244,10 +244,10 @@ def test_roundoff_domain():
     assert gm.insideRoundOffDomain(1.00, 2.0, 2)
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_Resets():
-    rb = amrex.RealBox(0, 0, 0, 1, 2, 6)
-    amrex.Geometry.ResetDefaultProbDomain(rb)
+    rb = amr.RealBox(0, 0, 0, 1, 2, 6)
+    amr.Geometry.ResetDefaultProbDomain(rb)
     Gm.ResetDefaultProbDomain(rb)
     is_periodic = [1, 0, 1]
     Gm.ResetDefaultPeriodicity(is_periodic)
@@ -261,5 +261,5 @@ def test_Resets():
     )
     assert gm.isPeriodic() == is_periodic
     print(gm.Coord())
-    CType = amrex.CoordSys.CoordType
+    CType = amr.CoordSys.CoordType
     assert gm.Coord() == CType.RZ

--- a/tests/test_intvect.py
+++ b/tests/test_intvect.py
@@ -3,12 +3,12 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 1, reason="Requires AMREX_SPACEDIM = 1")
+@pytest.mark.skipif(amr.Config.spacedim != 1, reason="Requires AMREX_SPACEDIM = 1")
 def test_iv_1d():
-    obj = amrex.IntVect(1)
+    obj = amr.IntVect(1)
     assert obj[0] == 1
     assert obj[-1] == 1
     with pytest.raises(IndexError):
@@ -17,9 +17,9 @@ def test_iv_1d():
         obj[1]
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 2, reason="Requires AMREX_SPACEDIM = 2")
+@pytest.mark.skipif(amr.Config.spacedim != 2, reason="Requires AMREX_SPACEDIM = 2")
 def test_iv_2d():
-    obj = amrex.IntVect(1, 2)
+    obj = amr.IntVect(1, 2)
     assert obj[0] == 1
     assert obj[1] == 2
     assert obj[-1] == 3
@@ -31,9 +31,9 @@ def test_iv_2d():
         obj[2]
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_iv_3d1():
-    obj = amrex.IntVect(1, 2, 3)
+    obj = amr.IntVect(1, 2, 3)
 
     # Check indexing
     assert obj[0] == 1
@@ -61,9 +61,9 @@ def test_iv_3d1():
     assert obj[2] == 4
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_iv_3d2():
-    obj = amrex.IntVect(3)
+    obj = amr.IntVect(3)
     assert obj[0] == 3
     assert obj[1] == 3
     assert obj[2] == 3
@@ -76,32 +76,32 @@ def test_iv_3d2():
     with pytest.raises(IndexError):
         obj[3]
 
-    obj = amrex.IntVect([2, 3, 4])
+    obj = amr.IntVect([2, 3, 4])
     assert obj[0] == 2
     assert obj[1] == 3
     assert obj[2] == 4
 
 
 def test_iv_static():
-    zero = amrex.IntVect.zero_vector()
-    for i in range(amrex.Config.spacedim):
+    zero = amr.IntVect.zero_vector()
+    for i in range(amr.Config.spacedim):
         assert zero[i] == 0
 
-    one = amrex.IntVect.unit_vector()
-    for i in range(amrex.Config.spacedim):
+    one = amr.IntVect.unit_vector()
+    for i in range(amr.Config.spacedim):
         assert one[i] == 1
 
-    assert zero == amrex.IntVect.cell_vector()
-    assert one == amrex.IntVect.node_vector()
+    assert zero == amr.IntVect.cell_vector()
+    assert one == amr.IntVect.node_vector()
 
 
 def test_iv_ops():
-    gold = amrex.IntVect(2)
-    one = amrex.IntVect.unit_vector()
+    gold = amr.IntVect(2)
+    one = amr.IntVect.unit_vector()
 
     two = one + one
     assert two == gold
-    assert two != amrex.IntVect.zero_vector()
+    assert two != amr.IntVect.zero_vector()
     assert two > one
     assert two >= gold
     assert one < two
@@ -110,31 +110,31 @@ def test_iv_ops():
     assert not (one > two)
 
     zero = one - one
-    assert zero == amrex.IntVect.zero_vector()
+    assert zero == amr.IntVect.zero_vector()
 
     mtwo = one * gold
     assert two == mtwo
 
-    four = amrex.IntVect(4)
+    four = amr.IntVect(4)
     dtwo = four / gold
     assert dtwo == mtwo
 
 
 def test_iv_conversions():
-    obj = amrex.IntVect.max_vector().numpy()
+    obj = amr.IntVect.max_vector().numpy()
     assert isinstance(obj, np.ndarray)
     assert obj.dtype == np.int32
 
     # check that memory is not collected too early
-    iv = amrex.IntVect(2)
+    iv = amr.IntVect(2)
     obj = iv.numpy()
     del iv
     assert obj[0] == 2
 
 
 def test_iv_iter():
-    a0 = amrex.IntVect(4)
-    b0 = amrex.IntVect(2)
+    a0 = amr.IntVect(4)
+    b0 = amr.IntVect(2)
 
     a1 = [x // 2 for x in a0]
     b1 = [x for x in b0]

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_mfab_loop(make_mfab):
@@ -109,8 +109,8 @@ def test_mfab_simple(make_mfab):
 
 @pytest.mark.parametrize("nghost", [0, 1])
 def test_mfab_ops(boxarr, distmap, nghost):
-    src = amrex.MultiFab(boxarr, distmap, 3, nghost)
-    dst = amrex.MultiFab(boxarr, distmap, 1, nghost)
+    src = amr.MultiFab(boxarr, distmap, 3, nghost)
+    dst = amr.MultiFab(boxarr, distmap, 1, nghost)
 
     src.set_val(10.0, 0, 1)
     src.set_val(20.0, 1, 1)
@@ -158,7 +158,7 @@ def test_mfab_mfiter(make_mfab):
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_mfab_ops_cuda_numba(make_mfab_device):
     mfab_device = make_mfab_device()
@@ -194,7 +194,7 @@ def test_mfab_ops_cuda_numba(make_mfab_device):
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_mfab_ops_cuda_cupy(make_mfab_device):
     mfab_device = make_mfab_device()
@@ -281,7 +281,7 @@ def test_mfab_ops_cuda_cupy(make_mfab_device):
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_mfab_ops_cuda_pytorch(make_mfab_device):
     mfab_device = make_mfab_device()
@@ -301,7 +301,7 @@ def test_mfab_ops_cuda_pytorch(make_mfab_device):
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_mfab_ops_cuda_cuml(make_mfab_device):
     mfab_device = make_mfab_device()
@@ -318,21 +318,21 @@ def test_mfab_ops_cuda_cuml(make_mfab_device):
 
 
 @pytest.mark.skipif(
-    amrex.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
+    amr.Config.gpu_backend != "CUDA", reason="Requires AMReX_GPU_BACKEND=CUDA"
 )
 def test_mfab_dtoh_copy(make_mfab_device):
     mfab_device = make_mfab_device()
 
-    mfab_host = amrex.MultiFab(
+    mfab_host = amr.MultiFab(
         mfab_device.box_array(),
         mfab_device.dm(),
         mfab_device.n_comp(),
         mfab_device.n_grow_vect(),
-        amrex.MFInfo().set_arena(amrex.The_Pinned_Arena()),
+        amr.MFInfo().set_arena(amr.The_Pinned_Arena()),
     )
     mfab_host.set_val(42.0, 0, mfab_host.n_comp())
 
-    amrex.dtoh_memcpy(mfab_host, mfab_device)
+    amr.dtoh_memcpy(mfab_host, mfab_device)
 
     # assert all are 0.0 on host
     host_min = mfab_host.min(0)
@@ -341,7 +341,7 @@ def test_mfab_dtoh_copy(make_mfab_device):
     assert host_max == 0.0
 
     mfab_host.set_val(11.0, 0, mfab_host.n_comp())
-    amrex.dtoh_memcpy(mfab_device, mfab_host)
+    amr.dtoh_memcpy(mfab_device, mfab_host)
 
     # assert all are 11.0 on device
     device_min = mfab_device.min(0)

--- a/tests/test_particle.py
+++ b/tests/test_particle.py
@@ -3,25 +3,25 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_particle_init():
-    p1 = amrex.Particle_7_0()
-    nreal = len(amrex.PIdx.RealValues.__members__)
-    nint = len(amrex.PIdx.IntValues.__members__)
-    assert amrex.Particle_7_0.NReal == nreal
-    assert amrex.Particle_7_0.NInt == nint
+    p1 = amr.Particle_7_0()
+    nreal = len(amr.PIdx.RealValues.__members__)
+    nint = len(amr.PIdx.IntValues.__members__)
+    assert amr.Particle_7_0.NReal == nreal
+    assert amr.Particle_7_0.NInt == nint
     assert p1.NReal == nreal
     assert p1.NInt == nint
 
-    p2 = amrex.Particle_7_0(1.0, 2.0, 3.0)
+    p2 = amr.Particle_7_0(1.0, 2.0, 3.0)
     assert p2.x == 1.0 and p2.y == 2.0 and p2.z == 3.0
 
-    p3 = amrex.Particle_7_0(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
+    p3 = amr.Particle_7_0(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
     assert p3.x == 1.0 and p3.get_rdata(0) == 4.0 and p3.get_rdata(6) == 10.0
 
-    p4 = amrex.Particle_7_0(1.0, 2.0, 3.0, rdata_0=4.0)
+    p4 = amr.Particle_7_0(1.0, 2.0, 3.0, rdata_0=4.0)
     assert (
         p4.x == 1.0
         and p4.z == 3.0
@@ -29,7 +29,7 @@ def test_particle_init():
         and p4.get_rdata(1) == 0 == p4.get_rdata(2) == p4.get_rdata(3)
     )
 
-    p5 = amrex.Particle_7_0(x=1.0, rdata_1=1.0, rdata_3=3.0)
+    p5 = amr.Particle_7_0(x=1.0, rdata_1=1.0, rdata_3=3.0)
     assert (
         p5.x == 1.0
         and p5.get_rdata(1) == 1.0
@@ -38,14 +38,14 @@ def test_particle_init():
     )
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_particle_set():
-    p1 = amrex.Particle_7_0()
+    p1 = amr.Particle_7_0()
     p1.setPos(1, 1.5)
     assert p1.pos(0) == 0 and p1.pos(1) == 1.5 and p1.pos(2) == 0
     p1.setPos([1.0, 1, 2])
     assert p1.pos(0) == 1 and p1.pos(1) == 1 and p1.pos(2) == 2
-    p1.setPos(amrex.RealVect(2, 3.3, 4.2))
+    p1.setPos(amr.RealVect(2, 3.3, 4.2))
     assert p1.pos(0) == 2 and p1.pos(1) == 3.3 and p1.pos(2) == 4.2
 
     print(p1.x, p1.y, p1.z)
@@ -58,7 +58,7 @@ def test_particle_set():
 
 
 def test_rdata():
-    p1 = amrex.Particle_2_1()
+    p1 = amr.Particle_2_1()
     rvec = [1.5, 2.0]
     p1.set_rdata(rvec)
     assert np.allclose(p1.get_rdata(), rvec)
@@ -73,7 +73,7 @@ def test_rdata():
 
 
 def test_idata():
-    p1 = amrex.Particle_2_1()
+    p1 = amr.Particle_2_1()
     ivec = [-1]
     p1.set_idata(ivec)
     assert p1.get_idata() == ivec

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 @pytest.fixture()
@@ -13,13 +13,13 @@ def Npart():
 
 @pytest.fixture(scope="function")
 def empty_particle_container(std_geometry, distmap, boxarr):
-    pc = amrex.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
+    pc = amr.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
     return pc
 
 
 @pytest.fixture(scope="function")
 def std_particle():
-    myt = amrex.ParticleInitType_1_1_2_1()
+    myt = amr.ParticleInitType_1_1_2_1()
     myt.real_struct_data = [0.5]
     myt.int_struct_data = [5]
     myt.real_array_data = [0.5, 0.2]
@@ -29,8 +29,8 @@ def std_particle():
 
 @pytest.fixture(scope="function")
 def particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
-    pc = amrex.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
-    myt = amrex.ParticleInitType_1_1_2_1()
+    pc = amr.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
+    myt = amr.ParticleInitType_1_1_2_1()
     myt.real_struct_data = [0.5]
     myt.int_struct_data = [5]
     myt.real_array_data = [0.5, 0.2]
@@ -42,7 +42,7 @@ def particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
 
 
 def test_particleInitType():
-    myt = amrex.ParticleInitType_1_1_2_1()
+    myt = amr.ParticleInitType_1_1_2_1()
     print(myt.real_struct_data)
     print(myt.int_struct_data)
     print(myt.real_array_data)
@@ -62,41 +62,41 @@ def test_particleInitType():
 def test_n_particles(particle_container, Npart):
     pc = particle_container
     assert pc.OK()
-    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_default.NStructReal == 1
-    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_default.NStructInt == 1
-    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_default.NArrayReal == 2
-    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_default.NArrayInt == 1
+    assert pc.NStructReal == amr.ParticleContainer_1_1_2_1_default.NStructReal == 1
+    assert pc.NStructInt == amr.ParticleContainer_1_1_2_1_default.NStructInt == 1
+    assert pc.NArrayReal == amr.ParticleContainer_1_1_2_1_default.NArrayReal == 2
+    assert pc.NArrayInt == amr.ParticleContainer_1_1_2_1_default.NArrayInt == 1
     assert (
         pc.NumberOfParticlesAtLevel(0) == np.sum(pc.NumberOfParticlesInGrid(0)) == Npart
     )
 
 
 def test_pc_init():
-    pc = amrex.ParticleContainer_1_1_2_1_default()
+    pc = amr.ParticleContainer_1_1_2_1_default()
 
     print("bytespread", pc.ByteSpread())
     print("capacity", pc.PrintCapacity())
     print("NumberOfParticles", pc.NumberOfParticlesAtLevel(0))
     assert pc.NumberOfParticlesAtLevel(0) == 0
 
-    bx = amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(63, 63, 63))
-    rb = amrex.RealBox(0, 0, 0, 1, 1, 1)
+    bx = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(63, 63, 63))
+    rb = amr.RealBox(0, 0, 0, 1, 1, 1)
     coord_int = 1  # RZ
     periodicity = [0, 0, 1]
-    gm = amrex.Geometry(bx, rb, coord_int, periodicity)
+    gm = amr.Geometry(bx, rb, coord_int, periodicity)
 
-    ba = amrex.BoxArray(bx)
+    ba = amr.BoxArray(bx)
     ba.max_size(32)
-    dm = amrex.DistributionMapping(ba)
+    dm = amr.DistributionMapping(ba)
 
     print("-------------------------")
     print("define particle container")
     pc.Define(gm, dm, ba)
     assert pc.OK()
-    assert pc.NStructReal == amrex.ParticleContainer_1_1_2_1_default.NStructReal == 1
-    assert pc.NStructInt == amrex.ParticleContainer_1_1_2_1_default.NStructInt == 1
-    assert pc.NArrayReal == amrex.ParticleContainer_1_1_2_1_default.NArrayReal == 2
-    assert pc.NArrayInt == amrex.ParticleContainer_1_1_2_1_default.NArrayInt == 1
+    assert pc.NStructReal == amr.ParticleContainer_1_1_2_1_default.NStructReal == 1
+    assert pc.NStructInt == amr.ParticleContainer_1_1_2_1_default.NStructInt == 1
+    assert pc.NArrayReal == amr.ParticleContainer_1_1_2_1_default.NArrayReal == 2
+    assert pc.NArrayInt == amr.ParticleContainer_1_1_2_1_default.NArrayInt == 1
 
     print("bytespread", pc.ByteSpread())
     print("capacity", pc.PrintCapacity())
@@ -108,7 +108,7 @@ def test_pc_init():
     print("add a particle to each grid")
     Npart_grid = 1
     iseed = 1
-    myt = amrex.ParticleInitType_1_1_2_1()
+    myt = amr.ParticleInitType_1_1_2_1()
     myt.real_struct_data = [0.5]
     myt.int_struct_data = [5]
     myt.real_array_data = [0.5, 0.2]
@@ -127,7 +127,7 @@ def test_pc_init():
     # lvl = 0
     for lvl in range(pc.finest_level + 1):
         print(f"at level {lvl}:")
-        for pti in amrex.ParIter_1_1_2_1_default(pc, level=lvl):
+        for pti in amr.ParIter_1_1_2_1_default(pc, level=lvl):
             print("...")
             assert pti.num_particles == 1
             assert pti.num_real_particles == 1
@@ -156,7 +156,7 @@ def test_pc_init():
 
     # read-only
     for lvl in range(pc.finest_level + 1):
-        for pti in amrex.ParConstIter_1_1_2_1_default(pc, level=lvl):
+        for pti in amr.ParConstIter_1_1_2_1_default(pc, level=lvl):
             assert pti.num_particles == 1
             assert pti.num_real_particles == 1
             assert pti.num_neighbor_particles == 0

--- a/tests/test_particleTile.py
+++ b/tests/test_particleTile.py
@@ -3,19 +3,19 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 ##########
 def test_ptile_data():
-    ptd = amrex.ParticleTileData_1_1_2_1()
+    ptd = amr.ParticleTileData_1_1_2_1()
     assert ptd.m_size == 0
     assert ptd.m_num_runtime_real == 0
     assert ptd.m_num_runtime_int == 0
 
 
 def test_ptile_funs():
-    pt = amrex.ParticleTile_1_1_2_1_default()
+    pt = amr.ParticleTile_1_1_2_1_default()
 
     assert pt.empty() and pt.size() == 0
     assert pt.numParticles() == pt.numRealParticles() == pt.numNeighborParticles() == 0
@@ -35,9 +35,9 @@ def test_ptile_funs():
 
 ################
 def test_ptile_pushback_ptiledata():
-    pt = amrex.ParticleTile_1_1_2_1_default()
-    p = amrex.Particle_1_1(1.0, 2.0, 3, 4.0, 5)
-    sp = amrex.Particle_3_2(5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11, 12)
+    pt = amr.ParticleTile_1_1_2_1_default()
+    p = amr.Particle_1_1(1.0, 2.0, 3, 4.0, 5)
+    sp = amr.Particle_3_2(5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11, 12)
     pt.push_back(p)
     pt.push_back(sp)
 
@@ -60,17 +60,17 @@ def test_ptile_pushback_ptiledata():
     )
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_access():
-    pt = amrex.ParticleTile_1_1_2_1_default()
-    sp1 = amrex.Particle_3_2()
+    pt = amr.ParticleTile_1_1_2_1_default()
+    sp1 = amr.Particle_3_2()
     pt.push_back(sp1)
     pt.push_back(sp1)
     sp1.x = 2.0
     sp1.z = 3.0
     td = pt.getParticleTileData()
     td[0] = sp1
-    sp2 = amrex.Particle_3_2()
+    sp2 = amr.Particle_3_2()
     sp2.x = 5.0
     sp2.y = 4.5
     pt[1] = sp2
@@ -81,7 +81,7 @@ def test_ptile_access():
 
 
 def test_ptile_soa():
-    pt = amrex.ParticleTile_1_1_2_1_default()
+    pt = amr.ParticleTile_1_1_2_1_default()
 
     pt.push_back_real(1, 2.1)
     pt.push_back_real([1.1, 1.3])
@@ -118,18 +118,18 @@ def test_ptile_soa():
     assert np.allclose(ir0, np.array([-66, 12, 31, 31, 31]))
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_aos():
-    pt = amrex.ParticleTile_1_1_2_1_default()
-    p1 = amrex.Particle_1_1()
-    p2 = amrex.Particle_1_1()
+    pt = amr.ParticleTile_1_1_2_1_default()
+    p1 = amr.Particle_1_1()
+    p2 = amr.Particle_1_1()
     p1.x = 3.0
     p2.x = 4.0
     p2.y = 8
     pt.push_back(p1)
 
     pt.push_back(p2)
-    p3 = amrex.Particle_1_1()
+    p3 = amr.Particle_1_1()
     p3.z = 20
     pt.push_back(p3)
     pt.resize(3)

--- a/tests/test_periodicity.py
+++ b/tests/test_periodicity.py
@@ -3,11 +3,11 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_periodicity():
-    obj = amrex.Periodicity()
+    obj = amr.Periodicity()
     assert obj.is_any_periodic == False
     assert obj.is_all_periodic == False
     assert obj.is_periodic(0) == False
@@ -15,14 +15,14 @@ def test_periodicity():
     # with pytest.raises(IndexError):
     #    obj[3]
 
-    non_periodic = amrex.Periodicity.non_periodic()
+    non_periodic = amr.Periodicity.non_periodic()
     assert obj == non_periodic
 
 
-@pytest.mark.skipif(amrex.Config.spacedim == 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim == 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_periodicity_3d():
-    iv = amrex.IntVect(1, 0, 1)
-    obj = amrex.Periodicity(iv)
+    iv = amr.IntVect(1, 0, 1)
+    obj = amr.Periodicity(iv)
     assert obj.is_any_periodic
     assert obj.is_all_periodic == False
     assert obj.is_periodic(0)

--- a/tests/test_podvector.py
+++ b/tests/test_podvector.py
@@ -3,11 +3,11 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_podvector_init():
-    podv = amrex.PODVector_real_std()
+    podv = amr.PODVector_real_std()
     print(podv.__array_interface__)
     # podv[0] = 1
     # podv[2] = 3
@@ -28,7 +28,7 @@ def test_podvector_init():
 
 
 def test_array_interface():
-    podv = amrex.PODVector_int_std()
+    podv = amr.PODVector_int_std()
     podv.push_back(1)
     podv.push_back(2)
     podv.push_back(1)

--- a/tests/test_realbox.py
+++ b/tests/test_realbox.py
@@ -3,13 +3,13 @@
 import numpy as np
 import pytest
 
-import amrex
-from amrex import RealVect as RV
-from amrex import XDim3
+import amrex.space3d as amr
+from amrex.space3d import RealVect as RV
+from amrex.space3d import XDim3
 
 
 def test_realbox_empty():
-    rb = amrex.RealBox()
+    rb = amr.RealBox()
     assert not rb.ok()
     assert rb.xlo[0] == 0 and rb.xlo[1] == 0 and rb.xlo[2] == 0 and rb.xhi[0] == -1
     assert rb.length(2) == -1 and rb.length(2) == -1 and rb.length(2) == -1
@@ -25,24 +25,24 @@ def test_realbox_empty():
 def test_realbox_frombox(std_box):
     dx = [1.0, 2.0, 3.0]
     base = [100.0, 200.0, 300.0]  # offset
-    rb1 = amrex.RealBox(std_box, dx, base)
+    rb1 = amr.RealBox(std_box, dx, base)
 
-    rb2 = amrex.RealBox(
+    rb2 = amr.RealBox(
         [100.0, 200.0, 300.0],
         [100.0 + dx[0] * 64, 200.0 + dx[1] * 64, 300.0 + dx[2] * 64],
     )
-    assert amrex.AlmostEqual(rb1, rb2)
+    assert amr.AlmostEqual(rb1, rb2)
 
 
 def test_realbox_contains():
-    rb1 = amrex.RealBox([0, 0, 0], [1, 2, 1.5])
+    rb1 = amr.RealBox([0, 0, 0], [1, 2, 1.5])
     point1 = [-1, 0, 2]
     point2 = [0.5, 0.5, 0.5]
     assert not rb1.contains(point1)
     assert rb1.contains(point2)
 
-    rb2 = amrex.RealBox(0.1, 0.2, 0.3, 0.3, 1, 1.0)
-    rb3 = amrex.RealBox([4, 5.0, 6.0], [5.0, 5.5, 7.0])
+    rb2 = amr.RealBox(0.1, 0.2, 0.3, 0.3, 1, 1.0)
+    rb3 = amr.RealBox([4, 5.0, 6.0], [5.0, 5.5, 7.0])
     assert rb1.contains(rb2)
     assert not rb1.contains(rb3)
     tol = 8
@@ -65,20 +65,20 @@ def test_realbox_contains():
 
 
 def test_realbox_intersects():
-    rb1 = amrex.RealBox([0, 0, 0], [1, 2, 1.5])
-    rb2 = amrex.RealBox([0.1, 0.2, 0.3], [0.3, 1, 1.0])
-    rb3 = amrex.RealBox([4, 5.0, 6.0], [5.0, 5.5, 7.0])
+    rb1 = amr.RealBox([0, 0, 0], [1, 2, 1.5])
+    rb2 = amr.RealBox([0.1, 0.2, 0.3], [0.3, 1, 1.0])
+    rb3 = amr.RealBox([4, 5.0, 6.0], [5.0, 5.5, 7.0])
     assert rb1.intersects(rb2)
     assert not rb3.intersects(rb1)
 
 
 def test_almost_equal():
-    rb1 = amrex.RealBox([0, 0, 0], [1, 2, 1.5])
-    rb2 = amrex.RealBox([0, 0, 0], [1, 2, 1.5])
-    rb3 = amrex.RealBox([0, 0.1, -0.1], [1, 2, 1.4])
-    assert amrex.AlmostEqual(rb1, rb2)
-    assert not amrex.AlmostEqual(rb1, rb3)
+    rb1 = amr.RealBox([0, 0, 0], [1, 2, 1.5])
+    rb2 = amr.RealBox([0, 0, 0], [1, 2, 1.5])
+    rb3 = amr.RealBox([0, 0.1, -0.1], [1, 2, 1.4])
+    assert amr.AlmostEqual(rb1, rb2)
+    assert not amr.AlmostEqual(rb1, rb3)
     tol = 0.05
-    assert not amrex.AlmostEqual(rb1, rb3, tol)
+    assert not amr.AlmostEqual(rb1, rb3, tol)
     tol = 0.2
-    assert amrex.AlmostEqual(rb1, rb3, tol)
+    assert amr.AlmostEqual(rb1, rb3, tol)

--- a/tests/test_realvect.py
+++ b/tests/test_realvect.py
@@ -3,23 +3,23 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_realvect_init():
-    rv = amrex.RealVect()
-    rv2 = amrex.RealVect([ii + 0.1 for ii in range(amrex.Config.spacedim)])
-    rv3 = amrex.RealVect(0.3)
+    rv = amr.RealVect()
+    rv2 = amr.RealVect([ii + 0.1 for ii in range(amr.Config.spacedim)])
+    rv3 = amr.RealVect(0.3)
 
-    for ii in range(amrex.Config.spacedim):
+    for ii in range(amr.Config.spacedim):
         assert rv[ii] == 0
         assert rv2[ii] == ii + 0.1
         assert rv3[ii] == 0.3
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 1, reason="Requires AMREX_SPACEDIM = 1")
+@pytest.mark.skipif(amr.Config.spacedim != 1, reason="Requires AMREX_SPACEDIM = 1")
 def test_rv_1d():
-    obj = amrex.RealVect(1.2)
+    obj = amr.RealVect(1.2)
     assert obj[0] == 1.2
     assert obj[-1] == 1.2
     with pytest.raises(IndexError):
@@ -28,9 +28,9 @@ def test_rv_1d():
         obj[1]
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 2, reason="Requires AMREX_SPACEDIM = 2")
+@pytest.mark.skipif(amr.Config.spacedim != 2, reason="Requires AMREX_SPACEDIM = 2")
 def test_rv_2d():
-    obj = amrex.RealVect(1.5, 2)
+    obj = amr.RealVect(1.5, 2)
     assert obj[0] == 1.5
     assert obj[1] == 2
     assert obj[-1] == 2
@@ -42,9 +42,9 @@ def test_rv_2d():
         obj[2]
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_rv_3d1():
-    obj = amrex.RealVect(1, 2, 3.14)
+    obj = amr.RealVect(1, 2, 3.14)
 
     # Check indexing
     assert obj[0] == 1
@@ -70,29 +70,29 @@ def test_rv_3d1():
     assert obj[2] == 4
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_rv_3d2():
-    # rv = amrex.RealVect(0.5,0.4,0.2)
-    rv2 = amrex.RealVect(amrex.IntVect(1, 2, 3))
+    # rv = amr.RealVect(0.5,0.4,0.2)
+    rv2 = amr.RealVect(amr.IntVect(1, 2, 3))
     # assert(rv[1] == 0.4)
     assert rv2[2] == 3
 
 
 def test_rv_static():
-    zero = amrex.RealVect.zero_vector()
-    for i in range(amrex.Config.spacedim):
+    zero = amr.RealVect.zero_vector()
+    for i in range(amr.Config.spacedim):
         assert zero[i] == 0
 
-    one = amrex.RealVect.unit_vector()
-    for i in range(amrex.Config.spacedim):
+    one = amr.RealVect.unit_vector()
+    for i in range(amr.Config.spacedim):
         assert one[i] == 1
 
 
 def test_comparison():
-    uv = amrex.RealVect.unit_vector()
-    zv = amrex.RealVect.zero_vector()
-    zv2 = amrex.RealVect()
-    v1 = amrex.RealVect([ii for ii in range(amrex.Config.spacedim)])
+    uv = amr.RealVect.unit_vector()
+    zv = amr.RealVect.zero_vector()
+    zv2 = amr.RealVect()
+    v1 = amr.RealVect([ii for ii in range(amr.Config.spacedim)])
 
     assert uv != zv
     assert zv == zv2
@@ -105,158 +105,158 @@ def test_comparison():
 
 
 def test_unary():
-    assert +amrex.RealVect(1.5) == amrex.RealVect(1.5)
-    assert -amrex.RealVect(1.5) == amrex.RealVect(-1.5)
+    assert +amr.RealVect(1.5) == amr.RealVect(1.5)
+    assert -amr.RealVect(1.5) == amr.RealVect(-1.5)
 
 
 def test_addition():
-    uv = amrex.RealVect.unit_vector()
-    zv = amrex.RealVect.zero_vector()
+    uv = amr.RealVect.unit_vector()
+    zv = amr.RealVect.zero_vector()
 
     assert zv + 1 == uv
-    zv2 = amrex.RealVect()
+    zv2 = amr.RealVect()
     zv2 += 1.0
     assert zv2 == uv
 
-    assert 1.0 + uv == amrex.RealVect(2)
+    assert 1.0 + uv == amr.RealVect(2)
     assert uv + zv == uv
 
 
 def test_subtraction():
-    uv = amrex.RealVect.unit_vector()
+    uv = amr.RealVect.unit_vector()
     # minus equal
-    v3 = amrex.RealVect([ii + 0.1 for ii in range(amrex.Config.spacedim)])
-    v4 = amrex.RealVect([ii + 1.1 for ii in range(amrex.Config.spacedim)])
-    v5 = amrex.RealVect([ii + 1.1 for ii in range(amrex.Config.spacedim)])
-    v6 = amrex.RealVect(-1)
+    v3 = amr.RealVect([ii + 0.1 for ii in range(amr.Config.spacedim)])
+    v4 = amr.RealVect([ii + 1.1 for ii in range(amr.Config.spacedim)])
+    v5 = amr.RealVect([ii + 1.1 for ii in range(amr.Config.spacedim)])
+    v6 = amr.RealVect(-1)
     v4 -= uv
-    for ii in range(amrex.Config.spacedim):
+    for ii in range(amr.Config.spacedim):
         assert 10 * int(v4[ii]) == 10 * int(v3[ii])
     v4 -= v6
-    for ii in range(amrex.Config.spacedim):
+    for ii in range(amr.Config.spacedim):
         assert v4[ii] == v5[ii]
 
     # v - v
     assert v5 - v3 == uv
     # r - v
-    assert 1.0 - v6 == amrex.RealVect(2.0)
+    assert 1.0 - v6 == amr.RealVect(2.0)
 
 
 def test_multiplication():
     # times equal
-    v1 = amrex.RealVect(1.5)
+    v1 = amr.RealVect(1.5)
     v1 *= 2
-    for ii in range(amrex.Config.spacedim):
+    for ii in range(amr.Config.spacedim):
         assert v1[ii] == 3
     # times equal
-    v1 = amrex.RealVect(1.5)
-    v2 = amrex.RealVect([ii for ii in range(amrex.Config.spacedim)])
+    v1 = amr.RealVect(1.5)
+    v2 = amr.RealVect([ii for ii in range(amr.Config.spacedim)])
     v2 *= v1
-    for ii in range(amrex.Config.spacedim):
+    for ii in range(amr.Config.spacedim):
         assert v2[ii] == 1.5 * ii
     # times
-    v1 = amrex.RealVect(1.5)
-    assert v1 * 3 == amrex.RealVect(4.5)
-    assert 3 * v1 == amrex.RealVect(4.5)
-    assert v1 * amrex.RealVect(3) == amrex.RealVect(4.5)
-    assert v1 * amrex.RealVect(2.0) == amrex.RealVect(3.0)
+    v1 = amr.RealVect(1.5)
+    assert v1 * 3 == amr.RealVect(4.5)
+    assert 3 * v1 == amr.RealVect(4.5)
+    assert v1 * amr.RealVect(3) == amr.RealVect(4.5)
+    assert v1 * amr.RealVect(2.0) == amr.RealVect(3.0)
     # scale
-    assert v1.scale(3) == amrex.RealVect(4.5)
+    assert v1.scale(3) == amr.RealVect(4.5)
 
 
 def test_dot_cross():
     # dotProduct
-    v1 = amrex.RealVect(1.5)
-    v2 = amrex.RealVect([1 + ii for ii in range(amrex.Config.spacedim)])
-    dims = amrex.Config.spacedim
+    v1 = amr.RealVect(1.5)
+    v2 = amr.RealVect([1 + ii for ii in range(amr.Config.spacedim)])
+    dims = amr.Config.spacedim
     assert v1.dotProduct(v2) == 1.5 * int(dims * (dims + 1) / 2)
 
     # crossProduct
-    if amrex.Config.spacedim == 3:
-        v1 = amrex.RealVect(1.5)
-        v2 = amrex.RealVect([ii for ii in range(amrex.Config.spacedim)])
-        assert v1.crossProduct(v2) == amrex.RealVect(1.5, -3, 1.5)
+    if amr.Config.spacedim == 3:
+        v1 = amr.RealVect(1.5)
+        v2 = amr.RealVect([ii for ii in range(amr.Config.spacedim)])
+        assert v1.crossProduct(v2) == amr.RealVect(1.5, -3, 1.5)
 
 
 def test_divide():
     # divide equal (2)
-    v1 = amrex.RealVect(3.0)
+    v1 = amr.RealVect(3.0)
     v1 /= 2.0
-    assert v1 == amrex.RealVect(1.5)
+    assert v1 == amr.RealVect(1.5)
 
-    v2 = amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
-    v2 /= amrex.RealVect(3)
-    assert v2 == amrex.RealVect([ii for ii in range(amrex.Config.spacedim)])
+    v2 = amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
+    v2 /= amr.RealVect(3)
+    assert v2 == amr.RealVect([ii for ii in range(amr.Config.spacedim)])
     # divide
-    assert amrex.RealVect(3.0) / amrex.RealVect(2.0) == amrex.RealVect(1.5)
-    assert amrex.RealVect(3.0) / 1.5 == amrex.RealVect(2.0)
-    assert 3.0 / amrex.RealVect(1.5) == amrex.RealVect(2.0)
+    assert amr.RealVect(3.0) / amr.RealVect(2.0) == amr.RealVect(1.5)
+    assert amr.RealVect(3.0) / 1.5 == amr.RealVect(2.0)
+    assert 3.0 / amr.RealVect(1.5) == amr.RealVect(2.0)
 
 
 def test_rounding():
     # floor
-    vlower = amrex.IntVect([1 + ii for ii in range(amrex.Config.spacedim)])
-    vupper = amrex.IntVect([2 + ii for ii in range(amrex.Config.spacedim)])
-    v2 = amrex.RealVect([1.5 + ii for ii in range(amrex.Config.spacedim)])
-    v3 = amrex.RealVect([1.49 + ii for ii in range(amrex.Config.spacedim)])
+    vlower = amr.IntVect([1 + ii for ii in range(amr.Config.spacedim)])
+    vupper = amr.IntVect([2 + ii for ii in range(amr.Config.spacedim)])
+    v2 = amr.RealVect([1.5 + ii for ii in range(amr.Config.spacedim)])
+    v3 = amr.RealVect([1.49 + ii for ii in range(amr.Config.spacedim)])
     assert v2.floor() == vlower
     assert v3.ceil() == vupper
     assert v2.round() == vupper
     assert v3.round() == vlower
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_3d_max():
     # max
-    v1 = amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
-    v2 = amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    v1 = amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
+    v2 = amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
     ref_list = [6, 3, 6]
-    compare_vect = amrex.RealVect([ref_list[ii] for ii in range(amrex.Config.spacedim)])
-    v3 = amrex.max(v1, v2)
+    compare_vect = amr.RealVect([ref_list[ii] for ii in range(amr.Config.spacedim)])
+    v3 = amr.max(v1, v2)
     assert v3 == compare_vect
-    assert v1 == amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
-    assert v2 == amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    assert v1 == amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
+    assert v2 == amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
 
     v1.max(v2)
     assert v1 == compare_vect
-    assert v2 == amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    assert v2 == amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
 
-    v1 = amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
-    v2 = amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    v1 = amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
+    v2 = amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
 
-    amrex.RealVect.max(v2, v1)
+    amr.RealVect.max(v2, v1)
     assert v2 == compare_vect
-    assert v1 == amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
+    assert v1 == amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_3d_min():
     # min
-    v1 = amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
-    v2 = amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    v1 = amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
+    v2 = amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
     ref_list = [0, 3, 0]
-    compare_vect = amrex.RealVect([ref_list[ii] for ii in range(amrex.Config.spacedim)])
-    v3 = amrex.min(v1, v2)
+    compare_vect = amr.RealVect([ref_list[ii] for ii in range(amr.Config.spacedim)])
+    v3 = amr.min(v1, v2)
     assert v3 == compare_vect
-    assert v1 == amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
-    assert v2 == amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    assert v1 == amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
+    assert v2 == amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
 
     v1.min(v2)
     assert v1 == compare_vect
-    assert v2 == amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    assert v2 == amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
 
-    v1 = amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
-    v2 = amrex.RealVect([3 * (2 - ii) for ii in range(amrex.Config.spacedim)])
+    v1 = amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
+    v2 = amr.RealVect([3 * (2 - ii) for ii in range(amr.Config.spacedim)])
 
-    amrex.RealVect.min(v2, v1)
+    amr.RealVect.min(v2, v1)
     assert v2 == compare_vect
-    assert v1 == amrex.RealVect([3 * ii for ii in range(amrex.Config.spacedim)])
+    assert v1 == amr.RealVect([3 * ii for ii in range(amr.Config.spacedim)])
 
 
-@pytest.mark.skipif(amrex.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_properties():
     tl = [1, -5, 4.2]
-    v1 = amrex.RealVect(tl)
+    v1 = amr.RealVect(tl)
 
     # sum
     assert np.isclose(v1.sum, sum(tl))
@@ -275,9 +275,9 @@ def test_properties():
 
 
 def test_basis_vector():
-    for ii in range(amrex.Config.spacedim):
-        ei = amrex.RealVect.BASISREALV(ii)
-        for jj in range(amrex.Config.spacedim):
+    for ii in range(amr.Config.spacedim):
+        ei = amr.RealVect.BASISREALV(ii)
+        for jj in range(amr.Config.spacedim):
             if ii == jj:
                 assert ei[jj] == 1
             else:

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -3,11 +3,11 @@
 import numpy as np
 import pytest
 
-import amrex
+import amrex.space3d as amr
 
 
 def test_soa_init():
-    soa = amrex.StructOfArrays_2_1_default()
+    soa = amr.StructOfArrays_2_1_default()
     print("--test init --")
     print("num real components", soa.NumRealComps())
     print("num int components", soa.NumIntComps())
@@ -51,9 +51,9 @@ def test_soa_init():
 
 
 def test_soa_from_tile():
-    pt = amrex.ParticleTile_1_1_2_1_default()
-    p = amrex.Particle_1_1(1.0, 2.0, 3, rdata_0=4.0, idata_1=5)
-    sp = amrex.Particle_3_2(
+    pt = amr.ParticleTile_1_1_2_1_default()
+    p = amr.Particle_1_1(1.0, 2.0, 3, rdata_0=4.0, idata_1=5)
+    sp = amr.Particle_3_2(
         5.0, 6.0, 7.0, rdata_0=8.0, rdata_1=9.0, rdata_2=10.0, idata_0=11, idata_1=12
     )
     pt.push_back(p)


### PR DESCRIPTION
Support compiling pyAMReX for multiple `AMReX_SPACEDIM` variants at once.

- [x] depends on https://github.com/AMReX-Codes/amrex/pull/3309

## Breaking Public Imports

This is a breaking change for public imports towards enabling runtime-controlled 1D, 2D or 3D imports.
The new API reads:
```py
import amrex.space3d as amr
```
and `amrex.space2d` or `amrex.space1d`, respectively.

Simulations that require multiple dimensions should try to import 3D and add AMReX APIs where missing, for lower-dimensional datasets. See `Things this does not yet solve`  in [AMReX#3309](https://github.com/AMReX-Codes/amrex/pull/3309).