### PR TITLE
Fix: Windows add_dll_directory Expand

### DIFF
--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -14,8 +14,9 @@ if os.name == "nt":
     # add anything in PATH
     paths = os.environ.get("PATH", "")
     for p in paths.split(";"):
-        if os.path.exists(p):
-            os.add_dll_directory(p)
+        p_abs = os.path.abspath(os.path.expanduser(os.path.expandvars(p)))
+        if os.path.exists(p_abs):
+            os.add_dll_directory(p_abs)
 
 # import core bindings to C++
 from . import amrex_1d_pybind

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -14,8 +14,9 @@ if os.name == "nt":
     # add anything in PATH
     paths = os.environ.get("PATH", "")
     for p in paths.split(";"):
-        if os.path.exists(p):
-            os.add_dll_directory(p)
+        p_abs = os.path.abspath(os.path.expanduser(os.path.expandvars(p)))
+        if os.path.exists(p_abs):
+            os.add_dll_directory(p_abs)
 
 # import core bindings to C++
 from . import amrex_2d_pybind

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -14,8 +14,9 @@ if os.name == "nt":
     # add anything in PATH
     paths = os.environ.get("PATH", "")
     for p in paths.split(";"):
-        if os.path.exists(p):
-            os.add_dll_directory(p)
+        p_abs = os.path.abspath(os.path.expanduser(os.path.expandvars(p)))
+        if os.path.exists(p_abs):
+            os.add_dll_directory(p_abs)
 
 # import core bindings to C++
 from . import amrex_3d_pybind


### PR DESCRIPTION
Expand paths in `PATH` environment variable before adding them and make them absolute paths.

See https://github.com/ECP-WarpX/impactx/issues/534