### PR TITLE
CMake: Replace `FetchContent_Populate`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.24.0)
 project(pyAMReX VERSION 24.08)
 
 include(${pyAMReX_SOURCE_DIR}/cmake/pyAMReXFunctions.cmake)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you just want to use CMake to build the project, jump into sections *1. Intro
 pyAMReX depends on the following popular third party software.
 
 - a mature [C++17](https://en.wikipedia.org/wiki/C%2B%2B17) compiler, e.g., GCC 8, Clang 7, NVCC 11.0, MSVC 19.15 or newer
-- [CMake 3.20.0+](https://cmake.org)
+- [CMake 3.24.0+](https://cmake.org)
 - [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
 - [pybind11](https://github.com/pybind/pybind11/) 2.12.0+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
   - [Python](https://python.org) 3.8+
@@ -85,7 +85,7 @@ brew update
 brew install ccache cmake libomp mpi4py numpy open-mpi python
 ```
 
-Now, `cmake --version` should be at version 3.20.0 or newer.
+Now, `cmake --version` should be at version 3.24.0 or newer.
 
 Or go:
 ```bash

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -41,21 +41,16 @@ macro(find_amrex)
             endif()
             add_subdirectory(${pyAMReX_amrex_src} _deps/localamrex-build/)
         else()
+            if(AMReX_GPU_BACKEND STREQUAL CUDA)
+                enable_language(CUDA)
+            endif()
             FetchContent_Declare(fetchedamrex
                 GIT_REPOSITORY ${pyAMReX_amrex_repo}
                 GIT_TAG        ${pyAMReX_amrex_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedamrex)
-
-            if(NOT fetchedamrex_POPULATED)
-                FetchContent_Populate(fetchedamrex)
-                list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
-                if(AMReX_GPU_BACKEND STREQUAL CUDA)
-                    enable_language(CUDA)
-                endif()
-                add_subdirectory(${fetchedamrex_SOURCE_DIR} ${fetchedamrex_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedamrex)
+            list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -25,12 +25,7 @@ function(find_pybind11)
                 GIT_TAG        ${pyAMReX_pybind11_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedpybind11)
-
-            if(NOT fetchedpybind11_POPULATED)
-                FetchContent_Populate(fetchedpybind11)
-                add_subdirectory(${fetchedpybind11_SOURCE_DIR} ${fetchedpybind11_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedpybind11)
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -7,7 +7,7 @@ pyAMReX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 8.4+, Clang 7, NVCC 11.0, MSVC 19.15 or newer
-- `CMake 3.20.0+ <https://cmake.org>`__
+- `CMake 3.24.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy
 - `pybind11 2.12.0+ <https://github.com/pybind/pybind11/>`__: we automatically download and compile a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.20.0,<4.0.0",
+    "cmake>=3.24.0,<4.0.0",
     "packaging>=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -56,14 +56,14 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(["cmake", "--version"])
         except OSError:
             raise RuntimeError(
-                "CMake 3.20.0+ must be installed to build the following "
+                "CMake 3.24.0+ must be installed to build the following "
                 + "extensions: "
                 + ", ".join(e.name for e in self.extensions)
             )
 
         cmake_version = parse(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
-        if cmake_version < parse("3.20.0"):
-            raise RuntimeError("CMake >= 3.20.0 is required")
+        if cmake_version < parse("3.24.0"):
+            raise RuntimeError("CMake >= 3.24.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
In CMake superbuilds, `FetchContent_Populate` is now deprecated. Use `FetchContent_MakeAvailable` instead.