### PR TITLE
Wrapper for writing single level plotfile

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
         ParallelDescriptor.cpp
         ParmParse.cpp
         Periodicity.cpp
+        PlotFileUtil.cpp
         PODVector.cpp
         Utility.cpp
         Vector.cpp

--- a/src/Base/PlotFileUtil.cpp
+++ b/src/Base/PlotFileUtil.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2021-2022 The AMReX Community
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_PlotFileUtil.H>
+#include <AMReX_Vector.H>
+#include <AMReX_Print.H>
+
+#include <sstream>
+#include <string>
+
+namespace py = pybind11;
+using namespace amrex;
+
+void init_PlotFileUtil(py::module& m)
+{
+    m.def("write_single_level_plotfile",
+          &amrex::WriteSingleLevelPlotfile,
+          "Writes single level plotfile",
+          py::arg("plotfilename"),
+          py::arg("mf"),
+          py::arg("varnames"),
+          py::arg("geom"),
+          py::arg("time"),
+          py::arg("level_step"),
+          py::arg("versionName")="HyperCLaw-V1.1",
+          py::arg("levelPrefix")="Level_",
+          py::arg("mfPrefix")="Cell",
+          py::arg("extra_dirs")=Vector<std::string>()
+    );
+}

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -37,6 +37,7 @@ void init_ArrayOfStructs(py::module &);
 void init_ParticleTile(py::module &);
 void init_ParticleContainer(py::module &);
 void init_Periodicity(py::module &);
+void init_PlotFileUtil(py::module &);
 void init_PODVector(py::module &);
 void init_Utility(py::module &);
 void init_Vector(py::module &);
@@ -77,6 +78,7 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
                ParticleTile
                ParticleContainer
                Periodicity
+               PlotFileUtil
                PODVector
                StructOfArrays
                Utility
@@ -113,6 +115,7 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     init_AmrMesh(m);
 
     // Wrappers around standalone functions
+    init_PlotFileUtil(m);
     init_Utility(m);
 
     // API runtime version


### PR DESCRIPTION
This PR includes a wrapper for single level plotfile. We also include a constructor for Vector so that we can pass a vector of strings when calling the plotfile function.

Thanks you @EZoni @ax3l @atmyers @oshapoval for the teamwork!

Note : This is build on top of branch that wraps FillBoundary. So please merge #154 before this PR

The implementation is tested in [this PR ](https://github.com/AMReX-Codes/amrex-tutorials/pull/96)

