### PR TITLE
WarpX Pure SoA in RZ

### DIFF
--- a/src/Particle/Particle.cpp
+++ b/src/Particle/Particle.cpp
@@ -327,8 +327,8 @@ void init_Particle(py::module& m) {
     make_Particle< 3, 2 > (m);
     make_Particle< 4, 0 > (m);  // HiPACE++ 22.07
     make_Particle< 5, 0 > (m);  // ImpactX 22.07
-    make_Particle< 6, 0 > (m);  // WarpX 24.01+
-    //make_Particle< 7, 0 > (m);  // WarpX 24.01+
-    make_Particle< 8, 0 > (m);  // ImpactX 24.01+
+    make_Particle< 6, 0 > (m);  // WarpX 24.02+
+    //make_Particle< 7, 0 > (m);  // WarpX 24.02+
+    make_Particle< 8, 0 > (m);  // ImpactX 24.02+
     make_Particle< 37, 1> (m);  // HiPACE++ 22.07
 }

--- a/src/Particle/ParticleContainer_WarpX.cpp
+++ b/src/Particle/ParticleContainer_WarpX.cpp
@@ -20,6 +20,7 @@ void init_ParticleContainer_WarpX(py::module& m) {
     make_ParticleContainer_and_Iterators<SoAParticle<5, 0>, 5, 0>(m);  // WarpX 24.02+ 1D
 #elif AMREX_SPACEDIM == 2
     make_ParticleContainer_and_Iterators<SoAParticle<6, 0>, 6, 0>(m);  // WarpX 24.02+ 2D
+    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m);  // WarpX 24.02+ RZ
 #elif AMREX_SPACEDIM == 3
     make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m);  // WarpX 24.02+ 3D
 #endif

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -198,6 +198,7 @@ void init_ParticleTile(py::module& m) {
     using SoAParticleType_5_0 = SoAParticle<5, 0>;
 #elif AMREX_SPACEDIM == 2
     using SoAParticleType_6_0 = SoAParticle<6, 0>;
+    using SoAParticleType_7_0 = SoAParticle<7, 0>;
 #elif AMREX_SPACEDIM == 3
     using SoAParticleType_7_0 = SoAParticle<7, 0>;
 #endif
@@ -209,12 +210,13 @@ void init_ParticleTile(py::module& m) {
     make_ParticleTile<ParticleType_0_0, 4, 0> (m);   // HiPACE++ 22.07
     make_ParticleTile<ParticleType_0_0, 5, 0> (m);   // ImpactX 22.07
 #if AMREX_SPACEDIM == 1
-    make_ParticleTile<SoAParticleType_5_0, 5, 0> (m);   // WarpX 24.01+ 1D
+    make_ParticleTile<SoAParticleType_5_0, 5, 0> (m);   // WarpX 24.02+ 1D
 #elif AMREX_SPACEDIM == 2
-    make_ParticleTile<SoAParticleType_6_0, 6, 0> (m);   // WarpX 24.01+ 2D
+    make_ParticleTile<SoAParticleType_6_0, 6, 0> (m);   // WarpX 24.02+ 2D
+    make_ParticleTile<SoAParticleType_7_0, 7, 0> (m);   // WarpX 24.02+ RZ
 #elif AMREX_SPACEDIM == 3
-    make_ParticleTile<SoAParticleType_7_0, 7, 0> (m);   // WarpX 24.01+ 3D
+    make_ParticleTile<SoAParticleType_7_0, 7, 0> (m);   // WarpX 24.02+ 3D
 #endif
-    make_ParticleTile<SoAParticleType_8_0, 8, 0> (m);   // ImpactX 24.01+
+    make_ParticleTile<SoAParticleType_8_0, 8, 0> (m);   // ImpactX 24.02+
     make_ParticleTile<ParticleType_0_0, 37, 1> (m);  // HiPACE++ 22.07
 }

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -105,6 +105,7 @@ void init_StructOfArrays(py::module& m) {
     make_StructOfArrays< 5, 0, true>(m);  // WarpX 24.02+ 1D
 #elif AMREX_SPACEDIM == 2
     make_StructOfArrays< 6, 0, true>(m);  // WarpX 24.02+ 2D
+    make_StructOfArrays< 7, 0, true>(m);  // WarpX 24.02+ RZ
 #elif AMREX_SPACEDIM == 3
     make_StructOfArrays< 7, 0, true>(m);  // WarpX 24.02+ 3D
 #endif


### PR DESCRIPTION
Specialize more containers in 2D for RZ.
Later on, make `theta` a runtime attribute so we can avoid all that extra compile and link time.

For https://github.com/ECP-WarpX/WarpX/pull/3850