### PR TITLE
pytest: support non-top level dirs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import itertools
-import os
+from pathlib import Path
 
 import pytest
 
@@ -21,7 +21,7 @@ if amr.Config.have_mpi:
     from mpi4py import MPI  # noqa
 
 # base path for input files
-basepath = os.getcwd()
+basepath = Path(__file__).parent
 
 
 @pytest.fixture(autouse=True, scope="function")


### PR DESCRIPTION
Generalize `basepath` to support running from any directory.

Follow-up to #181

X-ref https://github.com/ECP-WarpX/impactx/commit/476baddf2bc3b1f5e3ad7489de39ffa83c979fbc#r125869050\

- [ ] wait for https://github.com/ECP-WarpX/impactx/pull/445