### PR TITLE
Tests: Managed Memory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ def amrex_init(tmpdir):
                 "amrex.signal_handling=0",
                 # abort GPU runs if out-of-memory instead of swapping to host RAM
                 # "abort_on_out_of_gpu_memory=1",
+                # the arena for GPU runs defaults to managed
+                "amrex.the_arena_is_managed=1",
             ]
         )
         yield


### PR DESCRIPTION
Recently, AMReX' default changed away from defaulting the `Arena` to managed memory. Some of our tests still rely on it, so we keep the old default for now until #122.