### PR TITLE
`to_xp`: AoS, SoA, PODVector, MF, Array4

### DIFF
--- a/docs/source/usage/zerocopy.rst
+++ b/docs/source/usage/zerocopy.rst
@@ -7,7 +7,7 @@ The Python binding pyAMReX bridges the compute in AMReX block-structured codes a
 As such, it includes zero-copy GPU data access for AI/ML, in situ analysis, application coupling by implementing :ref:`standardized data interfaces <developers-implementation>`.
 
 
-CPU: numpy
+CPU: NumPy
 ----------
 
 zero-copy read and write access.
@@ -16,10 +16,10 @@ CPU as well as managed memory CPU/GPU.
 Call ``.to_numpy()`` on data objects of pyAMReX.
 See the optional arguments of this API.
 
-Writing to the created numpy array will also modify the underlying AMReX memory.
+Writing to the created NumPy array will also modify the underlying AMReX memory.
 
 
-GPU: cupy
+GPU: CuPy
 ---------
 
 GPU zero-copy read and write access.
@@ -27,7 +27,19 @@ GPU zero-copy read and write access.
 Call ``.to_cupy()`` on data objects of pyAMReX.
 See the optional arguments of this API.
 
-Writing to the created cupy array will also modify the underlying AMReX memory.
+Writing to the created CuPy array will also modify the underlying AMReX memory.
+
+
+CPU/GPU Agnostic Code: NumPy/CuPy
+---------------------------------
+
+The previous examples can be written in CPU/GPU agnostics manner.
+Either using NumPy (``np``) or CuPy (``cp``), we provide a `common short-hand abbreviation <https://docs.cupy.dev/en/stable/user_guide/basic.html#how-to-write-cpu-gpu-agnostic-code>`__ named ``xp`` .
+
+Call ``.to_xp()`` on data objects of pyAMReX.
+See the optional arguments of this API.
+
+Writing to the created NumPy/CuPy array will also modify the underlying AMReX memory.
 
 
 GPU: numba

--- a/src/amrex/Array4.py
+++ b/src/amrex/Array4.py
@@ -9,7 +9,7 @@ License: BSD-3-Clause-LBNL
 
 def array4_to_numpy(self, copy=False, order="F"):
     """
-    Provide a Numpy view into an Array4.
+    Provide a NumPy view into an Array4.
 
     This includes ngrow guard cells of the box.
 
@@ -32,7 +32,7 @@ def array4_to_numpy(self, copy=False, order="F"):
     Returns
     -------
     np.array
-        A numpy n-dimensional array.
+        A NumPy n-dimensional array.
     """
     import numpy as np
 
@@ -52,7 +52,7 @@ def array4_to_numpy(self, copy=False, order="F"):
 
 def array4_to_cupy(self, copy=False, order="F"):
     """
-    Provide a Cupy view into an Array4.
+    Provide a CuPy view into an Array4.
 
     This includes ngrow guard cells of the box.
 
@@ -92,6 +92,44 @@ def array4_to_cupy(self, copy=False, order="F"):
         raise ValueError("The order argument must be F or C.")
 
 
+def array4_to_xp(self, copy=False, order="F"):
+    """
+    Provide a NumPy or CuPy view into an Array4, depending on amr.Config.have_gpu .
+
+    This function is similar to CuPy's xp naming suggestion for CPU/GPU agnostic code:
+    https://docs.cupy.dev/en/stable/user_guide/basic.html#how-to-write-cpu-gpu-agnostic-code
+
+    This includes ngrow guard cells of the box.
+
+    Note on the order of indices:
+    By default, this is as in AMReX in Fortran contiguous order, indexing as
+    x,y,z. This has performance implications for use in external libraries such
+    as cupy.
+    The order="C" option will index as z,y,x and perform better with cupy.
+    https://github.com/AMReX-Codes/pyamrex/issues/55#issuecomment-1579610074
+
+    Parameters
+    ----------
+    self : amrex.Array4_*
+        An Array4 class in pyAMReX
+    copy : bool, optional
+        Copy the data if true, otherwise create a view (default).
+    order : string, optional
+        F order (default) or C. C is faster with external libraries.
+
+    Returns
+    -------
+    xp.array
+        A NumPy or CuPy n-dimensional array.
+    """
+    import inspect
+
+    amr = inspect.getmodule(self)
+    return (
+        self.to_cupy(copy, order) if amr.Config.have_gpu else self.to_numpy(copy, order)
+    )
+
+
 def register_Array4_extension(amr):
     """Array4 helper methods"""
     import inspect
@@ -106,3 +144,4 @@ def register_Array4_extension(amr):
     ):
         Array4_type.to_numpy = array4_to_numpy
         Array4_type.to_cupy = array4_to_cupy
+        Array4_type.to_xp = array4_to_xp

--- a/src/amrex/ArrayOfStructs.py
+++ b/src/amrex/ArrayOfStructs.py
@@ -9,7 +9,7 @@ License: BSD-3-Clause-LBNL
 
 def aos_to_numpy(self, copy=False):
     """
-    Provide Numpy views into a ArrayOfStructs.
+    Provide NumPy views into a ArrayOfStructs.
 
     Parameters
     ----------
@@ -22,7 +22,7 @@ def aos_to_numpy(self, copy=False):
     -------
     namedtuple
         A tuple with real and int components that are each lists
-        of 1D numpy arrays.
+        of 1D NumPy arrays.
     """
     import numpy as np
 
@@ -42,7 +42,7 @@ def aos_to_numpy(self, copy=False):
 
 def aos_to_cupy(self, copy=False):
     """
-    Provide Cupy views into a ArrayOfStructs.
+    Provide CuPy views into a ArrayOfStructs.
 
     Parameters
     ----------
@@ -55,7 +55,7 @@ def aos_to_cupy(self, copy=False):
     -------
     namedtuple
         A tuple with real and int components that are each lists
-        of 1D numpy arrays.
+        of 1D NumPy arrays.
 
     Raises
     ------
@@ -68,6 +68,32 @@ def aos_to_cupy(self, copy=False):
         raise ValueError("AoS is empty.")
 
     return cp.array(self, copy=copy)
+
+
+def aos_to_xp(self, copy=False):
+    """
+    Provide NumPy or CuPy views into a ArrayOfStructs, depending on amr.Config.have_gpu .
+
+    This function is similar to CuPy's xp naming suggestion for CPU/GPU agnostic code:
+    https://docs.cupy.dev/en/stable/user_guide/basic.html#how-to-write-cpu-gpu-agnostic-code
+
+    Parameters
+    ----------
+    self : amrex.ArrayOfStructs_*
+        An ArrayOfStructs class in pyAMReX
+    copy : bool, optional
+        Copy the data if true, otherwise create a view (default).
+
+    Returns
+    -------
+    namedtuple
+        A tuple with real and int components that are each lists
+        of 1D NumPy or CuPy arrays.
+    """
+    import inspect
+
+    amr = inspect.getmodule(self)
+    return self.to_cupy(copy) if amr.Config.have_gpu else self.to_numpy(copy)
 
 
 def register_AoS_extension(amr):
@@ -84,3 +110,4 @@ def register_AoS_extension(amr):
     ):
         AoS_type.to_numpy = aos_to_numpy
         AoS_type.to_cupy = aos_to_cupy
+        AoS_type.to_xp = aos_to_xp

--- a/src/amrex/PODVector.py
+++ b/src/amrex/PODVector.py
@@ -9,7 +9,7 @@ License: BSD-3-Clause-LBNL
 
 def podvector_to_numpy(self, copy=False):
     """
-    Provide a Numpy view into a PODVector (e.g., RealVector, IntVector).
+    Provide a NumPy view into a PODVector (e.g., RealVector, IntVector).
 
     Parameters
     ----------
@@ -21,7 +21,7 @@ def podvector_to_numpy(self, copy=False):
     Returns
     -------
     np.array
-        A 1D numpy array.
+        A 1D NumPy array.
     """
     import numpy as np
 
@@ -41,7 +41,7 @@ def podvector_to_numpy(self, copy=False):
 
 def podvector_to_cupy(self, copy=False):
     """
-    Provide a Cupy view into a PODVector (e.g., RealVector, IntVector).
+    Provide a CuPy view into a PODVector (e.g., RealVector, IntVector).
 
     Parameters
     ----------
@@ -68,6 +68,32 @@ def podvector_to_cupy(self, copy=False):
         raise ValueError("Vector is empty.")
 
 
+def podvector_to_xp(self, copy=False):
+    """
+    Provide a NumPy or CuPy view into a PODVector (e.g., RealVector, IntVector),
+    depending on amr.Config.have_gpu .
+
+    This function is similar to CuPy's xp naming suggestion for CPU/GPU agnostic code:
+    https://docs.cupy.dev/en/stable/user_guide/basic.html#how-to-write-cpu-gpu-agnostic-code
+
+    Parameters
+    ----------
+    self : amrex.PODVector_*
+        A PODVector class in pyAMReX
+    copy : bool, optional
+        Copy the data if true, otherwise create a view (default).
+
+    Returns
+    -------
+    xp.array
+        A 1D NumPy or CuPy array.
+    """
+    import inspect
+
+    amr = inspect.getmodule(self)
+    return self.to_cupy(copy) if amr.Config.have_gpu else self.to_numpy(copy)
+
+
 def register_PODVector_extension(amr):
     """PODVector helper methods"""
     import inspect
@@ -82,3 +108,4 @@ def register_PODVector_extension(amr):
     ):
         POD_type.to_numpy = podvector_to_numpy
         POD_type.to_cupy = podvector_to_cupy
+        POD_type.to_xp = podvector_to_xp

--- a/src/amrex/StructOfArrays.py
+++ b/src/amrex/StructOfArrays.py
@@ -76,7 +76,7 @@ def soa_int_comps(self, num_comps):
 
 def soa_to_numpy(self, copy=False):
     """
-    Provide Numpy views into a StructOfArrays.
+    Provide NumPy views into a StructOfArrays.
 
     Parameters
     ----------
@@ -89,7 +89,7 @@ def soa_to_numpy(self, copy=False):
     -------
     namedtuple
         A tuple with real and int components that are each dicts
-        of 1D numpy arrays. The dictionary key order is the same as
+        of 1D NumPy arrays. The dictionary key order is the same as
         in the C++ component order.
         For pure SoA particle layouts, an additional component idcpu
         with global particle indices is populated.
@@ -129,7 +129,7 @@ def soa_to_numpy(self, copy=False):
 
 def soa_to_cupy(self, copy=False):
     """
-    Provide Cupy views into a StructOfArrays.
+    Provide CuPy views into a StructOfArrays.
 
     Parameters
     ----------
@@ -142,7 +142,7 @@ def soa_to_cupy(self, copy=False):
     -------
     namedtuple
         A tuple with real and int components that are each dicts
-        of 1D numpy arrays. The dictionary key order is the same as
+        of 1D NumPy arrays. The dictionary key order is the same as
         in the C++ component order.
         For pure SoA particle layouts, an additional component idcpu
         with global particle indices is populated.
@@ -185,6 +185,35 @@ def soa_to_cupy(self, copy=False):
     return soa_view
 
 
+def soa_to_xp(self, copy=False):
+    """
+    Provide NumPy or CuPy views into a StructOfArrays, depending on amr.Config.have_gpu .
+
+    This function is similar to CuPy's xp naming suggestion for CPU/GPU agnostic code:
+    https://docs.cupy.dev/en/stable/user_guide/basic.html#how-to-write-cpu-gpu-agnostic-code
+
+    Parameters
+    ----------
+    self : amrex.StructOfArrays_*
+        A StructOfArrays class in pyAMReX
+    copy : bool, optional
+        Copy the data if true, otherwise create a view (default).
+
+    Returns
+    -------
+    namedtuple
+        A tuple with real and int components that are each dicts
+        of 1D NumPy or CuPy arrays. The dictionary key order is the same as
+        in the C++ component order.
+        For pure SoA particle layouts, an additional component idcpu
+        with global particle indices is populated.
+    """
+    import inspect
+
+    amr = inspect.getmodule(self)
+    return self.to_cupy(copy) if amr.Config.have_gpu else self.to_numpy(copy)
+
+
 def register_SoA_extension(amr):
     """StructOfArrays helper methods"""
     import inspect
@@ -204,3 +233,4 @@ def register_SoA_extension(amr):
         # converters
         SoA_type.to_numpy = soa_to_numpy
         SoA_type.to_cupy = soa_to_cupy
+        SoA_type.to_xp = soa_to_xp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,8 @@ def amrex_init(tmpdir):
                 "amrex.signal_handling=0",
                 # abort GPU runs if out-of-memory instead of swapping to host RAM
                 # "abort_on_out_of_gpu_memory=1",
-                # the arena for GPU runs defaults to managed
-                "amrex.the_arena_is_managed=1",
+                # avoid managed memory unless explicitly used
+                "amrex.the_arena_is_managed=0",
             ]
         )
         yield

--- a/tests/test_aos.py
+++ b/tests/test_aos.py
@@ -14,7 +14,11 @@ def test_aos_init():
 
 
 def test_aos_push_pop():
-    aos = amr.ArrayOfStructs_2_1_default()
+    aos = (
+        amr.ArrayOfStructs_2_1_managed()
+        if amr.Config.have_gpu
+        else amr.ArrayOfStructs_2_1_default()
+    )
     p1 = amr.Particle_2_1()
     p1.set_rdata([1.5, 2.2])
     p1.set_idata([3])
@@ -49,7 +53,11 @@ def test_aos_push_pop():
 
 
 def test_array_interface():
-    aos = amr.ArrayOfStructs_2_1_default()
+    aos = (
+        amr.ArrayOfStructs_2_1_managed()
+        if amr.Config.have_gpu
+        else amr.ArrayOfStructs_2_1_default()
+    )
     p1 = amr.Particle_2_1()
     p1.setPos([1, 2, 3])
     p1.set_rdata([4.5, 5.2])

--- a/tests/test_particleTile.py
+++ b/tests/test_particleTile.py
@@ -35,7 +35,11 @@ def test_ptile_funs():
 
 ################
 def test_ptile_pushback_ptiledata():
-    pt = amr.ParticleTile_2_1_3_1_default()
+    pt = (
+        amr.ParticleTile_2_1_3_1_managed()
+        if amr.Config.have_gpu
+        else amr.ParticleTile_2_1_3_1_default()
+    )
     p = amr.Particle_2_1(1.0, 2.0, 3.0, 4.0, 5.0, 6)
     sp = amr.Particle_5_2(5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 11, 12)
     pt.push_back(p)
@@ -62,7 +66,11 @@ def test_ptile_pushback_ptiledata():
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_access():
-    pt = amr.ParticleTile_2_1_3_1_default()
+    pt = (
+        amr.ParticleTile_2_1_3_1_managed()
+        if amr.Config.have_gpu
+        else amr.ParticleTile_2_1_3_1_default()
+    )
     sp1 = amr.Particle_5_2()
     pt.push_back(sp1)
     pt.push_back(sp1)
@@ -81,7 +89,11 @@ def test_ptile_access():
 
 
 def test_ptile_soa():
-    pt = amr.ParticleTile_2_1_3_1_default()
+    pt = (
+        amr.ParticleTile_2_1_3_1_managed()
+        if amr.Config.have_gpu
+        else amr.ParticleTile_2_1_3_1_default()
+    )
 
     pt.push_back_real(1, 2, 2.1)
     pt.push_back_real([1.1, 1.3, 1.5])
@@ -120,7 +132,11 @@ def test_ptile_soa():
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_ptile_aos_3d():
-    pt = amr.ParticleTile_2_1_3_1_default()
+    pt = (
+        amr.ParticleTile_2_1_3_1_managed()
+        if amr.Config.have_gpu
+        else amr.ParticleTile_2_1_3_1_default()
+    )
     p1 = amr.Particle_2_1()
     p2 = amr.Particle_2_1()
     p1.x = 3.0

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -50,7 +50,11 @@ def test_soa_init():
 
 
 def test_soa_from_tile():
-    pt = amr.ParticleTile_2_1_3_1_default()
+    pt = (
+        amr.ParticleTile_2_1_3_1_managed()
+        if amr.Config.have_gpu
+        else amr.ParticleTile_2_1_3_1_default()
+    )
     p = amr.Particle_2_1(1.0, 2.0, 3, rdata_0=4.0, rdata_1=5.0, rdata_2=6.0, idata_1=5)
     sp = amr.Particle_5_2(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9, 10)
     pt.push_back(p)


### PR DESCRIPTION
Add a `to_xp()` method that returns either NumPy or CuPy containers, depending on `amr.Config.have_gpu`, to all major AMReX data containers.

Close #216


### To Do

- [x] implement
- [x] update tests, disable default managed in tests
- [x] advertise prominently in zero-copy APIs and compute examples
- [x] run all tests on GPU (CUDA)