### PR TITLE
Doc: MultiFab Args & Doc Strings

### DIFF
--- a/src/amrex/Array4.py
+++ b/src/amrex/Array4.py
@@ -11,6 +11,8 @@ def array4_to_numpy(self, copy=False, order="F"):
     """
     Provide a Numpy view into an Array4.
 
+    This includes ngrow guard cells of the box.
+
     Note on the order of indices:
     By default, this is as in AMReX in Fortran contiguous order, indexing as
     x,y,z. This has performance implications for use in external libraries such
@@ -51,6 +53,8 @@ def array4_to_numpy(self, copy=False, order="F"):
 def array4_to_cupy(self, copy=False, order="F"):
     """
     Provide a Cupy view into an Array4.
+
+    This includes ngrow guard cells of the box.
 
     Note on the order of indices:
     By default, this is as in AMReX in Fortran contiguous order, indexing as

--- a/src/amrex/MultiFab.py
+++ b/src/amrex/MultiFab.py
@@ -13,6 +13,8 @@ def mf_to_numpy(amr, self, copy=False, order="F"):
     """
     Provide a Numpy view into a MultiFab.
 
+    This includes ngrow guard cells of each box.
+
     Note on the order of indices:
     By default, this is as in AMReX in Fortran contiguous order, indexing as
     x,y,z. This has performance implications for use in external libraries such
@@ -57,6 +59,8 @@ def mf_to_numpy(amr, self, copy=False, order="F"):
 def mf_to_cupy(self, copy=False, order="F"):
     """
     Provide a Cupy view into a MultiFab.
+
+    This includes ngrow guard cells of each box.
 
     Note on the order of indices:
     By default, this is as in AMReX in Fortran contiguous order, indexing as


### PR DESCRIPTION
Add comprehensive doc strings to MultiFab.

Document that `to_numpy`/`to_cupy` include guard cells.