### PR TITLE
Include pyAMReX.H & ODR Fix

### DIFF
--- a/src/AmrCore/AmrMesh.cpp
+++ b/src/AmrCore/AmrMesh.cpp
@@ -3,19 +3,17 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
-#include <AMReX_AmrMesh.H>
+#include "pyAMReX.H"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <AMReX_AmrMesh.H>
 
 #include <sstream>
 
-namespace py = pybind11;
-using namespace amrex;
 
+void init_AmrMesh(py::module &m)
+{
+    using namespace amrex;
 
-void init_AmrMesh(py::module &m) {
     py::class_< AmrInfo >(m, "AmrInfo")
         .def("__repr__",
             [](AmrInfo const & amr_info) {
@@ -75,6 +73,5 @@ void init_AmrMesh(py::module &m) {
         .def("finest_level", &AmrMesh::finestLevel)
         .def("ref_ratio", py::overload_cast< >(&AmrMesh::refRatio, py::const_))
         .def("ref_ratio", py::overload_cast< int >(&AmrMesh::refRatio, py::const_))
-
     ;
 }

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -1,15 +1,11 @@
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX.H>
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <string>
 
-namespace py = pybind11;
-using namespace amrex;
 
 namespace amrex {
    struct Config {};
@@ -17,13 +13,15 @@ namespace amrex {
 
 void init_AMReX(py::module& m)
 {
+    using namespace amrex;
+
     py::class_<AMReX>(m, "AMReX")
         .def_static("empty", &AMReX::empty)
         .def_static("size", &AMReX::size)
         .def_static("erase", &AMReX::erase)
         .def_static("top", &AMReX::top,
                     py::return_value_policy::reference)
-        ;
+    ;
 
     py::class_<Config>(m, "Config")
         .def_property_readonly_static(

--- a/src/Base/Arena.cpp
+++ b/src/Base/Arena.cpp
@@ -3,17 +3,14 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#include "pyAMReX.H"
+
 #include <AMReX_Arena.H>
-
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
-#include <pybind11/stl.h>
-
-namespace py = pybind11;
-using namespace amrex;
 
 
 void init_Arena(py::module &m) {
+    using namespace amrex;
+
     py::class_< Arena >(m, "Arena");
 
     m.def("The_Arena", &The_Arena, py::return_value_policy::reference)

--- a/src/Base/Array4.cpp
+++ b/src/Base/Array4.cpp
@@ -3,24 +3,21 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#include "pyAMReX.H"
+
 #include <AMReX_Array4.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_IntVect.H>
-
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
-#include <pybind11/stl.h>
 
 #include <cstdint>
 #include <sstream>
 #include <type_traits>
 
-namespace py = pybind11;
-using namespace amrex;
-
 
 namespace
 {
+    using namespace amrex;
+
     /** CPU: __array_interface__ v3
      *
      * https://numpy.org/doc/stable/reference/arrays.interface.html
@@ -77,6 +74,8 @@ namespace
 template< typename T >
 void make_Array4(py::module &m, std::string typestr)
 {
+    using namespace amrex;
+
     // dispatch simpler via: py::format_descriptor<T>::format() naming
     auto const array_name = std::string("Array4_").append(typestr);
     py::class_< Array4<T> >(m, array_name.c_str())

--- a/src/Base/BaseFab.cpp
+++ b/src/Base/BaseFab.cpp
@@ -3,18 +3,17 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_FArrayBox.H>
+#include "pyAMReX.H"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <AMReX_FArrayBox.H>
 
 #include <istream>
 
-namespace py = pybind11;
-using namespace amrex;
 
 namespace
 {
+    using namespace amrex;
+
     template< typename T >
     void init_bf(py::module &m, std::string typestr) {
         auto const bf_name = std::string("BaseFab_").append(typestr);
@@ -122,5 +121,7 @@ namespace
 }
 
 void init_BaseFab(py::module &m) {
+    using namespace amrex;
+
     init_bf<Real>(m, "Real");
 }

--- a/src/Base/Box.cpp
+++ b/src/Base/Box.cpp
@@ -3,22 +3,19 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H>
-
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
 
 #include <sstream>
 #include <optional>
 
-namespace py = pybind11;
-using namespace amrex;
 
 namespace
 {
+    using namespace amrex;
+
     /** A little Wrapper class to iterate an amrex::Box via
      *  amrex::Box::next().
      */
@@ -66,8 +63,9 @@ namespace
 }
 
 void init_Box(py::module &m) {
-    py::class_< Direction >(m, "Direction");
+    using namespace amrex;
 
+    py::class_< Direction >(m, "Direction");
 
 
     py::class_< Box >(m, "Box")

--- a/src/Base/BoxArray.cpp
+++ b/src/Base/BoxArray.cpp
@@ -3,20 +3,17 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_BoxArray.H>
 #include <AMReX_IntVect.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <sstream>
-
-namespace py = pybind11;
-using namespace amrex;
 
 
 void init_BoxArray(py::module &m) {
+    using namespace amrex;
+
     /* A collection of Boxes stored in an Array.  It is a
      * reference-counted concrete class, not a polymorphic one; i.e. you
      * cannot use any of the List member functions with a BoxList

--- a/src/Base/CoordSys.cpp
+++ b/src/Base/CoordSys.cpp
@@ -1,16 +1,12 @@
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_CoordSys.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
-#include <sstream>
-
-namespace py = pybind11;
-using namespace amrex;
 
 void init_CoordSys(py::module& m)
 {
+    using namespace amrex;
+
     py::class_<CoordSys> coord_sys(m, "CoordSys");
     coord_sys.def("__repr__",
              [](const CoordSys&) {

--- a/src/Base/Dim3.cpp
+++ b/src/Base/Dim3.cpp
@@ -1,16 +1,14 @@
-#include <AMReX_Config.H>
-#include <AMReX_Dim3.H>
+#include "pyAMReX.H"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <AMReX_Dim3.H>
 
 #include <sstream>
 
-namespace py = pybind11;
-using namespace amrex;
 
 void init_Dim3(py::module& m)
 {
+    using namespace amrex;
+
     py::class_<Dim3>(m, "Dim3")
         .def("__repr__",
              [](const Dim3& d) {

--- a/src/Base/DistributionMapping.cpp
+++ b/src/Base/DistributionMapping.cpp
@@ -3,21 +3,18 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_Vector.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <sstream>
-
-namespace py = pybind11;
-using namespace amrex;
 
 
 void init_DistributionMapping(py::module &m) {
+    using namespace amrex;
+
     py::class_< DistributionMapping >(m, "DistributionMapping")
         .def("__repr__",
             [](DistributionMapping const & dm) {

--- a/src/Base/FArrayBox.cpp
+++ b/src/Base/FArrayBox.cpp
@@ -3,20 +3,18 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_FArrayBox.H>
+#include "pyAMReX.H"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <AMReX_FArrayBox.H>
 
 #include <istream>
 #include <ostream>
 #include <string>
 
-namespace py = pybind11;
-using namespace amrex;
-
 
 void init_FArrayBox(py::module &m) {
+    using namespace amrex;
+
     py::class_< FArrayBox, BaseFab<Real> >(m, "FArrayBox")
         .def("__repr__",
              [](FArrayBox const & /* fab */) {

--- a/src/Base/Geometry.cpp
+++ b/src/Base/Geometry.cpp
@@ -1,22 +1,19 @@
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_Geometry.H>
 #include <AMReX_CoordSys.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_Periodicity.H>
 
-#include <pybind11/pybind11.h>
-// #include <pybind11/operators.h>
-#include <pybind11/stl.h>
-
 #include <sstream>
 #include <string>
 #include <stdexcept>
 
-namespace py = pybind11;
-using namespace amrex;
 
 void init_Geometry(py::module& m)
 {
+    using namespace amrex;
+
     py::class_<GeometryData>(m, "GeometryData")
         .def("__repr__",
             [](const GeometryData&) {

--- a/src/Base/IndexType.cpp
+++ b/src/Base/IndexType.cpp
@@ -3,21 +3,16 @@
  * Authors: David Grote
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_Dim3.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_IndexType.H>
-
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/numpy.h>
 
 #include <array>
 #include <sstream>
 #include <string>
 
-namespace py = pybind11;
-using namespace amrex;
 
 namespace {
     int check_index(const int i)
@@ -30,6 +25,8 @@ namespace {
 }
 
 void init_IndexType(py::module &m) {
+    using namespace amrex;
+
     py::class_< IndexType > index_type(m, "IndexType");
     index_type.def("__repr__",
              [](py::object& obj) {

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -3,23 +3,20 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_Dim3.H>
 #include <AMReX_IntVect.H>
-
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/numpy.h>
 
 #include <array>
 #include <sstream>
 #include <string>
 
-namespace py = pybind11;
-using namespace amrex;
 
+void init_IntVect(py::module &m)
+{
+    using namespace amrex;
 
-void init_IntVect(py::module &m) {
     py::class_< IntVect >(m, "IntVect")
         .def("__repr__",
              [](py::object& obj) {

--- a/src/Base/Iterator.H
+++ b/src/Base/Iterator.H
@@ -5,7 +5,8 @@
  */
 #pragma once
 
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_FArrayBox.H>
@@ -13,14 +14,9 @@
 #include <AMReX_FabArrayBase.H>
 #include <AMReX_MultiFab.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <memory>
 #include <string>
 
-namespace py = pybind11;
-using namespace amrex;
 
 namespace pyAMReX
 {

--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -3,9 +3,10 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#include "pyAMReX.H"
+
 #include "Base/Iterator.H"
 
-#include <AMReX_Config.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_FArrayBox.H>
@@ -13,17 +14,14 @@
 #include <AMReX_FabArrayBase.H>
 #include <AMReX_MultiFab.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <memory>
 #include <string>
 
-namespace py = pybind11;
-using namespace amrex;
 
+void init_MultiFab(py::module &m)
+{
+    using namespace amrex;
 
-void init_MultiFab(py::module &m) {
     py::class_< MFInfo >(m, "MFInfo")
         .def_readwrite("alloc", &MFInfo::alloc)
         .def_readwrite("arena", &MFInfo::arena)

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -3,21 +3,17 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
-#include <AMReX_PODVector.H>
+#include "pyAMReX.H"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
-#include <pybind11/stl.h>
+#include <AMReX_PODVector.H>
 
 #include <sstream>
 
 
-namespace py = pybind11;
-using namespace amrex;
-
 namespace
 {
+    using namespace amrex;
+
     /** CPU: __array_interface__ v3
      *
      * https://numpy.org/doc/stable/reference/arrays.interface.html
@@ -40,6 +36,8 @@ namespace
 template <class T, class Allocator = std::allocator<T> >
 void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
 {
+    using namespace amrex;
+
     using PODVector_type = PODVector<T, Allocator>;
     auto const podv_name = std::string("PODVector_").append(typestr)
                            .append("_").append(allocstr);

--- a/src/Base/ParallelDescriptor.cpp
+++ b/src/Base/ParallelDescriptor.cpp
@@ -3,27 +3,21 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_ParallelDescriptor.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
 
-#include <sstream>
-#include <optional>
+void init_ParallelDescriptor(py::module &m)
+{
+    using namespace amrex;
 
-namespace py = pybind11;
-using namespace amrex;
-
-
-void init_ParallelDescriptor(py::module &m) {
     auto mpd = m.def_submodule("ParallelDescriptor");
 
     mpd.def("NProcs", py::overload_cast<>(&ParallelDescriptor::NProcs))
        .def("MyProc", py::overload_cast<>(&ParallelDescriptor::MyProc))
        .def("IOProcessor", py::overload_cast<>(&ParallelDescriptor::IOProcessor))
        .def("IOProcessorNumber", py::overload_cast<>(&ParallelDescriptor::IOProcessorNumber))
-       ;
+   ;
     // ...
 }

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -3,23 +3,20 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_ParmParse.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-
 #include <string>
 #include <vector>
 
-namespace py = pybind11;
-using namespace amrex;
 
+void init_ParmParse(py::module &m)
+{
+    using namespace amrex;
 
-void init_ParmParse(py::module &m) {
     py::class_<ParmParse>(m, "ParmParse")
         .def("__repr__",
              [](ParmParse const &) {

--- a/src/Base/Periodicity.cpp
+++ b/src/Base/Periodicity.cpp
@@ -3,22 +3,21 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#include "pyAMReX.H"
+
 #include <AMReX_Periodicity.H>
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_SPACE.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-
 #include <ios>
 #include <sstream>
 
-namespace py = pybind11;
-using namespace amrex;
 
-void init_Periodicity(py::module &m) {
+void init_Periodicity(py::module &m)
+{
+    using namespace amrex;
+
     py::class_< Periodicity >(m, "Periodicity")
         .def("__repr__",
             [](Periodicity const & p) {

--- a/src/Base/RealBox.cpp
+++ b/src/Base/RealBox.cpp
@@ -3,7 +3,8 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_REAL.H>
@@ -12,19 +13,14 @@
 #include <AMReX_Box.H>
 #include <AMReX_RealBox.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-
 #include <array>
 #include <sstream>
 #include <string>
 #include <optional>
 
-namespace py = pybind11;
-using namespace amrex;
 
 void init_RealBox(py::module &m) {
+    using namespace amrex;
 
     py::class_< RealBox >(m, "RealBox")
         .def("__repr__",

--- a/src/Base/RealVect.cpp
+++ b/src/Base/RealVect.cpp
@@ -3,25 +3,21 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_RealBox.H>
 #include <AMReX_IntVect.H>
-
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
 
 #include <sstream>
 #include <string>
 #include <optional>
 #include <vector>
 
-namespace py = pybind11;
-using namespace amrex;
 
 void init_RealVect(py::module &m) {
+    using namespace amrex;
 
-     auto py_realvect = py::class_< RealVect>(m, "RealVect")
+    auto py_realvect = py::class_< RealVect>(m, "RealVect")
           .def("__repr__",
                [](py::object& obj) {
                     py::str py_name = obj.attr("__class__").attr("__name__");

--- a/src/Base/Utility.cpp
+++ b/src/Base/Utility.cpp
@@ -3,12 +3,12 @@
  * License: BSD-3-Clause-LBNL
  * Authors: Revathi Jambunathan, Axel Huebl
  */
-#include <AMReX_Utility.H>
-#include <pybind11/pybind11.h>
-#include <sstream>
+#include "pyAMReX.H"
 
-namespace py = pybind11;
-using namespace amrex;
+#include <AMReX_Utility.H>
+
+#include <string>
+
 
 void init_Utility(py::module& m)
 {

--- a/src/Base/Vector.cpp
+++ b/src/Base/Vector.cpp
@@ -3,13 +3,9 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
-#include <AMReX_PODVector.H>
+#include "pyAMReX.H"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/numpy.h>
-#include <pybind11/stl.h>
+#include <AMReX_PODVector.H>
 
 #include <sstream>
 #include <string>
@@ -17,11 +13,11 @@
 #include <optional>
 #include <vector>
 
-namespace py = pybind11;
-using namespace amrex;
 
 namespace
 {
+    using namespace amrex;
+
     /** CPU: __array_interface__ v3
      *
      * https://numpy.org/doc/stable/reference/arrays.interface.html
@@ -44,6 +40,8 @@ namespace
 template <class T, class Allocator = std::allocator<T> >
 void make_Vector(py::module &m, std::string typestr)
 {
+    using namespace amrex;
+
     using Vector_type = Vector<T, Allocator>;
     auto const v_name = std::string("Vector_").append(typestr);
 
@@ -97,7 +95,10 @@ void make_Vector(py::module &m, std::string typestr)
     ;
 }
 
-void init_Vector(py::module& m) {
+void init_Vector(py::module& m)
+{
+    using namespace amrex;
+
     make_Vector<Real> (m, "Real");
     if constexpr(!std::is_same_v<Real, ParticleReal>)
         make_Vector<ParticleReal> (m, "ParticleReal");

--- a/src/Particle/ArrayOfStructs.cpp
+++ b/src/Particle/ArrayOfStructs.cpp
@@ -3,20 +3,18 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_ArrayOfStructs.H>
 #include <AMReX_GpuAllocators.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <sstream>
 
-namespace py = pybind11;
-using namespace amrex;
 
 namespace
 {
+    using namespace amrex;
+
     /** CPU: __array_interface__ v3
      *
      * https://numpy.org/doc/stable/reference/arrays.interface.html
@@ -65,6 +63,8 @@ template <typename T_ParticleType,
           template<class> class Allocator=DefaultAllocator>
 void make_ArrayOfStructs(py::module &m, std::string allocstr)
 {
+    using namespace amrex;
+
     using AOSType = ArrayOfStructs<T_ParticleType, Allocator>;
     using ParticleType  = T_ParticleType;
 
@@ -124,6 +124,8 @@ void make_ArrayOfStructs(py::module &m, std::string allocstr)
 template <int NReal, int NInt>
 void make_ArrayOfStructs(py::module &m)
 {
+    using namespace amrex;
+
     // AMReX legacy AoS position + id/cpu particle ype
     using ParticleType = Particle<NReal, NInt>;
 

--- a/src/Particle/Particle.cpp
+++ b/src/Particle/Particle.cpp
@@ -3,15 +3,13 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
+#include "pyAMReX.H"
+
 #include <AMReX_Config.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_Particle.H>
-
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
 
 #include <array>
 #include <stdexcept>
@@ -22,10 +20,6 @@
 #include <cmath>
 #include <regex>
 
-
-namespace py = pybind11;
-using namespace amrex;
-using pReal = amrex_particle_real;
 
 struct PIdx
 {
@@ -56,6 +50,8 @@ namespace
 template <int T_NReal, int T_NInt=0>
 void make_Particle(py::module &m)
 {
+    using namespace amrex;
+
     using ParticleType = Particle<T_NReal, T_NInt>;
     auto const particle_name = std::string("Particle_").append(std::to_string(T_NReal) + "_" + std::to_string(T_NInt));
     py::class_<ParticleType> (m, particle_name.c_str())

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include "pyAMReX.H"
+
 #include "Base/Iterator.H"
 
 #include <AMReX_BoxArray.H>
@@ -18,13 +20,9 @@
 #include <AMReX_ParticleTile.H>
 #include <AMReX_ArrayOfStructs.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <string>
 #include <sstream>
 
-namespace py = pybind11;
 
 template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0>
 std::string particle_type_suffix ()
@@ -46,6 +44,8 @@ std::string particle_type_suffix ()
 template <bool is_const, typename T_ParIterBase>
 void make_Base_Iterators (py::module &m, std::string allocstr)
 {
+    using namespace amrex;
+
     using iterator_base = T_ParIterBase;
     using container = typename iterator_base::ContainerType;
     using ParticleType = typename container::ParticleType;
@@ -95,9 +95,11 @@ void make_Base_Iterators (py::module &m, std::string allocstr)
                        py::return_value_policy::reference_internal);
 }
 
-template <bool is_const, typename T_ParIter, template<class> class Allocator=DefaultAllocator>
+template <bool is_const, typename T_ParIter, template<class> class Allocator=amrex::DefaultAllocator>
 void make_Iterators (py::module &m, std::string allocstr)
 {
+    using namespace amrex;
+
     using iterator = T_ParIter;
     using container = typename iterator::ContainerType;
     using ParticleType = typename container::ParticleType;
@@ -130,6 +132,8 @@ void make_Iterators (py::module &m, std::string allocstr)
 
 template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0>
 void make_ParticleInitData (py::module &m) {
+    using namespace amrex;
+
     using ParticleType = T_ParticleType;
     using ParticleInitData = ParticleInitType<ParticleType::NReal, ParticleType::NInt, T_NArrayReal, T_NArrayInt>;
     // depends on https://github.com/AMReX-Codes/amrex/pull/3280
@@ -153,9 +157,11 @@ void make_ParticleInitData (py::module &m) {
 }
 
 template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0,
-          template<class> class Allocator=DefaultAllocator>
+          template<class> class Allocator=amrex::DefaultAllocator>
 void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
 {
+    using namespace amrex;
+
     using ParticleType = T_ParticleType;
     using ParticleContainerType = ParticleContainer_impl<
         ParticleType, T_NArrayReal, T_NArrayInt,

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -3,27 +3,25 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_BoxArray.H>
 #include <AMReX_GpuAllocators.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_ParticleTile.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <sstream>
 
-
-namespace py = pybind11;
-using namespace amrex;
 
 //Forward declaration
 template <int T_NReal, int T_NInt=0>
 void make_Particle(py::module &m);
 
 template <typename T_ParticleType, int NArrayReal, int NArrayInt>
-void make_ParticleTileData(py::module &m) {
+void make_ParticleTileData(py::module &m)
+{
+    using namespace amrex;
+
     using ParticleType = T_ParticleType;
     constexpr int NStructReal = ParticleType::NReal;
     constexpr int NStructInt = ParticleType::NInt;
@@ -52,9 +50,11 @@ void make_ParticleTileData(py::module &m) {
 }
 
 template <typename T_ParticleType, int NArrayReal, int NArrayInt,
-          template<class> class Allocator=DefaultAllocator>
+          template<class> class Allocator=amrex::DefaultAllocator>
 void make_ParticleTile(py::module &m, std::string allocstr)
 {
+    using namespace amrex;
+
     using ParticleType = T_ParticleType;
     constexpr int NStructReal = ParticleType::NReal;
     constexpr int NStructInt = ParticleType::NInt;
@@ -163,6 +163,8 @@ void make_ParticleTile(py::module &m)
 }
 
 void init_ParticleTile(py::module& m) {
+    using namespace amrex;
+
     // AMReX legacy AoS position + id/cpu particle ype
     using ParticleType_0_0 = Particle<0, 0>;
     using ParticleType_1_1 = Particle<1, 1>;

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -3,23 +3,20 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
+#include "pyAMReX.H"
+
 #include <AMReX_GpuAllocators.H>
 #include <AMReX_StructOfArrays.H>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <sstream>
-
-namespace py = pybind11;
-using namespace amrex;
 
 
 template <int NReal, int NInt,
-          template<class> class Allocator=DefaultAllocator>
+          template<class> class Allocator=amrex::DefaultAllocator>
 void make_StructOfArrays(py::module &m, std::string allocstr)
 {
+    using namespace amrex;
+
     using SOAType = StructOfArrays<NReal, NInt, Allocator>;
 
     auto const soa_name = std::string("StructOfArrays_") + std::to_string(NReal) + "_" +

--- a/src/pyAMReX.H
+++ b/src/pyAMReX.H
@@ -1,0 +1,21 @@
+/* Copyright 2021-2023 The AMReX Community
+ *
+ * This header is used to centrally define classes that shall not violate the
+ * C++ one-definition-rule (ODR) for various Python translation units.
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+#include <AMReX_Config.H>
+//include <AMReX.H>
+
+namespace py = pybind11;
+
+//PYBIND11_MAKE_OPAQUE(std::list<...>)

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -3,16 +3,12 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
-#include <AMReX_Config.H>
-#include <AMReX.H>
+#include "pyAMReX.H"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <AMReX.H>
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
-
-namespace py = pybind11;
 
 
 // forward declarations of exposed classes


### PR DESCRIPTION
We provide a single helper include now for all pyAMReX compilation units (TUs) / cpp files.

This ensures that optional pybind11 includes, e.g., for stl, numpy, functions and operators, are consistently present in all TUs. This is required to avoid C++ one-definition-rule (ODR) violations, which are undefined behavior and thus could cause instabilities down the road.