### PR TITLE
Add overload_cast to IntVect::dim3()

### DIFF
--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -65,7 +65,8 @@ namespace
         ;
 
         if constexpr (dim >= 1 && dim <=3) {
-            py_iv.def("dim3", &iv_type::template dim3<dim>);
+            py_iv.def("dim3",
+               py::overload_cast<>(&iv_type::template dim3<dim>, py::const_));
         }
 
         py_iv


### PR DESCRIPTION
In https://github.com/AMReX-Codes/amrex/pull/4016 I want to add another overload to `dim3()` which will require an overload_cast here.