### PR TITLE
Particles: Renames and Snake Case

### DIFF
--- a/src/Particle/ArrayOfStructs.cpp
+++ b/src/Particle/ArrayOfStructs.cpp
@@ -16,11 +16,11 @@ namespace
     using namespace amrex;
 
     // Note - this function MUST be consistent with AMReX_Particle.H
-    Long unpack_id (uint64_t cpuid) {
+    Long unpack_id (uint64_t idcpu) {
         Long r = 0;
 
-        uint64_t sign = cpuid >> 63;  // extract leftmost sign bit
-        uint64_t val  = ((cpuid >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
+        uint64_t sign = idcpu >> 63;  // extract leftmost sign bit
+        uint64_t val  = ((idcpu >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
 
         Long lval = static_cast<Long>(val);  // bc we take -
         r = (sign) ? lval : -lval;
@@ -28,8 +28,8 @@ namespace
     }
 
     // Note - this function MUST be consistent with AMReX_Particle.H
-    int unpack_cpu (uint64_t cpuid) {
-        return static_cast<int>(cpuid & 0x00FFFFFF);
+    int unpack_cpu (uint64_t idcpu) {
+        return static_cast<int>(idcpu & 0x00FFFFFF);
     }
 
     /** CPU: __array_interface__ v3
@@ -63,7 +63,7 @@ namespace
                 descr.append(py::make_tuple("rdata_"+std::to_string(ii),py::format_descriptor<RealType>::format()));
             }
         }
-        descr.append(py::make_tuple("cpuid", py::format_descriptor<uint64_t>::format()) );
+        descr.append(py::make_tuple("idcpu", py::format_descriptor<uint64_t>::format()) );
         if constexpr (ParticleType::NInt > 0) {
             for(int ii=0; ii < ParticleType::NInt; ++ii) {
                 descr.append(py::make_tuple("idata_"+std::to_string(ii),py::format_descriptor<int>::format()));

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -187,10 +187,10 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
                       const Vector<IntVect>&>())
 
         .def_property_readonly_static("is_soa_particle", [](const py::object&){return ParticleType::is_soa_particle;})
-        .def_property_readonly_static("NStructReal", [](const py::object&){return ParticleContainerType::NStructReal; })
-        .def_property_readonly_static("NStructInt", [](const py::object&){return ParticleContainerType::NStructInt; })
-        .def_property_readonly_static("NArrayReal", [](const py::object&){return ParticleContainerType::NArrayReal; })
-        .def_property_readonly_static("NArrayInt", [](const py::object&){return ParticleContainerType::NArrayInt; })
+        .def_property_readonly_static("num_struct_real", [](const py::object&){return ParticleContainerType::NStructReal; })
+        .def_property_readonly_static("num_struct_int", [](const py::object&){return ParticleContainerType::NStructInt; })
+        .def_property_readonly_static("num_array_real", [](const py::object&){return ParticleContainerType::NArrayReal; })
+        .def_property_readonly_static("num_array_int", [](const py::object&){return ParticleContainerType::NArrayInt; })
 
         .def_property_readonly("num_real_comps", &ParticleContainerType::NumRealComps,
             "The number of compile-time and runtime Real components in SoA")
@@ -200,6 +200,9 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
             "The number of runtime Real components in SoA")
         .def_property_readonly("num_runtime_int_comps", &ParticleContainerType::NumRuntimeIntComps,
             "The number of runtime Int components in SoA")
+
+        .def_property_readonly("num_position_components", [](const py::object&){ return AMREX_SPACEDIM; })
+        .def_property_readonly("byte_spread", &ParticleContainerType::ByteSpread)
 
         .def_property_readonly("finest_level", &ParticleContainerBase::finestLevel)
 
@@ -229,7 +232,7 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
                                     const Vector<IntVect>&>
                 (&ParticleContainerType::Define))
 
-        .def("numLocalTilesAtLevel", &ParticleContainerType::numLocalTilesAtLevel)
+        .def("num_local_tiles_at_level", &ParticleContainerType::numLocalTilesAtLevel)
 
         .def("reserve_data", &ParticleContainerType::reserveData)
         .def("resize_data", &ParticleContainerType::resizeData)
@@ -244,30 +247,29 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         //                  const ParticleInitData& mass,
         //                  bool serialize = false, RealBox bx = RealBox());
 
-        .def("Increment", &ParticleContainerType::Increment) // TODO pure SoA
+        .def("increment", &ParticleContainerType::Increment) // TODO pure SoA
         //.def("IncrementWithTotal", &ParticleContainerType::IncrementWithTotal, py::arg("mf"), py::arg("level"), py::arg("local")=false) // TODO pure SoA
-        .def("Redistribute", &ParticleContainerType::Redistribute, py::arg("lev_min")=0, py::arg("lev_max")=-1,
+        .def("redistribute", &ParticleContainerType::Redistribute, py::arg("lev_min")=0, py::arg("lev_max")=-1,
                                             py::arg("nGrow")=0, py::arg("local")=0, py::arg("remove_negative")=true)
-        .def("SortParticlesByCell", &ParticleContainerType::SortParticlesByCell)
-        .def("SortParticlesByBin", &ParticleContainerType::SortParticlesByBin)
+        .def("sort_particles_by_cell", &ParticleContainerType::SortParticlesByCell)
+        .def("sort_particles_by_bin", &ParticleContainerType::SortParticlesByBin)
         .def("OK", &ParticleContainerType::OK, py::arg("lev_min") = 0, py::arg("lev_max") = -1, py::arg("nGrow")=0)
-        .def("ByteSpread",&ParticleContainerType::ByteSpread)
-        .def("PrintCapacity", &ParticleContainerType::PrintCapacity)
-        .def("ShrinkToFit", &ParticleContainerType::ShrinkToFit)
+        .def("print_capacity", &ParticleContainerType::PrintCapacity)
+        .def("shrink_t_fit", &ParticleContainerType::ShrinkToFit)
         // Long NumberOfParticlesAtLevel (int level, bool only_valid = true, bool only_local = false) const;
-        .def("NumberOfParticlesAtLevel", &ParticleContainerType::NumberOfParticlesAtLevel,
+        .def("number_of_particles_at_level", &ParticleContainerType::NumberOfParticlesAtLevel,
             py::arg("level"), py::arg("only_valid")=true, py::arg("only_local")=false)
         // Vector<Long> NumberOfParticlesInGrid  (int level, bool only_valid = true, bool only_local = false) const;
-        .def("NumberOfParticlesInGrid", &ParticleContainerType::NumberOfParticlesInGrid,
+        .def("number_of_particles_in_grid", &ParticleContainerType::NumberOfParticlesInGrid,
             py::arg("level"), py::arg("only_valid")=true, py::arg("only_local")=false)
             // .def("DefineAndReturnParticleTile",
             //     py::overload_cast<int, int, int>
             //     (&ParticleContainerType::DefineAndReturnParticleTile))
                 // Long TotalNumberOfParticles (bool only_valid=true, bool only_local=false) const;
-        .def("TotalNumberOfParticles", &ParticleContainerType::TotalNumberOfParticles,
+        .def("total_number_of_particles", &ParticleContainerType::TotalNumberOfParticles,
             py::arg("only_valid")=true, py::arg("only_local")=false)
-        .def("RemoveParticlesAtLevel", &ParticleContainerType::RemoveParticlesAtLevel)
-        .def("RemoveParticlesNotAtFinestLevel", &ParticleContainerType::RemoveParticlesNotAtFinestLevel)
+        .def("remove_particles_at_level", &ParticleContainerType::RemoveParticlesAtLevel)
+        .def("remove_particles_not_at_finestLevel", &ParticleContainerType::RemoveParticlesNotAtFinestLevel)
         // void CreateVirtualParticles (int level, AoS& virts) const;
         //.def("CreateVirtualParticles", py::overload_cast<int, AoS&>(&ParticleContainerType::CreateVirtualParticles, py::const_),
         //    py::arg("level"), py::arg("virts"))
@@ -277,12 +279,12 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         //     py::arg("level"), py::arg("ngrow"), py::arg("ghosts"))
         //.def("CreateGhostParticles", py::overload_cast<int, int, ParticleTileType&>(&ParticleContainerType::CreateGhostParticles, py::const_),
         //     py::arg("level"), py::arg("ngrow"), py::arg("ghosts")) // TODO pure SoA
-        //.def("AddParticlesAtLevel", py::overload_cast<AoS&, int, int>(&ParticleContainerType::AddParticlesAtLevel),
+        //.def("add_particles_at_level", py::overload_cast<AoS&, int, int>(&ParticleContainerType::AddParticlesAtLevel),
         //    py::arg("particles"), py::arg("level"), py::arg("ngrow")=0)
-        .def("AddParticlesAtLevel", py::overload_cast<ParticleTileType&, int, int>(&ParticleContainerType::AddParticlesAtLevel),
+        .def("add_particles_at_level", py::overload_cast<ParticleTileType&, int, int>(&ParticleContainerType::AddParticlesAtLevel),
             py::arg("particles"), py::arg("level"), py::arg("ngrow")=0)
 
-        .def("clearParticles", &ParticleContainerType::clearParticles)
+        .def("clear_particles", &ParticleContainerType::clearParticles)
         // template <class PCType,
         //           std::enable_if_t<IsParticleContainer<PCType>::value, int> foo = 0>
         // void copyParticles (const PCType& other, bool local=false);
@@ -327,8 +329,8 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         // void WritePlotFilePre ();
 
         // void WritePlotFilePost ();
-        //.def("GetParticles", py::overload_cast<>(&ParticleContainerType::GetParticles), py::return_value_policy::reference_internal)
-        .def("GetParticles", py::overload_cast<int>(&ParticleContainerType::GetParticles), py::return_value_policy::reference_internal, py::arg("level"))
+        //.def("get_particles", py::overload_cast<>(&ParticleContainerType::GetParticles), py::return_value_policy::reference_internal)
+        .def("get_particles", py::overload_cast<int>(&ParticleContainerType::GetParticles), py::return_value_policy::reference_internal, py::arg("level"))
         // .def("ParticlesAt", py::overload_cast<int,int,int>(&ParticleContainerType::ParticlesAt),
         //     py::return_value_policy::reference_internal)
         // .def("ParticlesAt", py::overload_cast<int,int,int>(&ParticleContainerType::ParticlesAt,py::const_))
@@ -381,15 +383,15 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
     ;
 
     py_pc
-        .def("InitRandom", py::overload_cast<Long, ULong, const ParticleInitData&, bool, RealBox>(&ParticleContainerType::InitRandom))
+        .def("init_random", py::overload_cast<Long, ULong, const ParticleInitData&, bool, RealBox>(&ParticleContainerType::InitRandom))
     ;
 
     // TODO for pure SoA
     // depends on https://github.com/AMReX-Codes/amrex/pull/3280
     if constexpr (!T_ParticleType::is_soa_particle) {
         py_pc
-            .def("InitRandomPerBox", py::overload_cast<Long, ULong, const ParticleInitData&>(&ParticleContainerType::InitRandomPerBox))
-            .def("InitOnePerCell", &ParticleContainerType::InitOnePerCell)
+            .def("init_random_per_box", py::overload_cast<Long, ULong, const ParticleInitData&>(&ParticleContainerType::InitRandomPerBox))
+            .def("init_one_per_cell", &ParticleContainerType::InitOnePerCell)
         ;
     }
 

--- a/src/Particle/ParticleTile.cpp
+++ b/src/Particle/ParticleTile.cpp
@@ -41,11 +41,13 @@ void make_ParticleTileData(py::module &m)
 
     py::class_<ParticleTileDataType>(m, particle_tile_data_type.c_str())
             .def(py::init())
-            .def_readonly("m_size", &ParticleTileDataType::m_size)
-            .def_readonly("m_num_runtime_real", &ParticleTileDataType::m_num_runtime_real)
-            .def_readonly("m_num_runtime_int", &ParticleTileDataType::m_num_runtime_int)
-            .def("getSuperParticle", &ParticleTileDataType::template getSuperParticle<ParticleType>)
-            .def("setSuperParticle", &ParticleTileDataType::template setSuperParticle<ParticleType>)
+
+            .def_property_readonly("m_size", [](ParticleTileDataType const & ptd){ return ptd.m_size; })
+            .def_property_readonly("m_num_runtime_real", [](ParticleTileDataType const & ptd){ return ptd.m_num_runtime_real; })
+            .def_property_readonly("m_num_runtime_int", [](ParticleTileDataType const & ptd){ return ptd.m_num_runtime_int; })
+
+            .def("get_super_particle", &ParticleTileDataType::template getSuperParticle<ParticleType>)
+            .def("set_super_particle", &ParticleTileDataType::template setSuperParticle<ParticleType>)
             // setter & getter
             .def("__setitem__", [](ParticleTileDataType &pdt, int const v,
                                    SuperParticleType const value) { pdt.setSuperParticle(value, v); })
@@ -81,16 +83,18 @@ void make_ParticleTile(py::module &m, std::string allocstr)
         .def_readonly_static("NAR", &ParticleTileType::NAR)
         .def_readonly_static("NAI", &ParticleTileType::NAI)
         .def("define", &ParticleTileType::define)
-        .def("GetStructOfArrays", py::overload_cast<>(&ParticleTileType::GetStructOfArrays),
+        .def("get_struct_of_arrays", py::overload_cast<>(&ParticleTileType::GetStructOfArrays),
             py::return_value_policy::reference_internal)
-        .def("empty", &ParticleTileType::empty)
-        .def("size", &ParticleTileType::size)
-        .def("numParticles", &ParticleTileType::numParticles)
-        .def("numRealParticles", &ParticleTileType::numRealParticles)
-        .def("numNeighborParticles", &ParticleTileType::numNeighborParticles)
-        .def("numTotalParticles", &ParticleTileType::numTotalParticles)
-        .def("setNumNeighbors", &ParticleTileType::setNumNeighbors)
-        .def("getNumNeighbors", &ParticleTileType::getNumNeighbors)
+
+        .def_property_readonly("empty", &ParticleTileType::empty)
+        .def_property_readonly("size", &ParticleTileType::size)
+        .def_property_readonly("num_particles", &ParticleTileType::numParticles)
+        .def_property_readonly("num_real_particles", &ParticleTileType::numRealParticles)
+        .def_property_readonly("num_neighbor_particles", &ParticleTileType::numNeighborParticles)
+        .def_property_readonly("num_total_particles", &ParticleTileType::numTotalParticles)
+
+        .def("set_num_neighbors", &ParticleTileType::setNumNeighbors)
+        .def("get_num_neighbors", &ParticleTileType::getNumNeighbors)
         .def("resize", &ParticleTileType::resize)
     ;
 
@@ -122,21 +126,23 @@ void make_ParticleTile(py::module &m, std::string allocstr)
                                 std::size_t npar,
                                 int v)
                                 {ptile.push_back_int(comp, npar, v);})
-        .def("NumRealComps", &ParticleTileType::NumRealComps)
-        .def("NumIntComps", &ParticleTileType::NumIntComps)
-        .def("NumRuntimeRealComps", &ParticleTileType::NumRuntimeRealComps)
-        .def("NumRuntimeIntComps", &ParticleTileType::NumRuntimeIntComps)
+
+        .def_property_readonly("num_real_comps", &ParticleTileType::NumRealComps)
+        .def_property_readonly("num_int_comps", &ParticleTileType::NumIntComps)
+        .def_property_readonly("num_runtime_real_comps", &ParticleTileType::NumRuntimeRealComps)
+        .def_property_readonly("num_runtime_int_comps", &ParticleTileType::NumRuntimeIntComps)
+
         .def("shrink_to_fit", &ParticleTileType::shrink_to_fit)
         .def("capacity", &ParticleTileType::capacity)
         .def("swap",&ParticleTileType::swap)
-        .def("getParticleTileData", &ParticleTileType::getParticleTileData)
+        .def("get_particle_tile_data", &ParticleTileType::getParticleTileData)
         .def("__setitem__", [](ParticleTileType & pt, int const v, SuperParticleType const value){ pt.getParticleTileData().setSuperParticle( value, v); })
         .def("__getitem__", [](ParticleTileType & pt, int const v){ return pt.getParticleTileData().getSuperParticle(v); })
     ;
 
     if constexpr (!T_ParticleType::is_soa_particle) {
         py_particle_tile
-            .def("GetArrayOfStructs",
+            .def("get_array_of_structs",
                  py::overload_cast<>(&ParticleTileType::GetArrayOfStructs),
                  py::return_value_policy::reference_internal)
         ;

--- a/src/Particle/StructOfArrays.cpp
+++ b/src/Particle/StructOfArrays.cpp
@@ -34,37 +34,40 @@ void make_StructOfArrays(py::module &m, std::string allocstr)
              "Get the number of compile-time + runtime Real components")
         .def_property_readonly("num_int_comps", &SOAType::NumIntComps,
              "Get the number of compile-time + runtime Int components")
+        .def_property_readonly("has_idcpu", [](const py::object&){ return use64BitIdCpu; },
+             "In pure SoA particle layout, idcpu is an array in the SoA")
 
         // compile-time components
-        .def("GetRealData", py::overload_cast<>(&SOAType::GetRealData),
+        .def("get_real_data", py::overload_cast<>(&SOAType::GetRealData),
             py::return_value_policy::reference_internal,
             "Get access to the particle Real Arrays (only compile-time components)")
-        .def("GetIntData", py::overload_cast<>(&SOAType::GetIntData),
+        .def("get_int_data", py::overload_cast<>(&SOAType::GetIntData),
             py::return_value_policy::reference_internal,
             "Get access to the particle Int Arrays (only compile-time components)")
         // compile-time and runtime components
-        .def("GetRealData", py::overload_cast<const int>(&SOAType::GetRealData),
+        .def("get_real_data", py::overload_cast<const int>(&SOAType::GetRealData),
              py::return_value_policy::reference_internal,
              py::arg("index"),
              "Get access to a particle Real component Array (compile-time and runtime component)")
-        .def("GetIntData", py::overload_cast<const int>(&SOAType::GetIntData),
+        .def("get_int_data", py::overload_cast<const int>(&SOAType::GetIntData),
              py::return_value_policy::reference_internal,
              py::arg("index"),
              "Get access to a particle Real component Array (compile-time and runtime component)")
 
-        .def("size", &SOAType::size,
-             "Get the number of particles")
         .def("__len__", &SOAType::size,
              "Get the number of particles")
-        .def("numParticles", &SOAType::numParticles)
-        .def("numRealParticles", &SOAType::numRealParticles)
-        .def("numTotalParticles", &SOAType::numTotalParticles)
-        .def("setNumNeighbors", &SOAType::setNumNeighbors)
-        .def("getNumNeighbors", &SOAType::getNumNeighbors)
+        .def_property_readonly("size", &SOAType::size,
+             "Get the number of particles")
+        .def_property_readonly("num_particles", &SOAType::numParticles)
+        .def_property_readonly("num_real_particles", &SOAType::numRealParticles)
+        .def_property_readonly("num_total_particles", &SOAType::numTotalParticles)
+
+        .def("set_num_neighbors", &SOAType::setNumNeighbors)
+        .def("get_num_neighbors", &SOAType::getNumNeighbors)
         .def("resize", &SOAType::resize)
     ;
     if (use64BitIdCpu)
-        py_SoA.def("GetIdCPUData", py::overload_cast<>(&SOAType::GetIdCPUData),
+        py_SoA.def("get_idcpu_data", py::overload_cast<>(&SOAType::GetIdCPUData),
                    py::return_value_policy::reference_internal,
                    "Get access to a particle IdCPU component Array");
 }

--- a/src/amrex/ParticleComponentNames.py
+++ b/src/amrex/ParticleComponentNames.py
@@ -1,0 +1,68 @@
+"""
+This file is part of pyAMReX
+
+Copyright 2024 AMReX community
+Authors: Axel Huebl
+License: BSD-3-Clause-LBNL
+"""
+
+
+def soa_real_comps(num_comps, spacedim=3, rotate=True):
+    """
+    Name the ParticleReal components in SoA.
+
+    Parameters
+    ----------
+    num_comps : int
+      number of components to generate names for.
+    spacedim : int
+      AMReX dimensionality
+    rotate : bool = True
+      start with "x", "y", "z", "a", "b", ...
+
+    Returns
+    -------
+    A list of length num_comps with values
+    rotate=True (for pure SoA layout):
+      3D: "x", "y", "z", "a", "b", ... "w", "r0", "r1", ...
+      2D: "x", "y", "a", "b", ... "w", "r0", "r1", ...
+      1D: "x", "a", "b", ... "w", "r0", "r1", ...
+    rotate=False (for legacy layout):
+      1D-3D: "a", "b", ... "w", "r0", "r1", ...
+    """
+    import string
+
+    # x, y, z, a, b, ...
+    comp_names = list(string.ascii_lowercase)
+    if rotate:
+        # rotate x, y, z to be beginning (positions)
+        comp_names = comp_names[-3:] + comp_names[:-3]
+    else:
+        # cut off x, y, z to avoid confusion
+        comp_names = comp_names[:-3]
+
+    num_named = len(comp_names)
+    if num_comps < num_named:
+        comp_names = list(comp_names)[0:num_comps]
+    elif num_comps > num_named:
+        comp_names.extend(["r" + str(i) for i in range(num_comps - num_named)])
+
+    return comp_names
+
+
+def soa_int_comps(num_comps):
+    """
+    Name the int components in SoA.
+
+    Parameters
+    ----------
+    num_comps : int
+      number of components to generate names for.
+
+    Returns
+    -------
+    A list of length num_comps with values "i1", "i2", "i3", ...
+    """
+    comp_names = ["i" + str(i) for i in range(num_comps)]
+
+    return comp_names

--- a/src/amrex/ParticleContainer.py
+++ b/src/amrex/ParticleContainer.py
@@ -48,23 +48,37 @@ def pc_to_df(self, local=True, comm=None, root_rank=0):
                 continue
 
             if self.is_soa_particle:
+                soa_view = pti.soa().to_numpy(copy=True)
+
                 next_df = pd.DataFrame()
+
+                next_df["idcpu"] = soa_view.idcpu
+
+                soa_np_real = soa_view.real
+                for name, array in soa_np_real.items():
+                    next_df[name] = array
+
+                soa_np_int = soa_view.int
+                for name, array in soa_np_int.items():
+                    next_df[name] = array
             else:
                 # AoS
                 aos_np = pti.aos().to_numpy(copy=True)
                 next_df = pd.DataFrame(aos_np)
-                next_df.set_index("cpuid")
-                next_df.index.name = "cpuid"
 
-            # SoA
-            soa_view = pti.soa().to_numpy(copy=True)
-            soa_np_real = soa_view.real
-            soa_np_int = soa_view.int
+                # SoA
+                soa_view = pti.soa().to_numpy(copy=True)
+                soa_np_real = soa_view.real
+                soa_np_int = soa_view.int
 
-            for idx, array in enumerate(soa_np_real):
-                next_df[f"SoA_real_{idx}"] = array
-            for idx, array in enumerate(soa_np_int):
-                next_df[f"SoA_int_{idx}"] = array
+                for name, array in soa_np_real.items():
+                    next_df[f"SoA_{name}"] = array
+
+                for name, array in soa_np_int.items():
+                    next_df[f"SoA_{name}"] = array
+
+            next_df.set_index("idcpu")
+            next_df.index.name = "idcpu"
 
             dfs_local.append(next_df)
 

--- a/src/amrex/StructOfArrays.py
+++ b/src/amrex/StructOfArrays.py
@@ -8,6 +8,8 @@ License: BSD-3-Clause-LBNL
 
 from collections import namedtuple
 
+from .ParticleComponentNames import soa_int_comps, soa_real_comps
+
 
 def soa_to_numpy(self, copy=False):
     """
@@ -23,21 +25,41 @@ def soa_to_numpy(self, copy=False):
     Returns
     -------
     namedtuple
-        A tuple with real and int components that are each lists
-        of 1D numpy arrays.
+        A tuple with real and int components that are each dicts
+        of 1D numpy arrays. The dictionary key order is the same as
+        in the C++ component order.
+        For pure SoA particle layouts, an additional component idcpu
+        with global particle indices is populated.
     """
-    SoA_np = namedtuple(type(self).__name__ + "_np", ["real", "int"])
-
-    soa_view = SoA_np([], [])
-
-    if self.size() == 0:
+    if self.size == 0:
         raise ValueError("SoA is empty.")
 
-    for idx_real in range(self.num_real_comps):
-        soa_view.real.append(self.GetRealData(idx_real).to_numpy(copy=copy))
+    SoA_np = namedtuple(type(self).__name__ + "_np", ["real", "int", "idcpu"])
 
+    # note: Python 3.7+ dicts are guaranteed to keep the insertion order,
+    #       so users can also access them with .values()[<num>] as in the
+    #       unnamed C++ API if they want to
+    if self.has_idcpu:
+        soa_view = SoA_np({}, {}, self.get_idcpu_data().to_numpy(copy=copy))
+    else:
+        soa_view = SoA_np({}, {}, None)
+
+    # for the legacy data layout, do not start with x, y, z but with a, b, c, ...
+    if self.has_idcpu:
+        real_comp_names = soa_real_comps(self.num_real_comps)
+    else:
+        real_comp_names = soa_real_comps(self.num_real_comps, rotate=False)
+
+    for idx_real in range(self.num_real_comps):
+        soa_view.real[real_comp_names[idx_real]] = self.get_real_data(
+            idx_real
+        ).to_numpy(copy=copy)
+
+    int_comp_names = soa_int_comps(self.num_int_comps)
     for idx_int in range(self.num_int_comps):
-        soa_view.int.append(self.GetIntData(idx_int).to_numpy(copy=copy))
+        soa_view.int[int_comp_names[idx_int]] = self.get_int_data(idx_int).to_numpy(
+            copy=copy
+        )
 
     return soa_view
 
@@ -56,26 +78,44 @@ def soa_to_cupy(self, copy=False):
     Returns
     -------
     namedtuple
-        A tuple with real and int components that are each lists
-        of 1D numpy arrays.
+        A tuple with real and int components that are each dicts
+        of 1D numpy arrays. The dictionary key order is the same as
+        in the C++ component order.
+        For pure SoA particle layouts, an additional component idcpu
+        with global particle indices is populated.
 
     Raises
     ------
     ImportError
         Raises an exception if cupy is not installed
     """
-    SoA_cp = namedtuple(type(self).__name__ + "_cp", ["real", "int"])
-
-    soa_view = SoA_cp([], [])
-
-    if self.size() == 0:
+    if self.size == 0:
         raise ValueError("SoA is empty.")
 
-    for idx_real in range(self.num_real_comps):
-        soa_view.real.append(self.GetRealData(idx_real).to_cupy(copy=copy))
+    SoA_cp = namedtuple(type(self).__name__ + "_cp", ["real", "int", "idcpu"])
 
+    # note: Python 3.7+ dicts are guaranteed to keep the insertion order,
+    #       so users can also access them with .values()[<num>] as in the
+    #       unnamed C++ API if they want to
+    if self.has_idcpu:
+        soa_view = SoA_cp({}, {}, self.get_idcpu_data().to_cupy(copy=copy))
+    else:
+        soa_view = SoA_cp({}, {}, None)
+
+    real_comp_names = soa_real_comps(self.num_real_comps)
+    for idx_real in range(self.num_real_comps):
+        soa_view.real[real_comp_names[idx_real]] = self.get_real_data(idx_real).to_cupy(
+            copy=copy
+        )
+
+    int_comp_names = soa_int_comps(self.num_int_comps)
     for idx_int in range(self.num_int_comps):
-        soa_view.int.append(self.GetIntData(idx_int).to_cupy(copy=copy))
+        soa_view.int[int_comp_names[idx_real]] = self.get_int_data(idx_int).to_cupy(
+            copy=copy
+        )
+
+    if self.has_idcpu:
+        soa_view.idcpu = self.get_idcpu_data().to_cupy(copy=copy)
 
     return soa_view
 

--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -48,6 +48,7 @@ from ..Array4 import register_Array4_extension
 from ..ArrayOfStructs import register_AoS_extension
 from ..MultiFab import register_MultiFab_extension
 from ..PODVector import register_PODVector_extension
+from ..ParticleComponentNames import soa_int_comps, soa_real_comps  # noqa
 from ..ParticleContainer import register_ParticleContainer_extension
 from ..StructOfArrays import register_SoA_extension
 

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -48,6 +48,7 @@ from ..Array4 import register_Array4_extension
 from ..ArrayOfStructs import register_AoS_extension
 from ..MultiFab import register_MultiFab_extension
 from ..PODVector import register_PODVector_extension
+from ..ParticleComponentNames import soa_int_comps, soa_real_comps  # noqa
 from ..ParticleContainer import register_ParticleContainer_extension
 from ..StructOfArrays import register_SoA_extension
 

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -48,6 +48,7 @@ from ..Array4 import register_Array4_extension
 from ..ArrayOfStructs import register_AoS_extension
 from ..MultiFab import register_MultiFab_extension
 from ..PODVector import register_PODVector_extension
+from ..ParticleComponentNames import soa_int_comps, soa_real_comps  # noqa
 from ..ParticleContainer import register_ParticleContainer_extension
 from ..StructOfArrays import register_SoA_extension
 

--- a/tests/test_particleTile.py
+++ b/tests/test_particleTile.py
@@ -17,20 +17,20 @@ def test_ptile_data():
 def test_ptile_funs():
     pt = amr.ParticleTile_1_1_2_1_default()
 
-    assert pt.empty() and pt.size() == 0
-    assert pt.numParticles() == pt.numRealParticles() == pt.numNeighborParticles() == 0
-    assert pt.numTotalParticles() == pt.getNumNeighbors() == 0
+    assert pt.empty and pt.size == 0
+    assert pt.num_particles == pt.num_real_particles == pt.num_neighbor_particles == 0
+    assert pt.num_total_particles == pt.get_num_neighbors() == 0
 
-    pt.setNumNeighbors(3)
-    assert pt.numParticles() == 0 == pt.numRealParticles()
-    assert pt.numNeighborParticles() == pt.getNumNeighbors() == 3
-    assert pt.numTotalParticles() == 3
+    pt.set_num_neighbors(3)
+    assert pt.num_particles == 0 == pt.num_real_particles
+    assert pt.num_neighbor_particles == pt.get_num_neighbors() == 3
+    assert pt.num_total_particles == 3
 
     pt.resize(5)
-    assert not pt.empty() and pt.size() == 5
-    assert pt.numParticles() == 2 == pt.numRealParticles()
-    assert pt.numNeighborParticles() == pt.getNumNeighbors() == 3
-    assert pt.numTotalParticles() == 5
+    assert not pt.empty and pt.size == 5
+    assert pt.num_particles == 2 == pt.num_real_particles
+    assert pt.num_neighbor_particles == pt.get_num_neighbors() == 3
+    assert pt.num_total_particles == 5
 
 
 ################
@@ -41,18 +41,18 @@ def test_ptile_pushback_ptiledata():
     pt.push_back(p)
     pt.push_back(sp)
 
-    print("num particles", pt.numParticles())
-    print("num real particles", pt.numRealParticles())
-    print("num neighbor particles", pt.numNeighborParticles())
-    print("num totalparticles", pt.numTotalParticles())
-    print("num Neighbors", pt.getNumNeighbors())
-    print("tile is empty?", pt.empty())
-    print("tile size", pt.size())
-    assert not pt.empty()
-    assert pt.numParticles() == pt.numRealParticles() == pt.numTotalParticles() == 2
-    assert pt.numNeighborParticles() == pt.getNumNeighbors() == 0
+    print("num particles", pt.num_particles)
+    print("num real particles", pt.num_real_particles)
+    print("num neighbor particles", pt.num_neighbor_particles)
+    print("num totalparticles", pt.num_total_particles)
+    print("num Neighbors", pt.get_num_neighbors())
+    print("tile is empty?", pt.empty)
+    print("tile size", pt.size)
+    assert not pt.empty
+    assert pt.num_particles == pt.num_real_particles == pt.num_total_particles == 2
+    assert pt.num_neighbor_particles == pt.get_num_neighbors() == 0
 
-    td = pt.getParticleTileData()
+    td = pt.get_particle_tile_data()
     assert (
         np.isclose(td[0].get_rdata(0), 4.0)
         and np.isclose(td[1].get_rdata(2), 10.0)
@@ -68,7 +68,7 @@ def test_ptile_access():
     pt.push_back(sp1)
     sp1.x = 2.0
     sp1.z = 3.0
-    td = pt.getParticleTileData()
+    td = pt.get_particle_tile_data()
     td[0] = sp1
     sp2 = amr.Particle_3_2()
     sp2.x = 5.0
@@ -91,8 +91,8 @@ def test_ptile_soa():
     pt.push_back_int([12])
     pt.push_back_int(0, 3, 31)
 
-    rdata = pt.GetStructOfArrays().GetRealData()
-    idata = pt.GetStructOfArrays().GetIntData()
+    rdata = pt.get_struct_of_arrays().get_real_data()
+    idata = pt.get_struct_of_arrays().get_int_data()
     print("rdata: ", rdata)
 
     ar0 = np.array(rdata[0], copy=False)
@@ -133,15 +133,15 @@ def test_ptile_aos_3d():
     p3.z = 20
     pt.push_back(p3)
     pt.resize(3)
-    aos = np.array(pt.GetArrayOfStructs())
+    aos = np.array(pt.get_array_of_structs())
     print(aos)
     assert np.isclose(aos[0]["x"], 3.0) and np.isclose(aos[0]["y"], 0)
     assert np.isclose(aos[2][0], 0.0) and np.isclose(aos[2][2], 20)
 
 
 def test_ptile_aos():
-    cpuids = np.array([100, 100, 100, 100, 100], dtype=np.uint64)
-    ids = amr.unpack_ids(cpuids)
-    cpus = amr.unpack_cpus(cpuids)
+    idcpu = np.array([100, 100, 100, 100, 100], dtype=np.uint64)
+    ids = amr.unpack_ids(idcpu)
+    cpus = amr.unpack_cpus(idcpu)
     assert np.array_equal(ids, np.array([0, 0, 0, 0, 0]))
     assert np.array_equal(cpus, np.array([100, 100, 100, 100, 100]))

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -17,36 +17,36 @@ def test_soa_init():
     print("num real components", soa.num_real_comps)
     print("num int components", soa.num_int_comps)
     assert soa.num_real_comps == 3 and soa.num_int_comps == 4
-    print("num particles", soa.numParticles())
-    print("num real particles", soa.numRealParticles())
-    print("num totalparticles", soa.numTotalParticles())
-    print("num Neighbors", soa.getNumNeighbors())
-    print("soa size", soa.size())
-    assert soa.numParticles() == soa.numRealParticles() == 0
-    assert soa.size() == soa.numTotalParticles() == 0
-    assert soa.getNumNeighbors() == 0
+    print("num particles", soa.num_particles)
+    print("num real particles", soa.num_real_particles)
+    print("num totalparticles", soa.num_total_particles)
+    print("num Neighbors", soa.get_num_neighbors())
+    print("soa size", soa.size)
+    assert soa.num_particles == soa.num_real_particles == 0
+    assert soa.size == soa.num_total_particles == 0
+    assert soa.get_num_neighbors() == 0
 
     soa.resize(5)
     print("--test resize --")
-    print("num particles", soa.numParticles())
-    print("num real particles", soa.numRealParticles())
-    print("num totalparticles", soa.numTotalParticles())
-    print("num Neighbors", soa.getNumNeighbors())
-    print("soa size", soa.size())
-    assert soa.numParticles() == soa.numRealParticles() == 5
-    assert soa.size() == soa.numTotalParticles() == 5
-    assert soa.getNumNeighbors() == 0
+    print("num particles", soa.num_particles)
+    print("num real particles", soa.num_real_particles)
+    print("num totalparticles", soa.num_total_particles)
+    print("num Neighbors", soa.get_num_neighbors())
+    print("soa size", soa.size)
+    assert soa.num_particles == soa.num_real_particles == 5
+    assert soa.size == soa.num_total_particles == 5
+    assert soa.get_num_neighbors() == 0
 
-    soa.setNumNeighbors(3)
+    soa.set_num_neighbors(3)
     print("--test set neighbor num--")
-    print("num particles", soa.numParticles())
-    print("num real particles", soa.numRealParticles())
-    print("num totalparticles", soa.numTotalParticles())
-    print("num Neighbors", soa.getNumNeighbors())
-    print("soa size", soa.size())
-    assert soa.numParticles() == soa.numRealParticles() == 5
-    assert soa.size() == soa.numTotalParticles() == 8
-    assert soa.getNumNeighbors() == 3
+    print("num particles", soa.num_particles)
+    print("num real particles", soa.num_real_particles)
+    print("num totalparticles", soa.num_total_particles)
+    print("num Neighbors", soa.get_num_neighbors())
+    print("soa size", soa.size)
+    assert soa.num_particles == soa.num_real_particles == 5
+    assert soa.size == soa.num_total_particles == 8
+    assert soa.get_num_neighbors() == 3
 
 
 def test_soa_from_tile():
@@ -58,18 +58,18 @@ def test_soa_from_tile():
     pt.push_back(p)
     pt.push_back(sp)
 
-    soa = pt.GetStructOfArrays()
-    print("num particles", soa.numParticles())
-    print("num real particles", soa.numRealParticles())
-    print("num totalparticles", soa.numTotalParticles())
-    print("num Neighbors", soa.getNumNeighbors())
-    print("soa size", soa.size())
-    assert soa.numParticles() == soa.size() == 2
-    assert soa.numTotalParticles() == soa.numRealParticles() == 2
-    assert soa.getNumNeighbors() == 0
+    soa = pt.get_struct_of_arrays()
+    print("num particles", soa.num_particles)
+    print("num real particles", soa.num_real_particles)
+    print("num totalparticles", soa.num_total_particles)
+    print("num Neighbors", soa.get_num_neighbors())
+    print("soa size", soa.size)
+    assert soa.num_particles == soa.size == 2
+    assert soa.num_total_particles == soa.num_real_particles == 2
+    assert soa.get_num_neighbors() == 0
 
-    real_arrays = soa.GetRealData()
-    int_arrays = soa.GetIntData()
+    real_arrays = soa.get_real_data()
+    int_arrays = soa.get_int_data()
     print(real_arrays)
     assert np.isclose(real_arrays[0][1], 9) and np.isclose(real_arrays[1][1], 10)
     assert isinstance(int_arrays[0][0], int)
@@ -77,7 +77,7 @@ def test_soa_from_tile():
 
     real_arrays[1][0] = -1.2
 
-    ra1 = soa.GetRealData()
+    ra1 = soa.get_real_data()
     print(real_arrays)
     print(ra1)
     for ii, arr in enumerate(real_arrays):
@@ -86,7 +86,7 @@ def test_soa_from_tile():
     print("soa int test")
     iarr_np = int_arrays[0].to_numpy()
     iarr_np[0] = -3
-    ia1 = soa.GetIntData()
+    ia1 = soa.get_int_data()
     ia1_np = ia1[0].to_numpy()
     print(iarr_np)
     print(ia1_np)


### PR DESCRIPTION
Add more systematic default names to numpy/cupy/pandas arrays for self-describing access into positions and other attributes.

Snake-case all the particle methods. Use properties for read-only getters.

![image](https://github.com/AMReX-Codes/pyamrex/assets/1353258/3e2e44f0-fce5-4ff6-b6b6-ee6fc8b225cf)
