### PR TITLE
Particles: Restructure

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -234,7 +234,7 @@ jobs:
             -DAMReX_CUDA_ARCH=8.0       \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
             -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
-        cmake --build build --target pip_install -j 3
+        cmake --build build --target pip_install -j 2
 
         ccache -s
         du -hs ~/.cache/ccache

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -234,7 +234,7 @@ jobs:
             -DAMReX_CUDA_ARCH=8.0       \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
             -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
-        cmake --build build --target pip_install -j 4
+        cmake --build build --target pip_install -j 3
 
         ccache -s
         du -hs ~/.cache/ccache

--- a/docs/source/usage/api.rst
+++ b/docs/source/usage/api.rst
@@ -218,19 +218,19 @@ Additional runtime attributes (Real or Int) are always in SoA memory layout.
 
 ``amrex::ParticleTile<T_ParticleType, NArrayReal, NArrayInt, Allocator>`` is implemented for both legacy (AoS+SoA) and pure SoA particle types, many number of Real and Int arguments, and allocators, e.g.,
 
-.. autoclass:: amrex.space3d.ParticleTile_pureSoA_0_0_8_0_default
+.. autoclass:: amrex.space3d.ParticleTile_pureSoA_8_0_default
    :members:
    :undoc-members:
 
 ``amrex::ParticleTileData<T_ParticleType, NArrayReal>`` is implemented for both legacy (AoS+SoA) and pure SoA particle types, many number of Real and Int arguments, e.g.,
 
-.. autoclass:: amrex.space3d.ParticleTileData_pureSoA_0_0_8_0
+.. autoclass:: amrex.space3d.ParticleTileData_pureSoA_8_0
    :members:
    :undoc-members:
 
 ``amrex::ParticleContainer_impl<ParticleType, T_NArrayReal, T_NArrayInt, Allocator>`` is implemented for both legacy (AoS+SoA) and pure SoA particle types, many number of Real and Int arguments, and allocators, e.g.,
 
-.. autoclass:: amrex.space3d.ParticleContainer_1_1_2_1_default
+.. autoclass:: amrex.space3d.ParticleContainer_2_1_3_1_default
    :members:
    :undoc-members:
 
@@ -246,7 +246,7 @@ Likewise for other classes accessible and usable on particle containers:
 
 .. autoclass:: amrex.space3d.ParConstIter_pureSoA_8_0_default
 
-.. autoclass:: amrex.space3d.ParticleInitType_1_1_2_1
+.. autoclass:: amrex.space3d.ParticleInitType_2_1_3_1
    :members:
    :undoc-members:
 
@@ -262,12 +262,12 @@ This is for the legacy, AoS + SoA particle containers only:
 
 ``amrex::ArrayOfStructs<T_ParticleType, Allocator>`` is implemented for many numbers of extra Real and Int arguments, and allocators, e.g.,
 
-.. autoclass:: amrex.space3d.ArrayOfStructs_0_0_default
+.. autoclass:: amrex.space3d.ArrayOfStructs_2_1_default
    :members:
    :undoc-members:
 
 ``amrex::Particle<T_NReal, T_NInt>`` is implemented for many numbers of extra Real and Int arguments, e.g.,
 
-.. autoclass:: amrex.space3d.Particle_0_0
+.. autoclass:: amrex.space3d.Particle_2_1
    :members:
    :undoc-members:

--- a/src/Particle/ArrayOfStructs.H
+++ b/src/Particle/ArrayOfStructs.H
@@ -1,8 +1,10 @@
 /* Copyright 2022 The AMReX Community
  *
- * Authors: Ryan Sandberg
+ * Authors: Ryan Sandberg, Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#pragma once
+
 #include "pyAMReX.H"
 
 #include <AMReX_ArrayOfStructs.H>
@@ -14,23 +16,6 @@
 namespace
 {
     using namespace amrex;
-
-    // Note - this function MUST be consistent with AMReX_Particle.H
-    Long unpack_id (uint64_t idcpu) {
-        Long r = 0;
-
-        uint64_t sign = idcpu >> 63;  // extract leftmost sign bit
-        uint64_t val  = ((idcpu >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
-
-        Long lval = static_cast<Long>(val);  // bc we take -
-        r = (sign) ? lval : -lval;
-        return r;
-    }
-
-    // Note - this function MUST be consistent with AMReX_Particle.H
-    int unpack_cpu (uint64_t idcpu) {
-        return static_cast<int>(idcpu & 0x00FFFFFF);
-    }
 
     /** CPU: __array_interface__ v3
      *
@@ -181,13 +166,4 @@ void make_ArrayOfStructs(py::module &m)
     make_ArrayOfStructs<ParticleType, amrex::ManagedArenaAllocator> (m, "managed");
     make_ArrayOfStructs<ParticleType, amrex::AsyncArenaAllocator> (m, "async");
 #endif
-}
-
-void init_ArrayOfStructs(py::module& m) {
-    make_ArrayOfStructs<0, 0> (m);  // WarpX 22.07, ImpactX 22.07, HiPACE++ 22.07
-    make_ArrayOfStructs<1, 1> (m);  // test in ParticleContainer
-    make_ArrayOfStructs<2, 1> (m);  // test
-
-    m.def("unpack_ids", py::vectorize(unpack_id));
-    m.def("unpack_cpus", py::vectorize(unpack_cpu));
 }

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -1,10 +1,6 @@
 foreach(D IN LISTS AMReX_SPACEDIM)
     target_sources(pyAMReX_${D}d
       PRIVATE
-        Particle.cpp
-        StructOfArrays.cpp
-        ArrayOfStructs.cpp
-        ParticleTile.cpp
         ParticleContainer.cpp
         ParticleContainer_HiPACE.cpp
         ParticleContainer_ImpactX.cpp

--- a/src/Particle/Particle.H
+++ b/src/Particle/Particle.H
@@ -3,6 +3,8 @@
  * Authors: Ryan Sandberg
  * License: BSD-3-Clause-LBNL
  */
+#pragma once
+
 #include "pyAMReX.H"
 
 #include <AMReX_Config.H>
@@ -16,25 +18,11 @@
 #include <string>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_set>
 #include <utility>
 #include <cmath>
 #include <regex>
 
-
-struct PIdx
-{
-    enum RealValues { // Particle Attributes for sample particle struct-of-arrays
-          w = 0,
-          vx, vy, vz,
-          Ex, Ey, Ez,
-          nRealAttribs
-    };
-
-    enum IntValues {
-        nIntAttribs
-    };
-
-};
 
 namespace
 {
@@ -50,6 +38,17 @@ namespace
 template <int T_NReal, int T_NInt=0>
 void make_Particle(py::module &m)
 {
+    // For legacy AoS + SoA particles, we register a particle and superparticle.
+    // The latter adds the SoA attributes. Avoid to double-register those types.
+    /*
+    static std::unordered_set<std::array<int, 2>> registered;
+    std::array<int, 2> const this_p = {T_NReal, T_NInt}
+    if (auto search = registered.find(this_p); search != registered.end()) {
+        return;
+    }
+    registered.insert(this_p);
+    */
+
     using namespace amrex;
 
     using ParticleType = Particle<T_NReal, T_NInt>;
@@ -280,35 +279,4 @@ void make_Particle(py::module &m)
         .def_property("z", [](ParticleType &p){ return p.pos(2);}, [](ParticleType &p, Real val){ p.m_pos[2] = val; })
 #endif
     ;
-}
-
-
-
-void init_Particle(py::module& m) {
-
-    // TODO: we might need to move all or most of the defines in here into a
-    //       test/example submodule, so they do not collide with downstream projects
-    py::class_<PIdx> pidx(m, "PIdx");
-    py::enum_<PIdx::RealValues>(pidx, "RealValues")
-        .value("w", PIdx::RealValues::w)
-        .value("vx", PIdx::RealValues::vx)
-        .value("vy", PIdx::RealValues::vy)
-        .value("vz", PIdx::RealValues::vz)
-        .value("Ex", PIdx::RealValues::Ex)
-        .value("Ey", PIdx::RealValues::Ey)
-        .value("Ez", PIdx::RealValues::Ez)
-    ;
-    py::enum_<PIdx::IntValues>(pidx, "IntValues")
-    ;
-    make_Particle< PIdx::nRealAttribs, PIdx::nIntAttribs > (m);
-    make_Particle< 0, 0 > (m);
-    make_Particle< 1, 1 > (m);
-    make_Particle< 2, 1 > (m);
-    make_Particle< 3, 2 > (m);
-    make_Particle< 4, 0 > (m);  // HiPACE++ 22.07
-    make_Particle< 5, 0 > (m);  // ImpactX 22.07
-    make_Particle< 6, 0 > (m);  // WarpX 24.03+
-    //make_Particle< 7, 0 > (m);  // WarpX 24.03+
-    make_Particle< 8, 0 > (m);  // ImpactX 24.03+
-    make_Particle< 37, 1> (m);  // HiPACE++ 22.07
 }

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -7,6 +7,11 @@
 
 #include "pyAMReX.H"
 
+#include "Particle.H"
+#include "ArrayOfStructs.H"
+#include "StructOfArrays.H"
+#include "ParticleTile.H"
+
 #include <AMReX_BoxArray.H>
 #include <AMReX_GpuAllocators.H>
 #include <AMReX_IntVect.H>
@@ -416,6 +421,26 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
 template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0>
 void make_ParticleContainer_and_Iterators (py::module &m)
 {
+    if constexpr (T_ParticleType::is_soa_particle) {
+        make_Particle<T_NArrayReal, T_NArrayInt>(m);
+        make_StructOfArrays<T_NArrayReal, T_NArrayInt, true> (m);
+    } else {
+
+        make_Particle<  // particle
+            T_ParticleType::NReal,
+            T_ParticleType::NInt
+        >(m);
+        make_Particle<  // superparticle
+            T_ParticleType::NReal + T_NArrayReal,
+            T_ParticleType::NInt  + T_NArrayInt
+        >(m);
+
+        make_ArrayOfStructs<T_ParticleType::NReal, T_ParticleType::NInt> (m);
+        make_StructOfArrays<T_NArrayReal, T_NArrayInt> (m);
+    }
+
+    make_ParticleTile<T_ParticleType, T_NArrayReal, T_NArrayInt> (m);
+
     make_ParticleInitData<T_ParticleType, T_NArrayReal, T_NArrayInt>(m);
 
     // first, because used as copy target in methods in containers with other allocators

--- a/src/Particle/ParticleContainer.cpp
+++ b/src/Particle/ParticleContainer.cpp
@@ -1,13 +1,38 @@
 /* Copyright 2022 The AMReX Community
  *
- * Authors: Ryan Sandberg
+ * Authors: Ryan Sandberg, Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
 #include "ParticleContainer.H"
 
 #include <AMReX_Particle.H>
 
+#include <cstdint>
 
+
+namespace
+{
+    using namespace amrex;
+
+    // Note - this function MUST be consistent with AMReX_Particle.H
+    Long unpack_id (uint64_t idcpu) {
+        Long r = 0;
+
+        uint64_t sign = idcpu >> 63;  // extract leftmost sign bit
+        uint64_t val  = ((idcpu >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
+
+        Long lval = static_cast<Long>(val);  // bc we take -
+        r = (sign) ? lval : -lval;
+        return r;
+    }
+
+    // Note - this function MUST be consistent with AMReX_Particle.H
+    int unpack_cpu (uint64_t idcpu) {
+        return static_cast<int>(idcpu & 0x00FFFFFF);
+    }
+}
+
+// forward declarations
 void init_ParticleContainer_HiPACE(py::module& m);
 void init_ParticleContainer_ImpactX(py::module& m);
 void init_ParticleContainer_WarpX(py::module& m);
@@ -17,9 +42,25 @@ void init_ParticleContainer(py::module& m) {
 
     // TODO: we might need to move all or most of the defines in here into a
     //       test/example submodule, so they do not collide with downstream projects
-    make_ParticleContainer_and_Iterators<Particle<1, 1>, 2, 1>(m);  // tests
 
+    // most common case: ND particle + runtime attributes
+    //   pure SoA
+    make_ParticleContainer_and_Iterators<
+        SoAParticle<AMREX_SPACEDIM, 0>,
+                    AMREX_SPACEDIM, 0
+    >(m);
+    //   legacy AoS + SoA
+    //make_ParticleContainer_and_Iterators<Particle<0, 0>, 0, 0>(m);
+
+    // used in tests
+    make_ParticleContainer_and_Iterators<Particle<2, 1>, 3, 1>(m);
+
+    // application codes
     init_ParticleContainer_HiPACE(m);
     init_ParticleContainer_ImpactX(m);
     init_ParticleContainer_WarpX(m);
+
+    // for particle idcpu arrays
+    m.def("unpack_ids", py::vectorize(unpack_id));
+    m.def("unpack_cpus", py::vectorize(unpack_cpu));
 }

--- a/src/Particle/ParticleTile.H
+++ b/src/Particle/ParticleTile.H
@@ -1,8 +1,10 @@
 /* Copyright 2022 The AMReX Community
  *
- * Authors: Ryan Sandberg
+ * Authors: Ryan Sandberg, Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#pragma once
+
 #include "pyAMReX.H"
 
 #include <AMReX_BoxArray.H>
@@ -13,10 +15,6 @@
 
 #include <sstream>
 
-
-//Forward declaration
-template <int T_NReal, int T_NInt=0>
-void make_Particle(py::module &m);
 
 template <typename T_ParticleType, int NArrayReal, int NArrayInt>
 void make_ParticleTileData(py::module &m)
@@ -31,11 +29,15 @@ void make_ParticleTileData(py::module &m)
     using SuperParticleType = Particle<NStructReal + NArrayReal, NStructInt + NArrayInt>;
 
     auto particle_tile_data_type = std::string("ParticleTileData_");
-    if (T_ParticleType::is_soa_particle)
+    if (T_ParticleType::is_soa_particle) {
         particle_tile_data_type += "pureSoA_";
+    }
+    else {
+        particle_tile_data_type +=
+            std::to_string(NStructReal) + "_" +
+            std::to_string(NStructInt) + "_";
+    }
     particle_tile_data_type +=
-        std::to_string(NStructReal) + "_" +
-        std::to_string(NStructInt) + "_" +
         std::to_string(NArrayReal) + "_" +
         std::to_string(NArrayInt);
 
@@ -71,11 +73,15 @@ void make_ParticleTile(py::module &m, std::string allocstr)
     using SuperParticleType = Particle<NStructReal + NArrayReal, NStructInt + NArrayInt>;
 
     auto particle_tile_type = std::string("ParticleTile_");
-    if (T_ParticleType::is_soa_particle)
+    if (T_ParticleType::is_soa_particle) {
         particle_tile_type += "pureSoA_";
-    particle_tile_type += std::to_string(NStructReal) + "_" +
-                          std::to_string(NStructInt) + "_" +
-                          std::to_string(NArrayReal) + "_" +
+    }
+    else {
+        particle_tile_type +=
+            std::to_string(NStructReal) + "_" +
+            std::to_string(NStructInt) + "_";
+    }
+    particle_tile_type += std::to_string(NArrayReal) + "_" +
                           std::to_string(NArrayInt) + "_" + allocstr;
 
     auto py_particle_tile = py::class_<ParticleTileType>(m, particle_tile_type.c_str())
@@ -192,37 +198,4 @@ void make_ParticleTile(py::module &m)
     make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
                       amrex::AsyncArenaAllocator>(m, "async");
 #endif
-}
-
-void init_ParticleTile(py::module& m) {
-    using namespace amrex;
-
-    // AMReX legacy AoS position + id/cpu particle ype
-    using ParticleType_0_0 = Particle<0, 0>;
-    using ParticleType_1_1 = Particle<1, 1>;
-#if AMREX_SPACEDIM == 1
-    using SoAParticleType_5_0 = SoAParticle<5, 0>;
-#elif AMREX_SPACEDIM == 2
-    using SoAParticleType_6_0 = SoAParticle<6, 0>;
-    using SoAParticleType_7_0 = SoAParticle<7, 0>;
-#elif AMREX_SPACEDIM == 3
-    using SoAParticleType_7_0 = SoAParticle<7, 0>;
-#endif
-    using SoAParticleType_8_0 = SoAParticle<8, 0>;
-
-    // TODO: we might need to move all or most of the defines in here into a
-    //       test/example submodule, so they do not collide with downstream projects
-    make_ParticleTile<ParticleType_1_1, 2, 1> (m);
-    make_ParticleTile<ParticleType_0_0, 4, 0> (m);   // HiPACE++ 22.07
-    make_ParticleTile<ParticleType_0_0, 5, 0> (m);   // ImpactX 22.07
-#if AMREX_SPACEDIM == 1
-    make_ParticleTile<SoAParticleType_5_0, 5, 0> (m);   // WarpX 24.03+ 1D
-#elif AMREX_SPACEDIM == 2
-    make_ParticleTile<SoAParticleType_6_0, 6, 0> (m);   // WarpX 24.03+ 2D
-    make_ParticleTile<SoAParticleType_7_0, 7, 0> (m);   // WarpX 24.03+ RZ
-#elif AMREX_SPACEDIM == 3
-    make_ParticleTile<SoAParticleType_7_0, 7, 0> (m);   // WarpX 24.03+ 3D
-#endif
-    make_ParticleTile<SoAParticleType_8_0, 8, 0> (m);   // ImpactX 24.03+
-    make_ParticleTile<ParticleType_0_0, 37, 1> (m);  // HiPACE++ 22.07
 }

--- a/src/Particle/StructOfArrays.H
+++ b/src/Particle/StructOfArrays.H
@@ -1,8 +1,10 @@
 /* Copyright 2022 The AMReX Community
  *
- * Authors: Ryan Sandberg
+ * Authors: Ryan Sandberg, Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
+#pragma once
+
 #include "pyAMReX.H"
 
 #include <AMReX_GpuAllocators.H>
@@ -98,20 +100,4 @@ void make_StructOfArrays(py::module &m)
     make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator, use64BitIdCpu>(m, "managed");
     make_StructOfArrays<NReal, NInt, amrex::AsyncArenaAllocator, use64BitIdCpu>(m, "async");
 #endif
-}
-
-void init_StructOfArrays(py::module& m) {
-    make_StructOfArrays< 2, 1>(m);
-    make_StructOfArrays< 4, 0>(m);  // HiPACE++ 22.08 - 24.02
-    make_StructOfArrays< 5, 0>(m);  // ImpactX 22.07 - 24.02
-#if AMREX_SPACEDIM == 1
-    make_StructOfArrays< 5, 0, true>(m);  // WarpX 24.03+ 1D
-#elif AMREX_SPACEDIM == 2
-    make_StructOfArrays< 6, 0, true>(m);  // WarpX 24.03+ 2D
-    make_StructOfArrays< 7, 0, true>(m);  // WarpX 24.03+ RZ
-#elif AMREX_SPACEDIM == 3
-    make_StructOfArrays< 7, 0, true>(m);  // WarpX 24.03+ 3D
-#endif
-    make_StructOfArrays< 8, 0, true>(m);  // ImpactX 24.03+
-    make_StructOfArrays<37, 1>(m);  // HiPACE++ 22.09 - 24.02
 }

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -31,10 +31,6 @@ void init_AmrMesh(py::module &);
 void init_MultiFab(py::module &);
 void init_ParallelDescriptor(py::module &);
 void init_ParmParse(py::module &);
-void init_Particle(py::module &);
-void init_StructOfArrays(py::module &);
-void init_ArrayOfStructs(py::module &);
-void init_ParticleTile(py::module &);
 void init_ParticleContainer(py::module &);
 void init_Periodicity(py::module &);
 void init_PlotFileUtil(py::module &);
@@ -107,11 +103,7 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     init_FArrayBox(m);
     init_MultiFab(m);
     init_ParallelDescriptor(m);
-    init_Particle(m);
     init_PODVector(m);
-    init_StructOfArrays(m);
-    init_ArrayOfStructs(m);
-    init_ParticleTile(m);
 
     init_ParticleContainer(m);
     init_AmrMesh(m);

--- a/tests/test_particle.py
+++ b/tests/test_particle.py
@@ -7,21 +7,16 @@ import amrex.space3d as amr
 
 
 def test_particle_init():
-    p1 = amr.Particle_7_0()
-    nreal = len(amr.PIdx.RealValues.__members__)
-    nint = len(amr.PIdx.IntValues.__members__)
-    assert amr.Particle_7_0.NReal == nreal
-    assert amr.Particle_7_0.NInt == nint
-    assert p1.NReal == nreal
-    assert p1.NInt == nint
+    p1 = amr.Particle_8_0()
+    print(p1)
 
-    p2 = amr.Particle_7_0(1.0, 2.0, 3.0)
+    p2 = amr.Particle_8_0(1.0, 2.0, 3.0)
     assert p2.x == 1.0 and p2.y == 2.0 and p2.z == 3.0
 
-    p3 = amr.Particle_7_0(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
+    p3 = amr.Particle_8_0(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0)
     assert p3.x == 1.0 and p3.get_rdata(0) == 4.0 and p3.get_rdata(6) == 10.0
 
-    p4 = amr.Particle_7_0(1.0, 2.0, 3.0, rdata_0=4.0)
+    p4 = amr.Particle_8_0(1.0, 2.0, 3.0, rdata_0=4.0)
     assert (
         p4.x == 1.0
         and p4.z == 3.0
@@ -29,7 +24,7 @@ def test_particle_init():
         and p4.get_rdata(1) == 0 == p4.get_rdata(2) == p4.get_rdata(3)
     )
 
-    p5 = amr.Particle_7_0(x=1.0, rdata_1=1.0, rdata_3=3.0)
+    p5 = amr.Particle_8_0(x=1.0, rdata_1=1.0, rdata_3=3.0)
     assert (
         p5.x == 1.0
         and p5.get_rdata(1) == 1.0
@@ -40,7 +35,7 @@ def test_particle_init():
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_particle_set():
-    p1 = amr.Particle_7_0()
+    p1 = amr.Particle_8_0()
     p1.setPos(1, 1.5)
     assert p1.pos(0) == 0 and p1.pos(1) == 1.5 and p1.pos(2) == 0
     p1.setPos([1.0, 1, 2])

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -15,7 +15,7 @@ def Npart():
 
 @pytest.fixture(scope="function")
 def empty_particle_container(std_geometry, distmap, boxarr):
-    pc = amr.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
+    pc = amr.ParticleContainer_2_1_3_1_default(std_geometry, distmap, boxarr)
     return pc
 
 
@@ -27,21 +27,21 @@ def empty_soa_particle_container(std_geometry, distmap, boxarr):
 
 @pytest.fixture(scope="function")
 def std_particle():
-    myt = amr.ParticleInitType_1_1_2_1()
-    myt.real_struct_data = [0.5]
+    myt = amr.ParticleInitType_2_1_3_1()
+    myt.real_struct_data = [0.5, 0.6]
     myt.int_struct_data = [5]
-    myt.real_array_data = [0.5, 0.2]
+    myt.real_array_data = [0.5, 0.2, 0.3]
     myt.int_array_data = [1]
     return myt
 
 
 @pytest.fixture(scope="function")
 def particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
-    pc = amr.ParticleContainer_1_1_2_1_default(std_geometry, distmap, boxarr)
-    myt = amr.ParticleInitType_1_1_2_1()
-    myt.real_struct_data = [0.5]
+    pc = amr.ParticleContainer_2_1_3_1_default(std_geometry, distmap, boxarr)
+    myt = amr.ParticleInitType_2_1_3_1()
+    myt.real_struct_data = [0.5, 0.6]
     myt.int_struct_data = [5]
-    myt.real_array_data = [0.5, 0.2]
+    myt.real_array_data = [0.5, 0.2, 0.3]
     myt.int_array_data = [1]
 
     iseed = 1
@@ -62,20 +62,20 @@ def soa_particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
 
 
 def test_particleInitType():
-    myt = amr.ParticleInitType_1_1_2_1()
+    myt = amr.ParticleInitType_2_1_3_1()
     print(myt.real_struct_data)
     print(myt.int_struct_data)
     print(myt.real_array_data)
     print(myt.int_array_data)
 
-    myt.real_struct_data = [0.5]
+    myt.real_struct_data = [0.5, 0.7]
     myt.int_struct_data = [5]
-    myt.real_array_data = [0.5, 0.2]
+    myt.real_array_data = [0.5, 0.2, 0.4]
     myt.int_array_data = [1]
 
-    assert np.allclose(myt.real_struct_data, [0.5])
+    assert np.allclose(myt.real_struct_data, [0.5, 0.7])
     assert np.allclose(myt.int_struct_data, [5])
-    assert np.allclose(myt.real_array_data, [0.5, 0.2])
+    assert np.allclose(myt.real_array_data, [0.5, 0.2, 0.4])
     assert np.allclose(myt.int_array_data, [1])
 
 
@@ -83,15 +83,15 @@ def test_n_particles(particle_container, Npart):
     pc = particle_container
     assert pc.OK()
     assert (
-        pc.num_struct_real == amr.ParticleContainer_1_1_2_1_default.num_struct_real == 1
+        pc.num_struct_real == amr.ParticleContainer_2_1_3_1_default.num_struct_real == 2
     )
     assert (
-        pc.num_struct_int == amr.ParticleContainer_1_1_2_1_default.num_struct_int == 1
+        pc.num_struct_int == amr.ParticleContainer_2_1_3_1_default.num_struct_int == 1
     )
     assert (
-        pc.num_array_real == amr.ParticleContainer_1_1_2_1_default.num_array_real == 2
+        pc.num_array_real == amr.ParticleContainer_2_1_3_1_default.num_array_real == 3
     )
-    assert pc.num_array_int == amr.ParticleContainer_1_1_2_1_default.num_array_int == 1
+    assert pc.num_array_int == amr.ParticleContainer_2_1_3_1_default.num_array_int == 1
     assert (
         pc.number_of_particles_at_level(0)
         == np.sum(pc.number_of_particles_in_grid(0))
@@ -100,7 +100,7 @@ def test_n_particles(particle_container, Npart):
 
 
 def test_pc_init():
-    pc = amr.ParticleContainer_1_1_2_1_default()
+    pc = amr.ParticleContainer_2_1_3_1_default()
 
     print("bytespread", pc.byte_spread)
     print("capacity", pc.print_capacity())
@@ -122,15 +122,15 @@ def test_pc_init():
     pc.Define(gm, dm, ba)
     assert pc.OK()
     assert (
-        pc.num_struct_real == amr.ParticleContainer_1_1_2_1_default.num_struct_real == 1
+        pc.num_struct_real == amr.ParticleContainer_2_1_3_1_default.num_struct_real == 2
     )
     assert (
-        pc.num_struct_int == amr.ParticleContainer_1_1_2_1_default.num_struct_int == 1
+        pc.num_struct_int == amr.ParticleContainer_2_1_3_1_default.num_struct_int == 1
     )
     assert (
-        pc.num_array_real == amr.ParticleContainer_1_1_2_1_default.num_array_real == 2
+        pc.num_array_real == amr.ParticleContainer_2_1_3_1_default.num_array_real == 3
     )
-    assert pc.num_array_int == amr.ParticleContainer_1_1_2_1_default.num_array_int == 1
+    assert pc.num_array_int == amr.ParticleContainer_2_1_3_1_default.num_array_int == 1
 
     print("bytespread", pc.byte_spread)
     print("capacity", pc.print_capacity())
@@ -142,10 +142,10 @@ def test_pc_init():
     print("add a particle to each grid")
     Npart_grid = 1
     iseed = 1
-    myt = amr.ParticleInitType_1_1_2_1()
-    myt.real_struct_data = [0.5]
+    myt = amr.ParticleInitType_2_1_3_1()
+    myt.real_struct_data = [0.5, 0.4]
     myt.int_struct_data = [5]
-    myt.real_array_data = [0.5, 0.2]
+    myt.real_array_data = [0.5, 0.2, 0.4]
     myt.int_array_data = [1]
     pc.init_random_per_box(Npart_grid, iseed, myt)
     ngrid = ba.size

--- a/tests/test_particleTile.py
+++ b/tests/test_particleTile.py
@@ -8,14 +8,14 @@ import amrex.space3d as amr
 
 ##########
 def test_ptile_data():
-    ptd = amr.ParticleTileData_1_1_2_1()
+    ptd = amr.ParticleTileData_2_1_3_1()
     assert ptd.m_size == 0
     assert ptd.m_num_runtime_real == 0
     assert ptd.m_num_runtime_int == 0
 
 
 def test_ptile_funs():
-    pt = amr.ParticleTile_1_1_2_1_default()
+    pt = amr.ParticleTile_2_1_3_1_default()
 
     assert pt.empty and pt.size == 0
     assert pt.num_particles == pt.num_real_particles == pt.num_neighbor_particles == 0
@@ -35,9 +35,9 @@ def test_ptile_funs():
 
 ################
 def test_ptile_pushback_ptiledata():
-    pt = amr.ParticleTile_1_1_2_1_default()
-    p = amr.Particle_1_1(1.0, 2.0, 3, 4.0, 5)
-    sp = amr.Particle_3_2(5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11, 12)
+    pt = amr.ParticleTile_2_1_3_1_default()
+    p = amr.Particle_2_1(1.0, 2.0, 3.0, 4.0, 5.0, 6)
+    sp = amr.Particle_5_2(5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 11, 12)
     pt.push_back(p)
     pt.push_back(sp)
 
@@ -62,15 +62,15 @@ def test_ptile_pushback_ptiledata():
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_access():
-    pt = amr.ParticleTile_1_1_2_1_default()
-    sp1 = amr.Particle_3_2()
+    pt = amr.ParticleTile_2_1_3_1_default()
+    sp1 = amr.Particle_5_2()
     pt.push_back(sp1)
     pt.push_back(sp1)
     sp1.x = 2.0
     sp1.z = 3.0
     td = pt.get_particle_tile_data()
     td[0] = sp1
-    sp2 = amr.Particle_3_2()
+    sp2 = amr.Particle_5_2()
     sp2.x = 5.0
     sp2.y = 4.5
     pt[1] = sp2
@@ -81,10 +81,10 @@ def test_ptile_access():
 
 
 def test_ptile_soa():
-    pt = amr.ParticleTile_1_1_2_1_default()
+    pt = amr.ParticleTile_2_1_3_1_default()
 
-    pt.push_back_real(1, 2.1)
-    pt.push_back_real([1.1, 1.3])
+    pt.push_back_real(1, 2, 2.1)
+    pt.push_back_real([1.1, 1.3, 1.5])
     pt.push_back_real(1, 3, 3.14)
 
     pt.push_back_int(0, 10)
@@ -114,22 +114,22 @@ def test_ptile_soa():
     print("-------")
     # np.array(rdata[0])
     assert np.allclose(ar0, np.array([1.1]))
-    assert np.allclose(ar1, np.array([2.1, 1.3, 3.14, 3.14, 3.14]))
+    assert np.allclose(ar1, np.array([2.1, 2.1, 1.3, 3.14, 3.14, 3.14]))
     assert np.allclose(ir0, np.array([-66, 12, 31, 31, 31]))
 
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_aos_3d():
-    pt = amr.ParticleTile_1_1_2_1_default()
-    p1 = amr.Particle_1_1()
-    p2 = amr.Particle_1_1()
+    pt = amr.ParticleTile_2_1_3_1_default()
+    p1 = amr.Particle_2_1()
+    p2 = amr.Particle_2_1()
     p1.x = 3.0
     p2.x = 4.0
     p2.y = 8
     pt.push_back(p1)
 
     pt.push_back(p2)
-    p3 = amr.Particle_1_1()
+    p3 = amr.Particle_2_1()
     p3.z = 20
     pt.push_back(p3)
     pt.resize(3)

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -6,17 +6,17 @@ import amrex.space3d as amr
 
 
 def test_soa_init():
-    soa = amr.StructOfArrays_2_1_default()
+    soa = amr.StructOfArrays_3_1_default()
     print("--test init --")
     print("num real components", soa.num_real_comps)
     print("num int components", soa.num_int_comps)
-    assert soa.num_real_comps == 2 and soa.num_int_comps == 1
+    assert soa.num_real_comps == 3 and soa.num_int_comps == 1
 
     soa.define(1, 3)
     print("--test define --")
     print("num real components", soa.num_real_comps)
     print("num int components", soa.num_int_comps)
-    assert soa.num_real_comps == 3 and soa.num_int_comps == 4
+    assert soa.num_real_comps == 4 and soa.num_int_comps == 4
     print("num particles", soa.num_particles)
     print("num real particles", soa.num_real_particles)
     print("num totalparticles", soa.num_total_particles)
@@ -50,11 +50,9 @@ def test_soa_init():
 
 
 def test_soa_from_tile():
-    pt = amr.ParticleTile_1_1_2_1_default()
-    p = amr.Particle_1_1(1.0, 2.0, 3, rdata_0=4.0, idata_1=5)
-    sp = amr.Particle_3_2(
-        5.0, 6.0, 7.0, rdata_0=8.0, rdata_1=9.0, rdata_2=10.0, idata_0=11, idata_1=12
-    )
+    pt = amr.ParticleTile_2_1_3_1_default()
+    p = amr.Particle_2_1(1.0, 2.0, 3, rdata_0=4.0, rdata_1=5.0, rdata_2=6.0, idata_1=5)
+    sp = amr.Particle_5_2(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9, 10)
     pt.push_back(p)
     pt.push_back(sp)
 
@@ -71,9 +69,9 @@ def test_soa_from_tile():
     real_arrays = soa.get_real_data()
     int_arrays = soa.get_int_data()
     print(real_arrays)
-    assert np.isclose(real_arrays[0][1], 9) and np.isclose(real_arrays[1][1], 10)
+    assert np.isclose(real_arrays[0][1], 6.0) and np.isclose(real_arrays[1][1], 7.0)
     assert isinstance(int_arrays[0][0], int)
-    assert int_arrays[0][1] == 12
+    assert int_arrays[0][1] == 10
 
     real_arrays[1][0] = -1.2
 


### PR DESCRIPTION
The AMReX particle logic is heavily templated. For simpler maintenance, we move all declarations into header file and define needed types recursively from the particle container.