### PR TITLE
CMake: Warnings on AppleClang

### DIFF
--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -206,6 +206,8 @@ macro(set_cxx_warnings)
 
         #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code")
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wunreachable-code")
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")


### PR DESCRIPTION
Duplicate from Clang, so our AppleClang based developers get a nice set of warnings that we enforce as well.