### PR TITLE
CMake: More Pip Control Options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,9 @@ endif()
 
 # pip helpers for the amrex package ###########################################
 #
-set(PYINSTALLOPTIONS "" CACHE STRING
+set(PY_PIP_OPTIONS "-v" CACHE STRING
+    "Additional parameters to pass to `pip`")
+set(PY_PIP_INSTALL_OPTIONS "" CACHE STRING
     "Additional parameters to pass to `pip install`")
 
 # add a prefix to custom targets so we do not collide if used as a subproject
@@ -290,7 +292,7 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel
     ${CMAKE_COMMAND} -E rm -f -r amrex-whl
     COMMAND
         ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/
-            ${Python_EXECUTABLE} -m pip wheel -v --no-build-isolation --no-deps --wheel-dir=amrex-whl ${pyAMReX_SOURCE_DIR}
+            ${Python_EXECUTABLE} -m pip ${PY_PIP_OPTIONS} wheel --no-build-isolation --no-deps --wheel-dir=amrex-whl ${pyAMReX_SOURCE_DIR}
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS
@@ -299,7 +301,7 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel
 
 # this will also upgrade/downgrade dependencies, e.g., when the version of numpy changes
 add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install_requirements
-    ${Python_EXECUTABLE} -m pip install ${PYINSTALLOPTIONS} -r "${pyAMReX_SOURCE_DIR}/requirements.txt"
+    ${Python_EXECUTABLE} -m pip ${PY_PIP_OPTIONS} install ${PY_PIP_INSTALL_OPTIONS} -r "${pyAMReX_SOURCE_DIR}/requirements.txt"
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
 )
@@ -309,7 +311,7 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install_requirements
 # because otherwise pip would also force reinstall all dependencies.
 add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install
     ${CMAKE_COMMAND} -E env AMREX_MPI=${AMReX_MPI}
-        ${Python_EXECUTABLE} -m pip install --force-reinstall --no-index --no-deps ${PYINSTALLOPTIONS} --find-links=amrex-whl amrex
+        ${Python_EXECUTABLE} -m pip ${PY_PIP_OPTIONS} install --force-reinstall --no-index --no-deps ${PY_PIP_INSTALL_OPTIONS} --find-links=amrex-whl amrex
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS
@@ -321,7 +323,7 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install
 # this is for package managers only
 add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_install_nodeps
     ${CMAKE_COMMAND} -E env AMREX_MPI=${AMReX_MPI}
-        ${Python_EXECUTABLE} -m pip install --force-reinstall --no-index --no-deps ${PYINSTALLOPTIONS} --find-links=amrex-whl amrex
+        ${Python_EXECUTABLE} -m pip install --force-reinstall --no-index --no-deps ${PY_PIP_INSTALL_OPTIONS} --find-links=amrex-whl amrex
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}
     DEPENDS

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ If you are using the pip-driven install, selected [AMReX CMake options](https://
 | `PYAMREX_LIBDIR`             | *None*                                     | If set, search for pre-built a pyAMReX library               |
 | `PYAMREX_CCACHE`             | **ON**/OFF                                 | Search and use CCache to speed up rebuilds                   |
 | `PYAMREX_IPO`                | **ON**/OFF                                 | Compile with interprocedural/link optimization (IPO/LTO)     |
-| `PYINSTALLOPTIONS`           | *None*                                     | Additional options for ``pip install``, e.g., ``-v --user``  |
+| `PY_PIP_OPTIONS`             | `-v`                                       | Additional options for ``pip``, e.g., ``-vvv``               |
+| `PY_PIP_INSTALL_OPTIONS`     | *None*                                     | Additional options for ``pip install``, e.g., ``--user``     |
 
 Furthermore, pyAMReX adds a few selected CMake build options:
 

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -91,7 +91,8 @@ CMake Option                    Default & Values                             Des
 ``AMReX_SPACEDIM``              ``3``                                        Dimension(s) of AMReX as a ``;``-separated list
 ``AMReX_BUILD_SHARED_LIBS``     ON/**OFF**                                   Build AMReX library as shared (required for app extensions)
 ``pyAMReX_INSTALL``             **ON**/OFF                                   Enable install targets for pyAMReX
-``PYINSTALLOPTIONS``            *None*                                       Additional options for ``pip install``, e.g., ``-v --user``
+``PY_PIP_OPTIONS``              ``-v``                                       Additional options for ``pip``, e.g., ``-vvv``
+``PY_PIP_INSTALL_OPTIONS``      *None*                                       Additional options for ``pip install``, e.g., ``--user``
 ``Python_EXECUTABLE``           (newest found)                               Path to Python executable
 =============================== ============================================ ===========================================================
 


### PR DESCRIPTION
- `PY_PIP_OPTIONS`: Passed to `python -m pip ...`
- `PY_PIP_INSTALL_OPTIONS`: Passed to `python -m pip install ...` (formerly `PYINSTALLOPTIONS`)

Related to install control in https://github.com/spack/spack/pull/45251