### PR TITLE
Fix: Pinned Allocators First

### DIFF
--- a/src/Particle/ArrayOfStructs.cpp
+++ b/src/Particle/ArrayOfStructs.cpp
@@ -137,7 +137,7 @@ void make_ArrayOfStructs(py::module &m, std::string allocstr)
         .def("__getitem__", [](AOSType &aos, int const v){ return aos[v]; }, py::return_value_policy::reference)
 
         .def("to_host", [](AOSType const & aos) {
-            ArrayOfStructs<T_ParticleType, std::allocator> h_data;
+            ArrayOfStructs<T_ParticleType, amrex::PinnedArenaAllocator> h_data;
             h_data.resize(aos.size());
             //py::array_t<T_ParticleType> h_data(aos.size());
             amrex::Gpu::copy(amrex::Gpu::deviceToHost,
@@ -158,6 +158,9 @@ void make_ArrayOfStructs(py::module &m)
     // AMReX legacy AoS position + id/cpu particle ype
     using ParticleType = Particle<NReal, NInt>;
 
+    // first, because used as copy target in methods in containers with other allocators
+    make_ArrayOfStructs<ParticleType, amrex::PinnedArenaAllocator> (m, "pinned");
+
     // see Src/Base/AMReX_GpuContainers.H
     //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
     //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
@@ -173,7 +176,6 @@ void make_ArrayOfStructs(py::module &m)
     make_ArrayOfStructs<ParticleType, amrex::ArenaAllocator> (m, "arena");
 #endif
     //   end work-around
-    make_ArrayOfStructs<ParticleType, amrex::PinnedArenaAllocator> (m, "pinned");
 #ifdef AMREX_USE_GPU
     make_ArrayOfStructs<ParticleType, amrex::DeviceArenaAllocator> (m, "device");
     make_ArrayOfStructs<ParticleType, amrex::ManagedArenaAllocator> (m, "managed");

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -394,6 +394,10 @@ void make_ParticleContainer_and_Iterators (py::module &m)
     if constexpr (!T_ParticleType::is_soa_particle)
         make_ParticleInitData<T_ParticleType, T_NArrayReal, T_NArrayInt>(m);
 
+    // first, because used as copy target in methods in containers with other allocators
+    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+            amrex::PinnedArenaAllocator>(m, "pinned");
+
     // see Src/Base/AMReX_GpuContainers.H
     //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
     //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
@@ -415,8 +419,6 @@ void make_ParticleContainer_and_Iterators (py::module &m)
             amrex::ArenaAllocator>(m, "arena");
 #endif
     //   end work-around
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-            amrex::PinnedArenaAllocator>(m, "pinned");
 #ifdef AMREX_USE_GPU
     make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
                                          amrex::DeviceArenaAllocator>(m, "device");

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -143,6 +143,10 @@ void make_ParticleTile(py::module &m)
         make_ParticleTileData<T_ParticleType, NArrayReal, NArrayInt>(m);
     }
 
+    // first, because used as copy target in methods in containers with other allocators
+    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                      amrex::PinnedArenaAllocator>(m, "pinned");
+
     // see Src/Base/AMReX_GpuContainers.H
     //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
     //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
@@ -164,8 +168,6 @@ void make_ParticleTile(py::module &m)
                       amrex::ArenaAllocator>(m, "arena");
 #endif
     //   end work-around
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::PinnedArenaAllocator>(m, "pinned");
 #ifdef AMREX_USE_GPU
     make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
                       amrex::DeviceArenaAllocator>(m, "device");

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -62,6 +62,9 @@ void make_StructOfArrays(py::module &m, std::string allocstr)
 template <int NReal, int NInt>
 void make_StructOfArrays(py::module &m)
 {
+    // first, because used as copy target in methods in containers with other allocators
+    make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator>(m, "pinned");
+
     // see Src/Base/AMReX_GpuContainers.H
     //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
     //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
@@ -77,7 +80,6 @@ void make_StructOfArrays(py::module &m)
     make_StructOfArrays<NReal, NInt, amrex::ArenaAllocator>(m, "arena");
 #endif
     //   end work-around
-    make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator>(m, "pinned");
 #ifdef AMREX_USE_GPU
     make_StructOfArrays<NReal, NInt, amrex::DeviceArenaAllocator>(m, "device");
     make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator>(m, "managed");

--- a/src/amrex/space1d/amrex_1d_pybind/__init__.pyi
+++ b/src/amrex/space1d/amrex_1d_pybind/__init__.pyi
@@ -2773,7 +2773,7 @@ class ArrayOfStructs_0_0_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2845,7 +2845,7 @@ class ArrayOfStructs_0_0_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2917,7 +2917,7 @@ class ArrayOfStructs_0_0_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2989,7 +2989,7 @@ class ArrayOfStructs_1_1_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3061,7 +3061,7 @@ class ArrayOfStructs_1_1_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3133,7 +3133,7 @@ class ArrayOfStructs_1_1_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3205,7 +3205,7 @@ class ArrayOfStructs_2_1_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3277,7 +3277,7 @@ class ArrayOfStructs_2_1_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3349,7 +3349,7 @@ class ArrayOfStructs_2_1_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 

--- a/src/amrex/space2d/amrex_2d_pybind/__init__.pyi
+++ b/src/amrex/space2d/amrex_2d_pybind/__init__.pyi
@@ -2773,7 +2773,7 @@ class ArrayOfStructs_0_0_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2845,7 +2845,7 @@ class ArrayOfStructs_0_0_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2917,7 +2917,7 @@ class ArrayOfStructs_0_0_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2989,7 +2989,7 @@ class ArrayOfStructs_1_1_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3061,7 +3061,7 @@ class ArrayOfStructs_1_1_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3133,7 +3133,7 @@ class ArrayOfStructs_1_1_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3205,7 +3205,7 @@ class ArrayOfStructs_2_1_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3277,7 +3277,7 @@ class ArrayOfStructs_2_1_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3349,7 +3349,7 @@ class ArrayOfStructs_2_1_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 

--- a/src/amrex/space3d/amrex_3d_pybind/__init__.pyi
+++ b/src/amrex/space3d/amrex_3d_pybind/__init__.pyi
@@ -2773,7 +2773,7 @@ class ArrayOfStructs_0_0_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2845,7 +2845,7 @@ class ArrayOfStructs_0_0_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2917,7 +2917,7 @@ class ArrayOfStructs_0_0_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_0_0_default: ...
+    def to_host(self) -> ArrayOfStructs_0_0_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -2989,7 +2989,7 @@ class ArrayOfStructs_1_1_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3061,7 +3061,7 @@ class ArrayOfStructs_1_1_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3133,7 +3133,7 @@ class ArrayOfStructs_1_1_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_1_1_default: ...
+    def to_host(self) -> ArrayOfStructs_1_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3205,7 +3205,7 @@ class ArrayOfStructs_2_1_arena:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3277,7 +3277,7 @@ class ArrayOfStructs_2_1_default:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 
@@ -3349,7 +3349,7 @@ class ArrayOfStructs_2_1_pinned:
             Raises an exception if cupy is not installed
 
         """
-    def to_host(self) -> ArrayOfStructs_2_1_default: ...
+    def to_host(self) -> ArrayOfStructs_2_1_pinned: ...
     def to_numpy(self, copy=False):
         """
 


### PR DESCRIPTION
They are used in methods that copy from device to host and thus need to be known first, before other allocator flavors.

This should help with the first issue in #207

Introduced in #196 #192 #88 #55