### PR TITLE
Fix Include Guard in `pyAMReX.H`

### DIFF
--- a/src/pyAMReX.H
+++ b/src/pyAMReX.H
@@ -6,6 +6,8 @@
  * Authors: Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#pragma once
+
 #include <pybind11/pybind11.h>
 #include <pybind11/functional.h>
 #include <pybind11/numpy.h>


### PR DESCRIPTION
Every header needs an include guard to avoid duplicate definitions as this file grows with more content.

(not a visible bug *yet*)