### PR TITLE
Fix: Pre-Installed AMReX w/ CUDA

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -72,6 +72,10 @@ macro(find_amrex)
         # https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#importing-amrex-into-your-cmake-project
         find_package(AMReX 24.02 CONFIG REQUIRED COMPONENTS PARTICLES PIC)
         message(STATUS "AMReX: Found version '${AMReX_VERSION}'")
+
+        if(AMReX_GPU_BACKEND STREQUAL CUDA)
+            enable_language(CUDA)
+        endif()
     endif()
 endmacro()
 


### PR DESCRIPTION
Fix CMake language activation with pre-installed AMReX using the CUDA backend.

CMake configure error was:
```
-- Configuring done
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_CUDA_COMPILE_SEPARABLE_COMPILATION
```

Related to #252