### PR TITLE
`isort`: AMReX as First Party Module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,5 @@ ignore = ["E402"]
 
 
 [tool.isort]
+known_first_party = ["amrex"]
 profile = "black"


### PR DESCRIPTION
Declare `amrex` our first party module, even if it is not installed yet. This resolves inconsistencies when sorting imports in developer or remote runs (pre-commit.com CI).