### PR TITLE
Update `.gitignore` for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,24 @@
 *.out
 *.app
 
+## Compiler debris
+**/tmp_build_dir
+
+## Crash debris
+**/Backtrace.*
+
+## All compiled programs
+**/*.gnu.*.ex
+**/*.o
+**/*.ex
+
+## MacOS creates dynamic linker symbol files
+*.dSym
+
+## MacOS custom folder attributes
+.DS_Store
+
+
 ##########
 # Python #
 ##########
@@ -133,3 +151,9 @@ docs/source/_static/doxyhtml/
 docs/source/_static/
 docs/doxyhtml/
 docs/doxyxml/
+
+### Output ####
+## Plot files
+**/plt*
+## Checkpoints
+**/chk*


### PR DESCRIPTION
Exclude more temporary files.

Extracted from #271