### PR TITLE
EB: On by Default in Superbuild

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -66,7 +66,8 @@ macro(find_amrex)
     elseif(NOT pyAMReX_amrex_internal)
         message(STATUS "Searching for pre-installed AMReX ...")
         # https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#importing-amrex-into-your-cmake-project
-        find_package(AMReX 24.09 CONFIG REQUIRED COMPONENTS EB PARTICLES PIC)
+        # not strictly required yet to compile pyAMReX: EB
+        find_package(AMReX 24.09 CONFIG REQUIRED COMPONENTS PARTICLES PIC)
         message(STATUS "AMReX: Found version '${AMReX_VERSION}'")
 
         if(AMReX_GPU_BACKEND STREQUAL CUDA)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -27,6 +27,7 @@ macro(find_amrex)
             set(AMReX_FPE OFF CACHE BOOL "")
         endif()
 
+        set(AMReX_EB ON CACHE INTERNAL "")
         set(AMReX_PIC ON CACHE INTERNAL "")
         set(AMReX_ENABLE_TESTS OFF CACHE INTERNAL "")
         set(AMReX_FORTRAN OFF CACHE INTERNAL "")
@@ -65,7 +66,7 @@ macro(find_amrex)
     elseif(NOT pyAMReX_amrex_internal)
         message(STATUS "Searching for pre-installed AMReX ...")
         # https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#importing-amrex-into-your-cmake-project
-        find_package(AMReX 24.09 CONFIG REQUIRED COMPONENTS PARTICLES PIC)
+        find_package(AMReX 24.09 CONFIG REQUIRED COMPONENTS EB PARTICLES PIC)
         message(STATUS "AMReX: Found version '${AMReX_VERSION}'")
 
         if(AMReX_GPU_BACKEND STREQUAL CUDA)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -85,7 +85,7 @@ option(pyAMReX_amrex_internal "Download & build AMReX" ON)
 set(pyAMReX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(pyAMReX_amrex_internal)")
-set(pyAMReX_amrex_branch "24.09"
+set(pyAMReX_amrex_branch "b454719b10b8d73307852788e54cc62db99a6814"
     CACHE STRING
     "Repository branch for pyAMReX_amrex_repo if(pyAMReX_amrex_internal)")
 

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -36,6 +36,15 @@ void init_AMReX(py::module& m)
             [](py::object) { return Verbose(); },
             [](py::object, const int v) { SetVerbose(v); })
         .def_property_readonly_static(
+            "have_eb",
+            [](py::object){
+#ifdef AMREX_USE_EB
+                return true;
+#else
+                return false;
+#endif
+            })
+        .def_property_readonly_static(
             "have_mpi",
             [](py::object){
 #ifdef AMREX_USE_MPI


### PR DESCRIPTION
Now that AMReX EBs are fully runtime controlled, we will default use them in dependent projects like WarpX and can default to them here as well.

X-ref: https://github.com/ECP-WarpX/WarpX/pull/4865