### PR TITLE
Sphinx: Release Upper Bound

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,9 +10,9 @@ numpy  # in public APIs
 pybind11-stubgen  # type hints in pyi files
 pygments
 recommonmark
-# Sphinx<7.2 because we are waiting for
+# Attention: we need to track the resolution of
 #   https://github.com/breathe-doc/breathe/issues/943
-sphinx>=5.3,<7.2
+sphinx>=5.3
 sphinx-copybutton
 sphinx-design
 sphinx_rtd_theme>=1.1.1


### PR DESCRIPTION
A backport in Sphinx resolved the current breathe issue we saw in Sphinx 7.2