### PR TITLE
IPO/LTO Control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ pyamrex_set_default_install_dirs()
 
 # Options and Variants ########################################################
 #
+option(pyAMReX_IPO
+    "Compile with interprocedural optimization (IPO) / link-time optimization (LTO)"
+    ON
+)
+
 set(pyAMReX_VERSION_INFO "" CACHE STRING
     "PEP-440 conformant version (set by distutils)")
 # change the default build type to Release (or RelWithDebInfo) instead of Debug
@@ -119,7 +124,10 @@ foreach(D IN LISTS AMReX_SPACEDIM)
 
     # link dependencies
     target_link_libraries(pyAMReX_${D}d PUBLIC AMReX::amrex_${D}d)
-    target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::module pybind11::lto pybind11::windows_extras)
+    target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::module pybind11::windows_extras)
+    if(pyAMReX_IPO)
+        target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::lto)
+    endif()
 
     # set Python module properties
     set_target_properties(pyAMReX_${D}d PROPERTIES

--- a/README.md
+++ b/README.md
@@ -177,9 +177,24 @@ If you are using the pip-driven install, selected [AMReX CMake options](https://
 | `PYBIND11_INTERNAL`          | **ON**/OFF                                 | Needs a pre-installed pybind11 library if set to `OFF`       |
 | `CMAKE_BUILD_PARALLEL_LEVEL` | 2                                          | Number of parallel build threads                             |
 | `PYAMREX_LIBDIR`             | *None*                                     | If set, search for pre-built a pyAMReX library               |
+| `PYAMREX_IPO`                | **ON**/OFF                                 | Compile with interprocedural/link optimization (IPO/LTO)     |
 | `PYINSTALLOPTIONS`           | *None*                                     | Additional options for ``pip install``, e.g., ``-v --user``  |
 
-For example, one can also build against a local AMReX copy.
+Furthermore, pyAMReX adds a few selected CMake build options:
+
+| CMake Option                 | Default & Values                           | Description                                                   |
+|------------------------------|--------------------------------------------|---------------------------------------------------------------|
+| `pyAMReX_IPO`                | **ON**/OFF                                 | Compile with interprocedural/link optimization (IPO/LTO)      |
+| `pyAMReX_amrex_src`          | *None*                                     | Absolute path to AMReX source directory (preferred if set)    |
+| `pyAMReX_amrex_internal`     | **ON**/OFF                                 | Needs a pre-installed AMReX library if set to `OFF`           |
+| `pyAMReX_amrex_repo`         | `https://github.com/AMReX-Codes/amrex.git` | Repository URI to pull and build AMReX from                   |
+| `pyAMReX_amrex_branch`       | `development`                              | Repository branch for `pyAMReX_amrex_repo`                    |
+| `pyAMReX_pybind11_src`       | *None*                                     | Absolute path to pybind11 source directory (preferred if set) |
+| `pyAMReX_pybind11_internal`  | **ON**/OFF                                 | Needs a pre-installed pybind11 library if set to `OFF`        |
+| `pyAMReX_pybind11_repo`      | `https://github.com/pybind/pybind11.git`   | Repository URI to pull and build pybind11 from                |
+| `pyAMReX_pybind11_branch`    | `v2.10.1`                                  | Repository branch for `pyAMReX_pybind11_repo`                 |
+
+As one example, one can also build against a local AMReX copy.
 Assuming AMReX' source is located in `$HOME/src/amrex`, then `export AMREX_SRC=$HOME/src/amrex`.
 
 Or as a one-liner, assuming your AMReX source directory is located in `../amrex`:

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ class CMakeBuild(build_ext):
             "-DAMReX_MPI:BOOL=" + AMReX_MPI,
             "-DAMReX_PRECISION=" + AMReX_PRECISION,
             #'-DAMReX_PARTICLES_PRECISION=' + AMReX_PARTICLES_PRECISION,
+            "-DpyAMReX_IPO=" + PYAMREX_IPO,
             ## dependency control (developers & package managers)
             "-DpyAMReX_amrex_internal=" + AMReX_internal,
             "-DpyAMReX_pybind11_internal=" + pybind11_internal,
@@ -159,6 +160,8 @@ with open("./README.md", encoding="utf-8") as f:
 #   Work-around for https://github.com/pypa/setuptools/issues/1712
 # Pick up existing AMReX libraries or...
 PYAMREX_libdir = os.environ.get("PYAMREX_LIBDIR")
+
+PYAMREX_IPO = os.environ.get("PYAMREX_IPO", "ON")
 
 # ... build AMReX libraries with CMake
 #   note: changed default for SHARED, SPACEDIM, MPI, TESTING and EXAMPLES


### PR DESCRIPTION
Although pybind11 relies heavily on IPO/LTO to create low-latency, small-binary bindings, some compilers will have troubles with that.

Thus, we add a compile-time option to optionally disable it when needed.