### PR TITLE
CI: Save PR Number Once

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -120,18 +120,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
-
-  save_pr_number:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Save PR number
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo $PR_NUMBER > pr_number.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pr_number
-          path: pr_number.txt
-          retention-days: 1


### PR DESCRIPTION
Only run the `save_pr_number` script once per PR.

@WeiqunZhang, should this run for all our workflows per PR
- [ ] last
- [ ] first
- [x] at any time in parallel to running tests
- [ ] only on success of all tests
- [ ] ...?