### PR TITLE
pytest: Temporary Working Directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import itertools
+import os
 
 import pytest
 
@@ -17,6 +18,9 @@ except ImportError:
 
 if amr.Config.have_mpi:
     from mpi4py import MPI
+
+# base path for input files
+basepath = os.getcwd()
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,20 +20,21 @@ if amr.Config.have_mpi:
 
 
 @pytest.fixture(autouse=True, scope="function")
-def amrex_init():
-    amr.initialize(
-        [
-            # print AMReX status messages
-            "amrex.verbose=2",
-            # throw exceptions and create core dumps instead of
-            # AMReX backtrace files: allows to attach to
-            # debuggers
-            "amrex.throw_exception=1",
-            "amrex.signal_handling=0",
-            # abort GPU runs if out-of-memory instead of swapping to host RAM
-            # "abort_on_out_of_gpu_memory=1",
-        ]
-    )
+def amrex_init(tmpdir):
+    with tmpdir.as_cwd():
+        amr.initialize(
+            [
+                # print AMReX status messages
+                "amrex.verbose=2",
+                # throw exceptions and create core dumps instead of
+                # AMReX backtrace files: allows to attach to
+                # debuggers
+                "amrex.throw_exception=1",
+                "amrex.signal_handling=0",
+                # abort GPU runs if out-of-memory instead of swapping to host RAM
+                # "abort_on_out_of_gpu_memory=1",
+            ]
+        )
     yield
     amr.finalize()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,8 @@ def amrex_init(tmpdir):
                 # "abort_on_out_of_gpu_memory=1",
             ]
         )
-    yield
-    amr.finalize()
+        yield
+        amr.finalize()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Tests can generate temporary output and directories, which might clash and/or need cleaning between tests.

This changes the current working directory to a unique directory per test.