### PR TITLE
CI: Clarify GCC Debug Runner

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -55,7 +55,7 @@ jobs:
         mpiexec -np 1 python3 -m pytest tests/
 
   gcc10:
-    name: GNU@10.1
+    name: GNU@10.5 Debug
     runs-on: ubuntu-22.04
     env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
@@ -191,7 +191,7 @@ jobs:
         python3 -m pytest tests/
 
   nvcc11:
-    name: CUDA@11.2 GNU@9.3.0
+    name: CUDA@11.2 GNU@9.4.0
     runs-on: ubuntu-20.04
     env: {CXXFLAGS: "-fno-operator-names"}
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   msvc:
-    name: MSVC w/o MPI static release
+    name: MSVC w/o MPI Static Release
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       run: python3 -m pytest tests
 
   clang:
-    name: Clang w/o MPI shared debug
+    name: Clang w/o MPI Shared Debug
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
One GCC runner builds AMReX in `Debug` mode for more runtime tests. Reflect that in the name of the runner for clarity.

Confused a new contributor in #342