### PR TITLE
CMake: `pyAMReX_INSTALL`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ option(pyAMReX_IPO
     "Compile with interprocedural optimization (IPO) / link-time optimization (LTO)"
     ON
 )
+option(pyAMReX_INSTALL
+    "Enable install targets for pyAMReX"
+    ON
+)
 
 # change the default build type to Release (or RelWithDebInfo) instead of Debug
 set_default_build_type("Release")
@@ -219,26 +223,28 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     set(pyAMReX_INSTALL_TARGET_NAMES ${pyAMReX_INSTALL_TARGET_NAMES} pyAMReX_${D}d)
 endforeach()
 
-install(TARGETS ${pyAMReX_INSTALL_TARGET_NAMES}
-    EXPORT pyAMReXTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+if(pyAMReX_INSTALL)
+    install(TARGETS ${pyAMReX_INSTALL_TARGET_NAMES}
+        EXPORT pyAMReXTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 
-# CMake package file for find_package(pyAMReX) in depending projects
-install(EXPORT pyAMReXTargets
-    FILE pyAMReXTargets.cmake
-    NAMESPACE pyAMReX::
-    DESTINATION ${pyAMReX_INSTALL_CMAKEDIR}
-)
-install(
-    FILES
-        ${pyAMReX_BINARY_DIR}/pyAMReXConfig.cmake
-        ${pyAMReX_BINARY_DIR}/pyAMReXConfigVersion.cmake
-    DESTINATION ${pyAMReX_INSTALL_CMAKEDIR}
-)
+    # CMake package file for find_package(pyAMReX) in depending projects
+    install(EXPORT pyAMReXTargets
+        FILE pyAMReXTargets.cmake
+        NAMESPACE pyAMReX::
+        DESTINATION ${pyAMReX_INSTALL_CMAKEDIR}
+    )
+    install(
+        FILES
+            ${pyAMReX_BINARY_DIR}/pyAMReXConfig.cmake
+            ${pyAMReX_BINARY_DIR}/pyAMReXConfigVersion.cmake
+        DESTINATION ${pyAMReX_INSTALL_CMAKEDIR}
+    )
+endif()
 
 
 # pip helpers for the amrex package ###########################################

--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ Furthermore, pyAMReX adds a few selected CMake build options:
 
 | CMake Option                 | Default & Values                           | Description                                                   |
 |------------------------------|--------------------------------------------|---------------------------------------------------------------|
-| `AMReX_SPACEDIM`             | **3**, use `"1;2;3"` for all               | Dimension(s) of AMReX as a ``;``-separated list              |
+| `AMReX_SPACEDIM`             | **3**, use `"1;2;3"` for all               | Dimension(s) of AMReX as a ``;``-separated list               |
 | `pyAMReX_IPO`                | **ON**/OFF                                 | Compile with interprocedural/link optimization (IPO/LTO)      |
+| `pyAMReX_INSTALL`            | **ON**/OFF                                 | Enable install targets for pyAMReX                            |
 | `pyAMReX_amrex_src`          | *None*                                     | Absolute path to AMReX source directory (preferred if set)    |
 | `pyAMReX_amrex_internal`     | **ON**/OFF                                 | Needs a pre-installed AMReX library if set to `OFF`           |
 | `pyAMReX_amrex_repo`         | `https://github.com/AMReX-Codes/amrex.git` | Repository URI to pull and build AMReX from                   |

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -91,6 +91,7 @@ CMake Option                    Default & Values                             Des
 ``AMReX_SPACEDIM``              ``3``                                        Dimension(s) of AMReX as a ``;``-separated list
 ``AMReX_BUILD_SHARED_LIBS``     ON/**OFF**                                   Build AMReX library as shared (required for app extensions)
 ``pyAMReX_IPO``                 **ON**/OFF                                   Compile with interprocedural/link optimization (IPO/LTO)
+``pyAMReX_INSTALL``             **ON**/OFF                                   Enable install targets for pyAMReX
 ``PYINSTALLOPTIONS``            *None*                                       Additional options for ``pip install``, e.g., ``-v --user``
 ``Python_EXECUTABLE``           (newest found)                               Path to Python executable
 =============================== ============================================ ===========================================================


### PR DESCRIPTION
Control if install targets are generated. Mostly in symmetry to `AMReX_INSTALL`.