### PR TITLE
CI: Fix macOS

### DIFF
--- a/.github/workflows/dependencies/dependencies_mac.sh
+++ b/.github/workflows/dependencies/dependencies_mac.sh
@@ -12,3 +12,8 @@ brew install gfortran || true
 brew install libomp || true
 brew install open-mpi || true
 brew install ccache || true
+
+python3 -m venv venv
+source venv/bin/activate
+python3 -m pip install -U pip setuptools wheel pytest
+python3 -m pip install -U cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,8 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
+        source venv/bin/activate
+
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=600M
@@ -33,8 +35,6 @@ jobs:
 
         export CMAKE_BUILD_PARALLEL_LEVEL=3
 
-        python3 -m pip install -U pip setuptools wheel pytest
-        python3 -m pip install -U cmake
         python3 -m pip install -v .
         python3 -c "import amrex.space1d as amr; print(amr.__version__)"
         python3 -c "import amrex.space2d as amr; print(amr.__version__)"
@@ -45,6 +45,8 @@ jobs:
 
     - name: Unit tests
       run: |
+        source venv/bin/activate
+
         python3 -m pytest tests/
 
 


### PR DESCRIPTION
Account for recent homebrew breaking changes. Outdated docs:
https://docs.brew.sh/Homebrew-and-Python

Now outputs:
```
× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a Python library that isn't in Homebrew,
    use a virtual environment:

    python3 -m venv path/to/venv
    source path/to/venv/bin/activate
    python3 -m pip install xyz

    If you wish to install a Python application that isn't in Homebrew,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. You can install pipx with

    brew install pipx

    You may restore the old behavior of pip by passing
    the '--break-system-packages' flag to pip, or by adding
    'break-system-packages = true' to your pip.conf file. The latter
    will permanently disable this error.

    If you disable this error, we STRONGLY recommend that you additionally
    pass the '--user' flag to pip, or set 'user = true' in your pip.conf
    file. Failure to do this can result in a broken Homebrew installation.

    Read more about this behavior here: <https://peps.python.org/pep-0668/>

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
X-ref: https://peps.python.org/pep-0668