### PR TITLE
Update HIP CI for ROCm 6.1.0

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -11,7 +11,7 @@ jobs:
     name: HIP
     runs-on: ubuntu-20.04
     env:
-      CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed -fno-operator-names"
+      CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"
       CMAKE_GENERATOR: Ninja
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We can no longer use `-fno-operator-names` because rocm 6.1.0 uses operator names such as `or` in macros.

X-ref:
https://github.com/AMReX-Codes/amrex/pull/3897