### PR TITLE
pybind11-stubgen: submodule path in 2.0.1

### DIFF
--- a/.github/update_stub.sh
+++ b/.github/update_stub.sh
@@ -13,6 +13,6 @@ set -eu -o pipefail
 # we are in the source directory, .github/
 this_dir=$(cd $(dirname $0) && pwd)
 
-pybind11-stubgen --exit-code -o ${this_dir}/../src/amrex/ amrex.space1d
-pybind11-stubgen --exit-code -o ${this_dir}/../src/amrex/ amrex.space2d
-pybind11-stubgen --exit-code -o ${this_dir}/../src/amrex/ amrex.space3d
+pybind11-stubgen --exit-code -o ${this_dir}/../src/ amrex.space1d
+pybind11-stubgen --exit-code -o ${this_dir}/../src/ amrex.space2d
+pybind11-stubgen --exit-code -o ${this_dir}/../src/ amrex.space3d


### PR DESCRIPTION
Update the stub generator to account for a bugfix in 2.0.1+

x-ref:
- https://github.com/sizmailov/pybind11-stubgen/pull/136
- https://github.com/sizmailov/pybind11-stubgen/issues/135