### PR TITLE
CI: Fix to ROCm 6.1

### DIFF
--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2022 The ImpactX Community
+# Copyright 2022 The AMReX Community
 #
 # License: BSD-3-Clause-LBNL
 # Authors: Axel Huebl
@@ -32,6 +32,7 @@ echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${1-latest} ${UBUNTU_COD
   | sudo tee /etc/apt/sources.list.d/rocm.list
 echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
   | sudo tee -a /etc/profile.d/rocm.sh
+
 # we should not need to export HIP_PATH=/opt/rocm/hip with those installs
 
 sudo apt-get update
@@ -65,3 +66,4 @@ which clang++
 sudo curl -L -o /usr/local/bin/cmake-easyinstall https://raw.githubusercontent.com/ax3l/cmake-easyinstall/main/cmake-easyinstall
 sudo chmod a+x /usr/local/bin/cmake-easyinstall
 export CEI_SUDO="sudo"
+export CEI_TMP="/tmp/cei"

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -39,7 +39,7 @@ jobs:
         hipcc --version
         which clang
         which clang++
-        export CXX=$(which clang++)
+        export CXX=$(which hipcc)
         export CC=$(which clang)
 
         python3 -m pip install -U pip importlib_metadata launchpadlib setuptools wheel

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build_hip:
     name: HIP
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"
       CMAKE_GENERATOR: Ninja

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -8,8 +8,8 @@ concurrency:
 
 jobs:
   build_hip:
-    name: ROCm HIP 6.2
-    runs-on: ubuntu-22.04
+    name: ROCm HIP 6.1
+    runs-on: ubuntu-20.04
     env:
       CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"
       CMAKE_GENERATOR: Ninja
@@ -18,7 +18,7 @@ jobs:
     - name: install dependencies
       shell: bash
       run: |
-        .github/workflows/dependencies/hip.sh 6.2
+        .github/workflows/dependencies/hip.sh 6.1
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v4
@@ -39,11 +39,16 @@ jobs:
         hipcc --version
         which clang
         which clang++
-        export CXX=$(which hipcc)
+        export CXX=$(which clang++)
         export CC=$(which clang)
 
         python3 -m pip install -U pip importlib_metadata launchpadlib setuptools wheel
         python3 -m pip install -U cmake
+
+        # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
+        #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
+        #   https://github.com/open-mpi/ompi/issues/9317
+        export LDFLAGS="-lopen-pal"
 
         cmake -S . -B build              \
             -DCMAKE_VERBOSE_MAKEFILE=ON  \

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build_hip:
-    name: HIP
+    name: ROCm HIP 6.2
     runs-on: ubuntu-22.04
     env:
       CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"
@@ -18,7 +18,7 @@ jobs:
     - name: install dependencies
       shell: bash
       run: |
-        .github/workflows/dependencies/hip.sh
+        .github/workflows/dependencies/hip.sh 6.2
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v4

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -45,11 +45,6 @@ jobs:
         python3 -m pip install -U pip importlib_metadata launchpadlib setuptools wheel
         python3 -m pip install -U cmake
 
-        # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
-        #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
-        #   https://github.com/open-mpi/ompi/issues/9317
-        export LDFLAGS="-lopen-pal"
-
         cmake -S . -B build              \
             -DCMAKE_VERBOSE_MAKEFILE=ON  \
             -DAMReX_GPU_BACKEND=HIP      \


### PR DESCRIPTION
ROCm 6.1.2->6.2.0 switches Clang 17 to 18.
The current setup led to linker issues on Ubuntu 20.04:
```
ld.lld: error: undefined hidden symbol: __hip_gpubin_handle_f20551e8c5453d2a
>>> referenced by ld-temp.o
>>>               lto.tmp:(__hip_module_ctor.1796)
>>> referenced by ld-temp.o
>>>               lto.tmp:(__hip_module_ctor.1796)
>>> referenced by ld-temp.o
>>>               lto.tmp:(__hip_module_dtor.1798)
>>> referenced 1 more times
```
https://rocm.docs.amd.com/projects/HIP/en/docs-5.7.1/user_guide/hip_porting_driver_api.html#hip-clang-implementation-notes
![image](https://github.com/user-attachments/assets/017ebc10-c5db-45ad-b8ec-91c621142411)

switch from clang++ to hipcc as the compiler.