### PR TITLE
Fix CMake IPO Control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,13 @@ pyamrex_set_default_install_dirs()
 
 # Options and Variants ########################################################
 #
+set(_pyAMReX_IPO_DEFAULT ON)
+if(DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+    set(_pyAMReX_IPO_DEFAULT ${CMAKE_INTERPROCEDURAL_OPTIMIZATION})
+endif()
 option(pyAMReX_IPO
     "Compile with interprocedural optimization (IPO) / link-time optimization (LTO)"
-    ON
+    ${_pyAMReX_IPO_DEFAULT}
 )
 option(pyAMReX_INSTALL
     "Enable install targets for pyAMReX"
@@ -135,7 +139,13 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     target_link_libraries(pyAMReX_${D}d PUBLIC AMReX::amrex_${D}d)
     target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::module pybind11::windows_extras)
     if(pyAMReX_IPO)
-        target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::lto)
+        if(DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+            pyamrex_enable_IPO(pyAMReX_${D}d)
+        else()
+            # conditionally defined target in pybind11
+            # https://github.com/pybind/pybind11/blob/v2.12.0/tools/pybind11Common.cmake#L397-L403
+            target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::lto)
+        endif()
     endif()
 
     # set Python module properties

--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -223,6 +223,21 @@ macro(set_cxx_warnings)
 endmacro()
 
 
+# Enables interprocedural optimization for a list of targets
+#
+function(pyamrex_enable_IPO all_targets_list)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT is_IPO_available)
+    if(is_IPO_available)
+        foreach(tgt IN ITEMS ${all_targets_list})
+            set_target_properties(${tgt} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+        endforeach()
+    else()
+        message(FATAL_ERROR "Interprocedural optimization is not available, set pyAMReX_IPO=OFF")
+    endif()
+endfunction()
+
+
 # Set an MPI_TEST_EXE variable for test runs which runs num_ranks
 # ranks. On some systems, you might need to use the a specific
 # mpiexec wrapper, e.g. on Summit (ORNL) pass the hint


### PR DESCRIPTION
`pybind11::lto` is only defined if `CMAKE_INTERPROCEDURAL_OPTIMIZATION` is not set in [pybind11Common.cmake](https://github.com/pybind/pybind11/blob/v2.12.0/tools/pybind11Common.cmake#L397-L403). [Package managers like Spack use the latter.](https://github.com/spack/spack/pull/18374)