### PR TITLE
CI: Add `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,17 +86,6 @@ repos:
   - id: isort
     name: isort (python)
 
-# Python: Flake8 (checks only, does this support auto-fixes?)
-#- repo: https://github.com/PyCQA/flake8
-#  rev: 4.0.1
-#  hooks:
-#  - id: flake8
-#    additional_dependencies: &flake8_dependencies
-#      - flake8-bugbear
-#      - pep8-naming
-#    exclude: ^(docs/.*|tools/.*)$
-# Alternatively: use autopep8?
-
 # Python Formatting
 - repo: https://github.com/psf/black
   rev: 23.9.1 # Keep in sync with blacken-docs
@@ -109,6 +98,26 @@ repos:
     additional_dependencies:
     - black==23.9.1 # keep in sync with black hook
   # TODO: black-jupyter
+
+# Python: Ruff linter
+#   https://docs.astral.sh/ruff/
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.0
+  hooks:
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
+      types_or: [python, jupyter]
+
+# Python: Flake8 (only for pyflake and bugbear)
+#   Ruff above is faster
+#- repo: https://github.com/PyCQA/flake8
+#  rev: 6.1.0
+#  hooks:
+#  - id: flake8
+#    additional_dependencies: &flake8_dependencies
+#      - flake8-bugbear
+#      - Flake8-pyproject
+#    exclude: ^(docs/.*|tools/.*)$
 
 # Jupyter Notebooks: clean up all cell outputs
 - repo: https://github.com/roy-ht/pre-commit-jupyter

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -212,7 +212,7 @@ if os.path.exists(dst_path) and os.path.isdir(dst_path):
     shutil.rmtree(dst_path)
 shutil.copytree(src_path, dst_path)
 
-for subdir, dirs, files in os.walk(dst_path):
+for subdir, _dirs, files in os.walk(dst_path):
     for f in files:
         if f.find(".pyi") > 0:
             dir_path = os.path.relpath(subdir, dst_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,14 @@ requires = [
     "cmake>=3.20.0,<4.0.0"
 ]
 build-backend = "setuptools.build_meta"
+
+
+[tool.flake8]
+#ignore = ['E231', 'E241']
+select = ['F', 'B']
+
+
+[tool.ruff]
+# https://docs.astral.sh/ruff/
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E402"]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -132,7 +132,7 @@ def test_periodicity(geometry):
     gm = geometry
     bx = gm.Domain()
 
-    for non_periodic_coord in [0, 1]:
+    for _non_periodic_coord in [0, 1]:
         error_thrown = False
         try:
             gm.period(0)

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -150,7 +150,7 @@ def test_mfab_mfiter(make_mfab):
     assert iter(mfab).length == 8
 
     cnt = 0
-    for mfi in mfab:
+    for _mfi in mfab:
         cnt += 1
 
     assert iter(mfab).length == cnt

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -262,6 +262,7 @@ def test_per_cell(empty_particle_container, std_geometry, std_particle):
 
     sum_1 = 0
     for tile_ind, pt in lev.items():
+        print("tile", tile_ind)
         real_arrays = pt.GetStructOfArrays().GetRealData()
         sum_1 += np.sum(real_arrays[1])
     print(sum_1)


### PR DESCRIPTION
This adds [ruff](https://github.com/astral-sh/ruff) for Python code linting in pre-commits.

~~This is performed via `flake8 --select=F`, skipping all other stylistic checks of flake8 (which we perform with other tools such as black and isort). Also, `flake8` supports `...  # noqa` annotations to [silence warnings](https://github.com/PyCQA/pyflakes/issues/431) from `pyflakes`.~~