### PR TITLE
precommit: make sure isort output is compatible with black

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,3 +36,6 @@ indent_size = unset
 # isort config
 force_sort_within_sections = true
 known_first_party = amrex,impactx,picmistandard,pywarpx,warpx
+# same as the "black" multi-line import style
+multi_line_output = 3
+include_trailing_comma = True


### PR DESCRIPTION
It was observed recently that isort and black pre-commit filters were incompatible.  This PR adds some configuration options to make the isort output compatible with what black expects