### PR TITLE
Fix Ubuntu 20.04 CI

### DIFF
--- a/.github/workflows/dependencies/dependencies_nvcc11.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc11.sh
@@ -24,8 +24,8 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" \
     | sudo tee /etc/apt/sources.list.d/cuda.list
 sudo apt-get update
 sudo apt-get install -y \

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -42,7 +42,7 @@ jobs:
         export CXX=$(which clang++)
         export CC=$(which clang)
 
-        python3 -m pip install -U pip setuptools wheel
+        python3 -m pip install -U pip importlib_metadata launchpadlib setuptools wheel
         python3 -m pip install -U cmake
 
         # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   tests-oneapi-sycl:
     name: oneAPI SYCL 3D
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies
@@ -58,7 +58,7 @@ jobs:
 
   tests-icpx:
     name: ICPX
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies
@@ -75,7 +75,8 @@ jobs:
     - name: Build & Install
       # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
       # mkl/rng/device/detail/mrg32k3a_impl.hpp has missing braces in array-array initalization
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare -Wno-missing-braces -Wno-error=pass-failed -Wno-tautological-constant-compare"}
+      # /usr/include/c++/12/bits/stl_tempbuf.h has deprecated-declarations in 'get_temporary_buffer<std::pair<long, int>>'
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare -Wno-missing-braces -Wno-error=pass-failed -Wno-tautological-constant-compare -Wno-deprecated-declarations"}
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
@@ -150,7 +151,7 @@ jobs:
 
         export CXX=$(which icpc)
         export CC=$(which icc)
-        python3 -m pip install -U pip setuptools wheel
+        python3 -m pip install -U pip importlib_metadata launchpadlib setuptools wheel
         python3 -m pip install -U cmake
         python3 -m pip install -U pytest mpi4py
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -222,7 +222,7 @@ jobs:
         export CXX=$(which g++)
         export CUDAHOSTCXX=$(which g++)
 
-        python3 -m pip install -U pip setuptools wheel
+        python3 -m pip install -U pip importlib_metadata launchpadlib setuptools wheel
         python3 -m pip install -U cmake
 
         cmake -S . -B build             \


### PR DESCRIPTION
Outdated lines and errors in CI jobs running on Ubuntu 20.04:
```
File "/home/runner/.local/lib/python3.8/site-packages/setuptools/_entry_points.py", line 44, in <module>
      def validate(eps: metadata.EntryPoints):
  AttributeError: module 'importlib_metadata' has no attribute 'EntryPoints'
  error: subprocess-exited-with-error
```

and before that a warning
```
Collecting pip
  Downloading pip-24.1.2-py3-none-any.whl (1.8 MB)
Collecting setuptools
  Downloading setuptools-71.0.0-py3-none-any.whl (908 kB)
Collecting wheel
  Downloading wheel-0.43.0-py3-none-any.whl (65 kB)
ERROR: launchpadlib 1.10.13 requires testresources, which is not installed.
Installing collected packages: pip, setuptools, wheel
Successfully installed pip-24.1.2 setuptools-71.0.0 wheel-0.43.0
Defaulting to user installation because normal site-packages is not writeable
```