### PR TITLE
CI: Windows Clang-Cl w/ CCache

### DIFF
--- a/.github/ci/vcvarsall.ps1
+++ b/.github/ci/vcvarsall.ps1
@@ -1,0 +1,12 @@
+# https://discourse.cmake.org/t/how-to-configure-cmake-on-windows-to-use-clang-cl-with-ninja-multi-config-for-intel-32-bits-intel-64-bits-and-arm64-coming-from-visual-studio/3430/10
+# https://gitlab.kitware.com/cmake/cmake/-/blob/master/.gitlab/ci/vcvarsall.ps1
+
+$erroractionpreference = "stop"
+
+cmd /c "`"$env:VCVARSALL`" $env:VCVARSPLATFORM -vcvars_ver=$env:VCVARSVERSION & set" |
+foreach {
+    if ($_ -match "=") {
+        $v = $_.split("=")
+        [Environment]::SetEnvironmentVariable($v[0], $v[1])
+    }
+}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
 
   clang:
     name: Clang w/o MPI shared debug
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v3
@@ -41,15 +41,22 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build
       run: |
+        $Env:VCVARSALL = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat"
+        $Env:VCVARSPLATFORM = "x64"
+        $Env:VCVARSVERSION = "14.36"
+        Invoke-Expression -Command .github/ci/vcvarsall.ps1
+
         python3 -m pip install -U pip setuptools wheel pytest
         python3 -m pip install -U cmake
         python3 -m pip install -r requirements.txt
 
-        cmake -S . -B build               `
-              -T "ClangCl"                `
-              -DCMAKE_VERBOSE_MAKEFILE=ON `
-              -DBUILD_SHARED_LIBS=ON      `
-              -DAMReX_MPI=OFF             `
+        cmake -S . -B build                 `
+              -G "Ninja"                    `
+              -DCMAKE_C_COMPILER=clang-cl   `
+              -DCMAKE_CXX_COMPILER=clang-cl `
+              -DCMAKE_VERBOSE_MAKEFILE=ON   `
+              -DBUILD_SHARED_LIBS=ON        `
+              -DAMReX_MPI=OFF               `
               -DAMReX_SPACEDIM="1;2;3"
         if(!$?) { Exit $LASTEXITCODE }
 


### PR DESCRIPTION
Follow-up to #188

- [ ] Windows Clang-Cl: Powershell & Ninja
- [ ] CCache

We cannot add ccache support for the other build, since [the VS Generator is not (yet) supported with CMake's CCache logic](https://github.com/AMReX-Codes/pyamrex/pull/188#issuecomment-1710652115).