### PR TITLE
Ruff: Run on pyi files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,24 +74,13 @@ repos:
 # Python: Ruff linter & formatter
 #   https://docs.astral.sh/ruff/
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.6
+  rev: v0.5.7
   hooks:
     # Run the linter
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
-      types_or: [python, jupyter]
     # Run the formatter
     - id: ruff-format
-
-# Sorts Python imports according to PEP8
-# https://www.python.org/dev/peps/pep-0008/#imports
-# Needed until https://github.com/astral-sh/ruff/issues/12872 is fixed
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-  - id: isort
-    name: isort (python)
-    args: ["--profile", "black", "--filter-files"]
 
 # Jupyter Notebooks: clean up all cell outputs
 - repo: https://github.com/roy-ht/pre-commit-jupyter

--- a/src/amrex/space1d/__init__.pyi
+++ b/src/amrex/space1d/__init__.pyi
@@ -96,10 +96,7 @@ from amrex.space1d.amrex_1d_pybind import (
     Geometry,
     GeometryData,
     IndexType,
-)
-from amrex.space1d.amrex_1d_pybind import IntVect1D
-from amrex.space1d.amrex_1d_pybind import IntVect1D as IntVect
-from amrex.space1d.amrex_1d_pybind import (
+    IntVect1D,
     IntVect2D,
     IntVect3D,
     MFInfo,
@@ -287,6 +284,7 @@ from amrex.space1d.amrex_1d_pybind import (
     unpack_ids,
     write_single_level_plotfile,
 )
+from amrex.space1d.amrex_1d_pybind import IntVect1D as IntVect
 
 from . import amrex_1d_pybind
 

--- a/src/amrex/space2d/__init__.pyi
+++ b/src/amrex/space2d/__init__.pyi
@@ -97,10 +97,7 @@ from amrex.space2d.amrex_2d_pybind import (
     GeometryData,
     IndexType,
     IntVect1D,
-)
-from amrex.space2d.amrex_2d_pybind import IntVect2D
-from amrex.space2d.amrex_2d_pybind import IntVect2D as IntVect
-from amrex.space2d.amrex_2d_pybind import (
+    IntVect2D,
     IntVect3D,
     MFInfo,
     MFIter,
@@ -311,6 +308,7 @@ from amrex.space2d.amrex_2d_pybind import (
     unpack_ids,
     write_single_level_plotfile,
 )
+from amrex.space2d.amrex_2d_pybind import IntVect2D as IntVect
 
 from . import amrex_2d_pybind
 

--- a/src/amrex/space3d/__init__.pyi
+++ b/src/amrex/space3d/__init__.pyi
@@ -98,10 +98,7 @@ from amrex.space3d.amrex_3d_pybind import (
     IndexType,
     IntVect1D,
     IntVect2D,
-)
-from amrex.space3d.amrex_3d_pybind import IntVect3D
-from amrex.space3d.amrex_3d_pybind import IntVect3D as IntVect
-from amrex.space3d.amrex_3d_pybind import (
+    IntVect3D,
     MFInfo,
     MFIter,
     MFItInfo,
@@ -287,6 +284,7 @@ from amrex.space3d.amrex_3d_pybind import (
     unpack_ids,
     write_single_level_plotfile,
 )
+from amrex.space3d.amrex_3d_pybind import IntVect3D as IntVect
 
 from . import amrex_3d_pybind
 


### PR DESCRIPTION
Ensure ruff is actually run on `.pyi` files.
They have a separate type `pyi` but we can just use the defaults, too.

Follow-up to #351 and 3a9a8c4b53881e35b5530f78b8526a3157bbcc56