### PR TITLE
Add amrex::Print() Like Function

### DIFF
--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -32,3 +32,9 @@ __author__ = amrex_1d_pybind.__author__
 #
 def d_decl(x, y, z):
     return (x,)
+
+
+def Print(*args, **kwargs):
+    """Wrap amrex::Print() - only the IO processor writes"""
+    if ParallelDescriptor.IOProcessor():
+        print(*args, **kwargs)

--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -36,5 +36,8 @@ def d_decl(x, y, z):
 
 def Print(*args, **kwargs):
     """Wrap amrex::Print() - only the IO processor writes"""
-    if ParallelDescriptor.IOProcessor():
+    if not initialized():
+        print("warning: Print all - AMReX not initialized")
+        print(*args, **kwargs)
+    elif ParallelDescriptor.IOProcessor():
         print(*args, **kwargs)

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -36,5 +36,8 @@ def d_decl(x, y, z):
 
 def Print(*args, **kwargs):
     """Wrap amrex::Print() - only the IO processor writes"""
-    if ParallelDescriptor.IOProcessor():
+    if not initialized():
+        print("warning: Print all - AMReX not initialized")
+        print(*args, **kwargs)
+    elif ParallelDescriptor.IOProcessor():
         print(*args, **kwargs)

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -32,3 +32,9 @@ __author__ = amrex_2d_pybind.__author__
 #
 def d_decl(x, y, z):
     return (x, y)
+
+
+def Print(*args, **kwargs):
+    """Wrap amrex::Print() - only the IO processor writes"""
+    if ParallelDescriptor.IOProcessor():
+        print(*args, **kwargs)

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -32,3 +32,9 @@ __author__ = amrex_3d_pybind.__author__
 #
 def d_decl(x, y, z):
     return (x, y, z)
+
+
+def Print(*args, **kwargs):
+    """Wrap amrex::Print() - only the IO processor writes"""
+    if ParallelDescriptor.IOProcessor():
+        print(*args, **kwargs)

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -36,5 +36,8 @@ def d_decl(x, y, z):
 
 def Print(*args, **kwargs):
     """Wrap amrex::Print() - only the IO processor writes"""
-    if ParallelDescriptor.IOProcessor():
+    if not initialized():
+        print("warning: Print all - AMReX not initialized")
+        print(*args, **kwargs)
+    elif ParallelDescriptor.IOProcessor():
         print(*args, **kwargs)

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -6,3 +6,8 @@ import amrex.space3d as amr
 def test_concatenate():
     pltname = amr.concatenate("plt", 1000, 5)
     assert pltname == "plt01000"
+
+
+def test_print():
+    print("hello from everyone")
+    amr.Print("byeee from IO processor")


### PR DESCRIPTION
Add `amr.Print(...)` that behaves like Python's `print()`, but only prints on the AMReX IOProcessor.

- [x] add a test