### PR TITLE
Implement multifab wrapper functionality from WarpX

### DIFF
--- a/docs/source/usage/compute.rst
+++ b/docs/source/usage/compute.rst
@@ -48,6 +48,14 @@ This is how to iterate and potentially compute for all blocks assigned to a loca
          :start-after: # Manual: Compute Mfab Detailed START
          :end-before: # Manual: Compute Mfab Detailed END
 
+   .. tab-item:: Global
+
+      .. literalinclude:: ../../../tests/test_multifab.py
+         :language: python3
+         :dedent: 4
+         :start-after: # Manual: Compute Mfab Global START
+         :end-before: # Manual: Compute Mfab Global END
+
 
 For a complete physics example that uses CPU/GPU agnostic Python code for computation on fields, see:
 

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -1,12 +1,21 @@
 """
 This file is part of pyAMReX
 
-Copyright 2023 AMReX community
-Authors: Axel Huebl
+Copyright 2024 AMReX community
+Authors: Axel Huebl, David Grote
 License: BSD-3-Clause-LBNL
 """
 
 from .Iterator import next
+
+import numpy as np
+
+try:
+    from mpi4py import MPI as mpi
+    comm_world = mpi.COMM_WORLD
+    npes = comm_world.Get_size()
+except ImportError:
+    npes = 1
 
 
 def mf_to_numpy(self, copy=False, order="F"):
@@ -173,6 +182,467 @@ def copy_multifab(amr, self):
     return mf
 
 
+def imesh(self, idir, include_ghosts=False):
+    """Returns the integer mesh along the specified direction with the appropriate centering.
+    This is the location of the data points in grid cell units.
+
+    Parameters
+    ----------
+    self : amrex.MultiFab
+        A MultiFab class in pyAMReX
+    direction : integer
+        Zero based direction number.
+        In a typical Cartesian case, 0 would be 'x' direction.
+    include_ghosts : bool, default=False
+        Whether or not ghost cells are included in the mesh.
+    """
+
+    min_box = self.box_array().minimal_box()
+    ilo = min_box.small_end[idir]
+    ihi = min_box.big_end[idir]
+
+    if include_ghosts:
+        # The ghost cells are added to the upper and lower end of the global domain.
+        nghosts = self.n_grow_vect
+        ilo -= nghosts[idir]
+        ihi += nghosts[idir]
+
+    # The centering shift
+    ix_type = self.box_array().ix_type()
+    if ix_type.node_centered(idir):
+        # node centered
+        shift = 0.0
+    else:
+        # cell centered
+        shift = 0.5
+
+    return np.arange(ilo, ihi + 1) + shift
+
+
+def shape(self, include_ghosts=False):
+    """Returns the shape of the global array
+
+    Parameters
+    ----------
+    self : amrex.MultiFab
+        A MultiFab class in pyAMReX
+    include_ghosts : bool, default=False
+        Whether or not ghost cells are included
+    """
+    min_box = self.box_array().minimal_box()
+    result = min_box.size
+    if include_ghosts:
+        result = result + 2*self.n_grow_vect
+    result = list(result) + [self.nComp]
+    return tuple(result)
+
+
+def _get_indices(index, missing):
+    """Expand the index list to length three.
+
+    Parameters
+    ----------
+    index: sequence of length dims
+        The indices for each dim
+
+    missing:
+        The value used to fill in the extra dimensions added
+    """
+    return list(index) + (3 - len(index))*[missing]
+
+
+def _get_min_indices(self, include_ghosts):
+    """Returns the minimum indices, expanded to length 3
+
+    Parameters
+    ----------
+    self : amrex.MultiFab
+        A MultiFab class in pyAMReX
+    include_ghosts : bool, default=False
+        Whether or not ghost cells are included
+    """
+    min_box = self.box_array().minimal_box()
+    if include_ghosts:
+        min_box.grow(self.n_grow_vect)
+    return _get_indices(min_box.small_end, 0)
+
+
+def _get_max_indices(self, include_ghosts):
+    """Returns the maximum indices, expanded to length 3.
+
+    Parameters
+    ----------
+    self : amrex.MultiFab
+        A MultiFab class in pyAMReX
+    include_ghosts : bool, default=False
+        Whether or not ghost cells are included
+    """
+    min_box = self.box_array().minimal_box()
+    if include_ghosts:
+        min_box.grow(self.n_grow_vect)
+    return _get_indices(min_box.big_end, 0)
+
+
+def _fix_index(self, ii, imax, d, include_ghosts):
+    """Handle negative index, wrapping them as needed.
+    When ghost cells are included, the indices are
+    shifted by the number of ghost cells before being wrapped.
+
+    Parameters
+    ----------
+    self : amrex.MultiFab
+        A MultiFab class in pyAMReX
+    ii : integer
+        The index to be wrapped
+    imax : integer
+        The maximum value that the index could have
+    d : integer
+        The direction of the index
+    include_ghosts: bool
+        Whether or not ghost cells are included
+    """
+    nghosts = list(_get_indices(self.n_grow_vect, 0)) + [0]
+    if include_ghosts:
+        ii += nghosts[d]
+    if ii < 0:
+        ii += imax
+    if include_ghosts:
+        ii -= nghosts[d]
+    return ii
+
+
+def _find_start_stop(self, ii, imin, imax, d, include_ghosts):
+    """Given the input index, calculate the start and stop range of the indices.
+
+    Parameters
+    ----------
+    ii : None, slice, or integer
+        Input index, either None, a slice object, or an integer.
+        Note that ii can be negative.
+    imin : integer
+        The global lowest lower bound in the specified direction.
+        This can include the ghost cells.
+    imax : integer
+        The global highest upper bound in the specified direction.
+        This can include the ghost cells.
+        This should be the max index + 1.
+    d : integer
+        The dimension number, 0, 1, 2, or 3 (3 being the components)
+    include_ghosts : bool
+        Whether or not ghost cells are included
+
+    If ii is a slice, the start and stop values are used directly,
+    unless they are None, then the lower or upper bound is used.
+    An assertion checks if the indices are within the bounds.
+    """
+    if ii is None:
+        iistart = imin
+        iistop = imax
+    elif isinstance(ii, slice):
+        if ii.start is None:
+            iistart = imin
+        else:
+            iistart = _fix_index(self, ii.start, imax, d, include_ghosts)
+        if ii.stop is None:
+            iistop = imax
+        else:
+            iistop = _fix_index(self, ii.stop, imax, d, include_ghosts)
+    else:
+        ii = _fix_index(self, ii, imax, d, include_ghosts)
+        iistart = ii
+        iistop = ii + 1
+    assert imin <= iistart <= imax, Exception(
+        f"Dimension {d+1} lower index is out of bounds"
+    )
+    assert imin <= iistop <= imax, Exception(
+        f"Dimension {d+1} upper index is out of bounds"
+    )
+    return iistart, iistop
+
+def _get_field(self, mfi, include_ghosts):
+    """Return the field at the given mfi.
+    If include ghosts is true, return the whole array, otherwise
+    return the interior slice that does not include the ghosts.
+
+    Parameters
+    ----------
+    self : amrex.MultiFab
+        A MultiFab class in pyAMReX
+    mfi : amrex.MFIiter
+        Index to the FAB of the MultiFab
+    include_ghosts : bool, default=False
+        Whether or not ghost cells are included
+    """
+    # Note that the array will always have 4 dimensions.
+    # even when dims < 3.
+    # The transpose is taken since the Python array interface to Array4 in
+    # self.array(mfi) is in C ordering.
+    # Note: transposing creates a view and not a copy.
+    import inspect
+    amr = inspect.getmodule(self)
+    if amr.Config.have_gpu:
+        device_arr = self.array(mfi).to_cupy(copy=False, order="F")
+    else:
+        device_arr = self.array(mfi).to_numpy(copy=False, order="F")
+    if not include_ghosts:
+        device_arr = device_arr[
+            tuple([slice(ng, -ng) for ng in self.n_grow_vect])
+        ]
+    return device_arr
+
+
+def _get_intersect_slice(self, mfi, starts, stops, icstart, icstop, include_ghosts):
+    """Return the slices where the block intersects with the global slice.
+    If the block does not intersect, return None.
+    This also shifts the block slices by the number of ghost cells in the
+    MultiFab arrays since the arrays include the ghost cells.
+
+    Parameters
+    ----------
+    mfi : MFIter
+        The MFIter instance for the current block,
+    starts : sequence
+        The minimum indices of the global slice.
+        These can be negative.
+    stops : sequence
+        The maximum indices of the global slice.
+        These can be negative.
+    icstart : integer
+        The minimum component index of the global slice.
+        These can be negative.
+    icstops : integer
+        The maximum component index of the global slice.
+        These can be negative.
+    include_ghosts : bool, default=False
+        Whether or not ghost cells are included
+
+    Returns
+    -------
+    block_slices : tuple or None
+        The slices of the intersections relative to the block
+    global_slices : tuple or None
+        The slices of the intersections relative to the global array where the data from individual block will go
+    """
+    box = mfi.tilebox()
+    if include_ghosts:
+        box.grow(self.n_grow_vect)
+
+    ilo = _get_indices(box.small_end, 0)
+    ihi = _get_indices(box.big_end, 0)
+
+    # Add 1 to the upper end to be consistent with the slicing notation
+    ihi_p1 = [i + 1 for i in ihi]
+    i1 = np.maximum(starts, ilo)
+    i2 = np.minimum(stops, ihi_p1)
+
+    if np.all(i1 < i2):
+        block_slices = []
+        global_slices = []
+        for i in range(3):
+            block_slices.append(slice(i1[i] - ilo[i], i2[i] - ilo[i]))
+            global_slices.append(slice(i1[i] - starts[i], i2[i] - starts[i]))
+
+        block_slices.append(slice(icstart, icstop))
+        global_slices.append(slice(0, icstop - icstart))
+
+        return tuple(block_slices), tuple(global_slices)
+    else:
+        return None, None
+
+
+def __getitem__(self, index):
+    """Returns slice of the MultiFab using global indexing.
+    The shape of the object returned depends on the number of ix, iy and iz specified, which
+    can be from none to all three. Note that the values of ix, iy and iz are
+    relative to the fortran indexing, meaning that 0 is the lower boundary
+    of the whole domain, and in fortran ordering, i.e. [ix,iy,iz].
+    This allows negative indexing, though with ghosts cells included, the first n-ghost negative
+    indices will refer to the lower guard cells.
+
+    Parameters
+    ----------
+    index : integer, or sequence of integers or slices, or Ellipsis
+        Index of the slice to return
+    """
+    # Temporary value until fixed
+    include_ghosts = False
+
+    # Get the number of dimensions. Is there a cleaner way to do this?
+    dims = len(self.n_grow_vect)
+
+    # Note that the index can have negative values (which wrap around) and has 1 added to the upper
+    # limit using python style slicing
+    if index == Ellipsis:
+        index = dims * [slice(None)]
+    elif isinstance(index, slice):
+        # If only one slice passed in, it was not wrapped in a list
+        index = [index]
+
+    if len(index) < dims + 1:
+        # Add extra dims to index, including for the component.
+        # These are the dims left out and assumed to extend over the full size of the dim
+        index = list(index)
+        while len(index) < dims + 1:
+            index.append(slice(None))
+    elif len(index) > dims + 1:
+        raise Exception("Too many indices given")
+
+    # Expand the indices to length 3
+    ii = _get_indices(index, None)
+    ic = index[-1]
+
+    # Global extent. These include the ghost cells when include_ghosts is True
+    ixmin, iymin, izmin = _get_min_indices(self, include_ghosts)
+    ixmax, iymax, izmax = _get_max_indices(self, include_ghosts)
+
+    # Setup the size of the array to be returned
+    ixstart, ixstop = _find_start_stop(self, ii[0], ixmin, ixmax + 1, 0, include_ghosts)
+    iystart, iystop = _find_start_stop(self, ii[1], iymin, iymax + 1, 1, include_ghosts)
+    izstart, izstop = _find_start_stop(self, ii[2], izmin, izmax + 1, 2, include_ghosts)
+    icstart, icstop = _find_start_stop(self, ic, 0, self.n_comp, 3, include_ghosts)
+
+    # Gather the data to be included in a list to be sent to other processes
+    starts = [ixstart, iystart, izstart]
+    stops = [ixstop, iystop, izstop]
+    datalist = []
+    for mfi in self:
+        block_slices, global_slices = _get_intersect_slice(
+            self, mfi, starts, stops, icstart, icstop, include_ghosts
+        )
+        if global_slices is not None:
+            # Note that the array will always have 4 dimensions.
+            device_arr = _get_field(self, mfi, include_ghosts)
+            slice_arr = device_arr[block_slices]
+            try:
+                # Copy data from host to device using cupy syntax
+                slice_arr = slice_arr.get()
+            except AttributeError:
+                # Array is already a numpy array on the host
+                pass
+            datalist.append((global_slices, slice_arr))
+
+    # Gather the data from all processors
+    if npes == 1:
+        all_datalist = [datalist]
+    else:
+        all_datalist = comm_world.allgather(datalist)
+
+    # Create the array to be returned
+    result_shape = (
+        max(0, ixstop - ixstart),
+        max(0, iystop - iystart),
+        max(0, izstop - izstart),
+        max(0, icstop - icstart),
+    )
+
+    # Now, copy the data into the result array
+    result_global = None
+    for datalist in all_datalist:
+        for global_slices, f_arr in datalist:
+            if result_global is None:
+                # Delay allocation to here so that the type can be obtained
+                result_global = np.zeros(result_shape, dtype=f_arr.dtype)
+            result_global[global_slices] = f_arr
+
+    if result_global is None:
+        # Something went wrong with the index and no data was found. Return an empty array.
+        result_global = np.zeros(0)
+
+    # Remove dimensions of length 1, and if all dimensions
+    # are removed, return a scalar (that's what the [()] does)
+    return result_global.squeeze()[()]
+
+
+def __setitem__(self, index, value):
+    """Sets slices of a decomposed array.
+    The shape of the input object depends on the number of arguments specified, which can
+    be from none to all three.
+    This allows negative indexing, though with ghosts cells included, the first n-ghost negative
+    indices will refer to the lower guard cells.
+
+    Parameters
+    ----------
+    index : integer, or sequence of integers or slices, or Ellipsis
+        The slice to set
+    value : scalar or array
+        Input value to assign to the specified slice of the MultiFab
+    """
+    # Temporary value until fixed
+    include_ghosts = False
+    # Get the number of dimensions. Is there a cleaner way to do this?
+    dims = len(self.n_grow_vect)
+
+    # Note that the index can have negative values (which wrap around) and has 1 added to the upper
+    # limit using python style slicing
+    if index == Ellipsis:
+        index = tuple(dims * [slice(None)])
+    elif isinstance(index, slice):
+        # If only one slice passed in, it was not wrapped in a list
+        index = [index]
+
+    if len(index) < dims + 1:
+        # Add extra dims to index, including for the component.
+        # These are the dims left out and assumed to extend over the full size of the dim.
+        index = list(index)
+        while len(index) < dims + 1:
+            index.append(slice(None))
+    elif len(index) > dims + 1:
+        raise Exception("Too many indices given")
+
+    # Expand the indices to length 3
+    ii = _get_indices(index, None)
+    ic = index[-1]
+
+    # Global extent. These include the ghost cells when include_ghosts is True
+    ixmin, iymin, izmin = _get_min_indices(self, include_ghosts)
+    ixmax, iymax, izmax = _get_max_indices(self, include_ghosts)
+
+    # Setup the size of the global array to be set
+    ixstart, ixstop = _find_start_stop(self, ii[0], ixmin, ixmax + 1, 0, include_ghosts)
+    iystart, iystop = _find_start_stop(self, ii[1], iymin, iymax + 1, 1, include_ghosts)
+    izstart, izstop = _find_start_stop(self, ii[2], izmin, izmax + 1, 2, include_ghosts)
+    icstart, icstop = _find_start_stop(self, ic, 0, self.n_comp, 3, include_ghosts)
+
+    if isinstance(value, np.ndarray):
+        # Expand the shape of the input array to match the shape of the global array
+        # (it needs to be 4-D).
+        # This converts value to an array if needed, and the [...] grabs a view so
+        # that the shape change below doesn't affect value.
+        value3d = np.array(value)[...]
+        global_shape = list(value3d.shape)
+        # The shape of 1 is added for the extra dimensions and when index is an integer
+        # (in which case the dimension was not in the input array).
+        if not isinstance(ii[0], slice):
+            global_shape[0:0] = [1]
+        if not isinstance(ii[1], slice):
+            global_shape[1:1] = [1]
+        if not isinstance(ii[2], slice):
+            global_shape[2:2] = [1]
+        if not isinstance(ic, slice) or len(global_shape) < 4:
+            global_shape[3:3] = [1]
+        value3d.shape = global_shape
+
+        if libwarpx.libwarpx_so.Config.have_gpu:
+            # check if cupy is available for use
+            xp, cupy_status = load_cupy()
+            if cupy_status is not None:
+                libwarpx.amr.Print(cupy_status)
+
+    starts = [ixstart, iystart, izstart]
+    stops = [ixstop, iystop, izstop]
+    for mfi in self:
+        block_slices, global_slices = _get_intersect_slice(
+            self, mfi, starts, stops, icstart, icstop, include_ghosts
+        )
+        if global_slices is not None:
+            mf_arr = _get_field(self, mfi, include_ghosts)
+            if isinstance(value, np.ndarray):
+                # The data is copied from host to device automatically if needed
+                mf_arr[block_slices] = value3d[global_slices]
+            else:
+                mf_arr[block_slices] = value
+
+
 def register_MultiFab_extension(amr):
     """MultiFab helper methods"""
 
@@ -191,3 +661,8 @@ def register_MultiFab_extension(amr):
 
     amr.MultiFab.copy = lambda self: copy_multifab(amr, self)
     amr.MultiFab.copy.__doc__ = copy_multifab.__doc__
+
+    amr.MultiFab.imesh = imesh
+    amr.MultiFab.shape = shape
+    amr.MultiFab.__getitem__ = __getitem__
+    amr.MultiFab.__setitem__ = __setitem__

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -232,9 +232,20 @@ def shape(self, include_ghosts=False):
     min_box = self.box_array().minimal_box()
     result = min_box.size
     if include_ghosts:
-        result = result + 2*self.n_grow_vect
+        result = result + self.n_grow_vect*2
     result = list(result) + [self.nComp]
     return tuple(result)
+
+
+def shape_with_ghost(self):
+    """Returns the shape of the global array including ghost cells
+
+    Parameters
+    ----------
+    self : amrex.MultiFab
+        A MultiFab class in pyAMReX
+    """
+    return shape(self, include_ghosts=True)
 
 
 def _get_indices(index, missing):
@@ -680,6 +691,7 @@ def register_MultiFab_extension(amr):
     amr.MultiFab.copy.__doc__ = copy_multifab.__doc__
 
     amr.MultiFab.imesh = imesh
-    amr.MultiFab.shape = shape
+    amr.MultiFab.shape = property(shape)
+    amr.MultiFab.shape_with_ghost = property(shape_with_ghost)
     amr.MultiFab.__getitem__ = __getitem__
     amr.MultiFab.__setitem__ = __setitem__

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -573,6 +573,7 @@ def __getitem__(self, index):
     else:
         try:
             from mpi4py import MPI as mpi
+
             comm_world = mpi.COMM_WORLD
         except ImportError:
             raise Exception("MultiFab.__getitem__ requires mpi4py")

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -237,7 +237,7 @@ def shape(self, include_ghosts=False):
     return tuple(result)
 
 
-def shape_with_ghost(self):
+def shape_with_ghosts(self):
     """Returns the shape of the global array including ghost cells
 
     Parameters
@@ -692,6 +692,6 @@ def register_MultiFab_extension(amr):
 
     amr.MultiFab.imesh = imesh
     amr.MultiFab.shape = property(shape)
-    amr.MultiFab.shape_with_ghost = property(shape_with_ghost)
+    amr.MultiFab.shape_with_ghosts = property(shape_with_ghosts)
     amr.MultiFab.__getitem__ = __getitem__
     amr.MultiFab.__setitem__ = __setitem__

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -511,7 +511,6 @@ def __getitem__(self, index):
         npes = amr.ParallelDescriptor.NProcs()
     else:
         npes = 1
-    print(f"\n\n\n\n npes = {npes}\n\n\n")
     if npes == 1:
         all_datalist = [datalist]
     else:

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -597,6 +597,10 @@ def __setitem__(self, index, value):
     value : scalar or array
         Input value to assign to the specified slice of the MultiFab
     """
+    import inspect
+
+    amr = inspect.getmodule(self)
+
     # Temporary value until fixed
     include_ghosts = False
     # Get the number of dimensions. Is there a cleaner way to do this?
@@ -652,11 +656,11 @@ def __setitem__(self, index, value):
             global_shape[3:3] = [1]
         value3d.shape = global_shape
 
-        if libwarpx.libwarpx_so.Config.have_gpu:
+        if amr.Config.have_gpu:
             # check if cupy is available for use
             xp, cupy_status = load_cupy()
             if cupy_status is not None:
-                libwarpx.amr.Print(cupy_status)
+                amr.Print(cupy_status)
 
     starts = [ixstart, iystart, izstart]
     stops = [ixstop, iystop, izstop]

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -6,12 +6,13 @@ Authors: Axel Huebl, David Grote
 License: BSD-3-Clause-LBNL
 """
 
-from .Iterator import next
-
 import numpy as np
+
+from .Iterator import next
 
 try:
     from mpi4py import MPI as mpi
+
     comm_world = mpi.COMM_WORLD
     npes = comm_world.Get_size()
 except ImportError:
@@ -232,7 +233,7 @@ def shape(self, include_ghosts=False):
     min_box = self.box_array().minimal_box()
     result = min_box.size
     if include_ghosts:
-        result = result + self.n_grow_vect*2
+        result = result + self.n_grow_vect * 2
     result = list(result) + [self.nComp]
     return tuple(result)
 
@@ -259,7 +260,7 @@ def _get_indices(index, missing):
     missing:
         The value used to fill in the extra dimensions added
     """
-    return list(index) + (3 - len(index))*[missing]
+    return list(index) + (3 - len(index)) * [missing]
 
 
 def _get_min_indices(self, include_ghosts):
@@ -370,6 +371,7 @@ def _find_start_stop(self, ii, imin, imax, d, include_ghosts):
     )
     return iistart, iistop
 
+
 def _get_field(self, mfi, include_ghosts):
     """Return the field at the given mfi.
     If include ghosts is true, return the whole array, otherwise
@@ -390,20 +392,20 @@ def _get_field(self, mfi, include_ghosts):
     # self.array(mfi) is in C ordering.
     # Note: transposing creates a view and not a copy.
     import inspect
+
     amr = inspect.getmodule(self)
     if amr.Config.have_gpu:
         device_arr = self.array(mfi).to_cupy(copy=False, order="F")
     else:
         device_arr = self.array(mfi).to_numpy(copy=False, order="F")
     if not include_ghosts:
-        device_arr = device_arr[
-            tuple([slice(ng, -ng) for ng in self.n_grow_vect])
-        ]
+        device_arr = device_arr[tuple([slice(ng, -ng) for ng in self.n_grow_vect])]
     return device_arr
 
 
-def _get_intersect_slice(self, mfi, starts, stops, icstart, icstop,
-                         include_ghosts, with_internal_ghosts):
+def _get_intersect_slice(
+    self, mfi, starts, stops, icstart, icstop, include_ghosts, with_internal_ghosts
+):
     """Return the slices where the block intersects with the global slice.
     If the block does not intersect, return None.
     This also shifts the block slices by the number of ghost cells in the

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -481,18 +481,24 @@ def _get_intersect_slice(
 
 
 def __getitem__(self, index):
-    """Returns slice of the MultiFab using global indexing.
+    """Returns slice of the MultiFab using global indexing, as a numpy array.
+    This uses numpy array indexing, with the indexing relative to the global array.
+    The slice ranges can cross multiple blocks and the result will be gathered into a single
+    array.
+
+    In an MPI context, this is a global operation. An "allgather" is performed so that the full
+    result is returned on all processors.
+
     The shape of the object returned depends on the number of ix, iy and iz specified, which
-    can be from none to all three. Note that the values of ix, iy and iz are
-    relative to the fortran indexing, meaning that 0 is the lower boundary
-    of the whole domain, and in fortran ordering, i.e. [ix,iy,iz].
-    This allows negative indexing, though with ghosts cells included, the first n-ghost negative
-    indices will refer to the lower guard cells.
+    can be from none to all three. Note that the values of ix, iy and iz are in fortran ordering,
+    i.e. [ix,iy,iz], and that 0 is the lower boundary of the whole domain.
 
     Parameters
     ----------
-    index : integer, or sequence of integers or slices, or Ellipsis
-        Index of the slice to return
+    index : the index using numpy style indexing
+        Index of the slice to return.
+        The slice for each dimension can be ":" for the whole range, a slice instance, or an integer.
+        An Ellipsis can be used to represent the full range of multiple dimensions, as with numpy.
     """
     # Temporary value until fixed
     include_ghosts = False
@@ -584,16 +590,23 @@ def __getitem__(self, index):
 
 
 def __setitem__(self, index, value):
-    """Sets slices of a decomposed array using global indexing.
-    The shape of the input object depends on the number of arguments specified, which can
-    be from none to all three.
-    This allows negative indexing, though with ghosts cells included, the first n-ghost negative
-    indices will refer to the lower guard cells.
+    """Sets the slice of the MultiFab using global indexing.
+    This uses numpy array indexing, with the indexing relative to the global array.
+    The slice ranges can cross multiple blocks and the value will be distributed accordingly.
+
+    In an MPI context, this is a local operation. On each processor, the blocks within the slice
+    range will be set to the value.
+
+    The shape of the value depends on the number of ix, iy and iz specified, which
+    can be from none to all three. Note that the values of ix, iy and iz are in fortran ordering,
+    i.e. [ix,iy,iz], and that 0 is the lower boundary of the whole domain.
 
     Parameters
     ----------
-    index : integer, or sequence of integers or slices, or Ellipsis
-        The slice to set
+    index : the index using numpy style indexing
+        Index of the slice to return.
+        The slice for each dimension can be ":" for the whole range, a slice instance, or an integer.
+        An Ellipsis can be used to represent the full range of multiple dimensions, as with numpy.
     value : scalar or array
         Input value to assign to the specified slice of the MultiFab
     """

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -511,6 +511,7 @@ def __getitem__(self, index):
         npes = amr.ParallelDescriptor.NProcs()
     else:
         npes = 1
+    print(f"\n\n\n\n npes = {npes}\n\n\n")
     if npes == 1:
         all_datalist = [datalist]
     else:

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -582,7 +582,7 @@ def __getitem__(self, index):
 
 
 def __setitem__(self, index, value):
-    """Sets slices of a decomposed array.
+    """Sets slices of a decomposed array using global indexing.
     The shape of the input object depends on the number of arguments specified, which can
     be from none to all three.
     This allows negative indexing, though with ghosts cells included, the first n-ghost negative

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -290,7 +290,7 @@ def _get_max_indices(self, include_ghosts):
 def _handle_imaginary_negative_index(index, imin, imax):
     """This convects imaginary and negative indices to the actual value"""
     if isinstance(index, complex):
-        assert (index.real == 0.), "Ghost indices must be purely imaginary"
+        assert index.real == 0.0, "Ghost indices must be purely imaginary"
         ii = int(index.imag)
         if ii <= 0:
             result = imin + ii
@@ -317,7 +317,9 @@ def _process_index(self, index):
         index = list(index)
         for i in range(len(index)):
             if index[i] == Ellipsis:
-                index = index[:i] + (dims + 2 - len(index))*[slice(None)] + index[i+1:]
+                index = (
+                    index[:i] + (dims + 2 - len(index)) * [slice(None)] + index[i + 1 :]
+                )
                 break
     else:
         raise Exception("MultiFab.__getitem__: unexpected index type")
@@ -325,7 +327,7 @@ def _process_index(self, index):
     if len(index) < dims + 1:
         # Add extra dims to index, including for the component.
         # These are the dims left out and assumed to extend over the valid cells
-        index = index + (dims + 1 - len(index))*[slice(None)]
+        index = index + (dims + 1 - len(index)) * [slice(None)]
     elif len(index) > dims + 1:
         raise Exception("Too many indices given")
 
@@ -344,7 +346,9 @@ def _process_index(self, index):
             if index[i].start is None:
                 start = mins[i]
             else:
-                start = _handle_imaginary_negative_index(index[i].start, mins[i], maxs[i])
+                start = _handle_imaginary_negative_index(
+                    index[i].start, mins[i], maxs[i]
+                )
             if index[i].stop is None:
                 stop = maxs[i] + 1
             else:
@@ -352,11 +356,15 @@ def _process_index(self, index):
             index[i] = slice(start, stop, index[i].step)
         elif isinstance(index[i], tuple):
             # The slice includes ghosts
-            assert len(index[i]) == 0, "Indicator to include all ghost cells must be an empty tuple"
+            assert (
+                len(index[i]) == 0
+            ), "Indicator to include all ghost cells must be an empty tuple"
             index[i] = slice(mins_with_ghost[i], maxs_with_ghost[i] + 1)
         else:
             ii = _handle_imaginary_negative_index(index[i], mins[i], maxs[i])
-            assert (mins_with_ghost[i] <= ii and ii <= maxs_with_ghost[i]), "Index out of range"
+            assert (
+                mins_with_ghost[i] <= ii and ii <= maxs_with_ghost[i]
+            ), "Index out of range"
             index[i] = slice(ii, ii + 1)
 
     return index
@@ -443,7 +451,9 @@ def _get_intersect_slice(self, mfi, index, with_internal_ghosts):
 
     if np.all(i1 < i2):
         block_slices = [slice(i1[i] - boxlo[i], i2[i] - boxlo[i]) for i in range(3)]
-        global_slices = [slice(i1[i] - index[i].start, i2[i] - index[i].start) for i in range(3)]
+        global_slices = [
+            slice(i1[i] - index[i].start, i2[i] - index[i].start) for i in range(3)
+        ]
 
         block_slices.append(index[3])
         global_slices.append(slice(0, index[3].stop - index[3].start))

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -622,10 +622,6 @@ def __setitem__(self, index, value):
     value : scalar or array
         Input value to assign to the specified slice of the MultiFab
     """
-    import inspect
-
-    amr = inspect.getmodule(self)
-
     # Temporary value until fixed
     include_ghosts = False
     # Get the number of dimensions. Is there a cleaner way to do this?
@@ -680,12 +676,6 @@ def __setitem__(self, index, value):
         if not isinstance(ic, slice) or len(global_shape) < 4:
             global_shape[3:3] = [1]
         value3d.shape = global_shape
-
-        if amr.Config.have_gpu:
-            # check if cupy is available for use
-            xp, cupy_status = load_cupy()
-            if cupy_status is not None:
-                amr.Print(cupy_status)
 
     starts = [ixstart, iystart, izstart]
     stops = [ixstop, iystop, izstop]

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -89,6 +89,14 @@ def test_mfab_numpy(mfab):
         # Components dimension, sets second component.
         mfab[-1j:2j,:,(),2] = np.full((nx+2, ny, nz+2*nghosts), 42.)
 
+        # Get a range of cells
+        # Get the data along the valid cells in the first dimension (gathering data across blocks
+        # and processors), at the first upper guard cell in the second dimensionn, and cell 16 of
+        # the third (with 16 being relative to 0 which is the lower end of the full domain).
+        # Note that in an MPI context, this is a global operation, so caution is required when
+        # scaling to large numbers of processors.
+        mfslice = mfab[:,1j,16]
+
     # Manual: Compute Mfab Global END
 
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -63,6 +63,24 @@ def test_mfab_numpy(mfab):
             field[()] = 42.0
     # Manual: Compute Mfab Simple END
 
+    # Manual: Compute Mfab Global START
+    # finest active MR level, get from a
+    # simulation's AmrMesh object, e.g.:
+    # finest_level = sim.finest_level
+    finest_level = 0  # no MR
+
+    # iterate over mesh-refinement levels
+    for lev in range(finest_level + 1):
+        # get an existing MultiFab, e.g.,
+        # from a simulation:
+        # mfab = sim.get_field(lev=lev)
+        # Config = sim.extension.Config
+
+        # Using global indexing
+        mfab[...] = 42.0
+
+    # Manual: Compute Mfab Global END
+
 
 @pytest.mark.skipif(amr.Config.have_gpu, reason="This test only runs on CPU")
 def test_mfab_loop_slow(mfab):

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -95,6 +95,9 @@ def test_mfab_numpy(mfab):
         # the third (with 16 being relative to 0 which is the lower end of the full domain).
         # Note that in an MPI context, this is a global operation, so caution is required when
         # scaling to large numbers of processors.
+        print(f"small end {mfab.box_array().minimal_box().small_end}")
+        print(f"big   end {mfab.box_array().minimal_box().big_end}")
+        print(f"nghosts   {mfab.n_grow_vect}")
         mfslice = mfab[:, 1j, 2]
         mfab[:, 1j, 2] = 2 * mfslice
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -96,7 +96,7 @@ def test_mfab_numpy(mfab):
         # Note that in an MPI context, this is a global operation, so caution is required when
         # scaling to large numbers of processors.
         mfslice = mfab[:, 1j, 16]
-        mfab[:, 1j, 16] = 2*mfslice
+        mfab[:, 1j, 16] = 2 * mfslice
 
     # Manual: Compute Mfab Global END
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -87,7 +87,7 @@ def test_mfab_numpy(mfab):
         # Third dimension, sets all valid and ghost cells
         #  - The empty tuple is used to specify the range to include all valid and ghost cells.
         # Components dimension, sets second component.
-        mfab[-1j:2j, :, (), 2] = np.full((nx + 2, ny, nz + 2 * nghosts), 42.0)
+        mfab[-1j:2j, :, (), 2] = 42.
 
         # Get a range of cells
         # Get the data along the valid cells in the first dimension (gathering data across blocks

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -95,8 +95,8 @@ def test_mfab_numpy(mfab):
         # the third (with 16 being relative to 0 which is the lower end of the full domain).
         # Note that in an MPI context, this is a global operation, so caution is required when
         # scaling to large numbers of processors.
-        mfslice = mfab[:, 1j, 16]
-        mfab[:, 1j, 16] = 2 * mfslice
+        mfslice = mfab[:, 1j, 2]
+        mfab[:, 1j, 2] = 2 * mfslice
 
     # Manual: Compute Mfab Global END
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -86,8 +86,8 @@ def test_mfab_numpy(mfab):
         # Second dimension, sets all valid cells.
         # Third dimension, sets all valid and ghost cells
         #  - The empty tuple is used to specify the range to include all valid and ghost cells.
-        # Components dimension, sets second component.
-        mfab[-1j:2j, :, (), 2] = 42.0
+        # Components dimension, sets first component.
+        mfab[-1j:2j, :, (), 0] = 42.0
 
         # Get a range of cells
         # Get the data along the valid cells in the first dimension (gathering data across blocks

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -96,6 +96,7 @@ def test_mfab_numpy(mfab):
         # Note that in an MPI context, this is a global operation, so caution is required when
         # scaling to large numbers of processors.
         mfslice = mfab[:, 1j, 16]
+        mfab[:, 1j, 16] = 2*mfslice
 
     # Manual: Compute Mfab Global END
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -95,9 +95,9 @@ def test_mfab_numpy(mfab):
         # the third (with 16 being relative to 0 which is the lower end of the full domain).
         # Note that in an MPI context, this is a global operation, so caution is required when
         # scaling to large numbers of processors.
-        print(f"small end {mfab.box_array().minimal_box().small_end}")
-        print(f"big   end {mfab.box_array().minimal_box().big_end}")
-        print(f"nghosts   {mfab.n_grow_vect}")
+        print(f"small end {list(mfab.box_array().minimal_box().small_end)}")
+        print(f"big   end {list(mfab.box_array().minimal_box().big_end)}")
+        print(f"nghosts   {list(mfab.n_grow_vect)}")
         mfslice = mfab[:, 1j, 2]
         mfab[:, 1j, 2] = 2 * mfslice
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -77,7 +77,17 @@ def test_mfab_numpy(mfab):
         # Config = sim.extension.Config
 
         # Using global indexing
+        # Set all valid cells
         mfab[...] = 42.0
+
+        # Set a range of cells. Indices are in Fortran order.
+        # First dimension, sets from first lower guard cell to first upper guard cell.
+        #  - Imaginary indices refer to the guard cells, negative lower, positive upper.
+        # Second dimension, sets all valid cells.
+        # Third dimension, sets all valid and ghost cells
+        #  - The empty tuple is used to specify the range to include all valid and ghost cells.
+        # Components dimension, sets second component.
+        mfab[-1j:2j,:,(),2] = np.full((nx+2, ny, nz+2*nghosts), 42.)
 
     # Manual: Compute Mfab Global END
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -95,11 +95,10 @@ def test_mfab_numpy(mfab):
         # the third (with 16 being relative to 0 which is the lower end of the full domain).
         # Note that in an MPI context, this is a global operation, so caution is required when
         # scaling to large numbers of processors.
-        print(f"small end {list(mfab.box_array().minimal_box().small_end)}")
-        print(f"big   end {list(mfab.box_array().minimal_box().big_end)}")
-        print(f"nghosts   {list(mfab.n_grow_vect)}")
-        mfslice = mfab[:, 1j, 2]
-        mfab[:, 1j, 2] = 2 * mfslice
+        if mfab.n_grow_vect.max > 0:
+            mfslice = mfab[:, 1j, 2]
+            # The assignment is to the last valid cell of the second dimension.
+            mfab[:, -1, 2] = 2 * mfslice
 
     # Manual: Compute Mfab Global END
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -87,7 +87,7 @@ def test_mfab_numpy(mfab):
         # Third dimension, sets all valid and ghost cells
         #  - The empty tuple is used to specify the range to include all valid and ghost cells.
         # Components dimension, sets second component.
-        mfab[-1j:2j,:,(),2] = np.full((nx+2, ny, nz+2*nghosts), 42.)
+        mfab[-1j:2j, :, (), 2] = np.full((nx + 2, ny, nz + 2 * nghosts), 42.0)
 
         # Get a range of cells
         # Get the data along the valid cells in the first dimension (gathering data across blocks
@@ -95,7 +95,7 @@ def test_mfab_numpy(mfab):
         # the third (with 16 being relative to 0 which is the lower end of the full domain).
         # Note that in an MPI context, this is a global operation, so caution is required when
         # scaling to large numbers of processors.
-        mfslice = mfab[:,1j,16]
+        mfslice = mfab[:, 1j, 16]
 
     # Manual: Compute Mfab Global END
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -87,7 +87,7 @@ def test_mfab_numpy(mfab):
         # Third dimension, sets all valid and ghost cells
         #  - The empty tuple is used to specify the range to include all valid and ghost cells.
         # Components dimension, sets second component.
-        mfab[-1j:2j, :, (), 2] = 42.
+        mfab[-1j:2j, :, (), 2] = 42.0
 
         # Get a range of cells
         # Get the data along the valid cells in the first dimension (gathering data across blocks


### PR DESCRIPTION
This adds the code from the WarpX fields.py that allows global indexing of MultiFabs. This is done by adding `__getitem__` and `__setitem__` methods for the MultiFab object. 

Note that this incorporates the changes from WarpX PR [#4370](https://github.com/ECP-WarpX/WarpX/pull/4370) that had not been merged in.

This currently only does the get/set without including the ghost cells. What is needed is a way of specifying  inclusion of the ghost cells. Perhaps this?
```py
mf = MultiFab()
mf[:,5,6]  # without ghost cells
mf[:,5,6] = 2.  # without ghost cells
mf.with_ghosts([slice(None),5,6])  # with ghost cells (in the first dimension)
mf.with_ghosts([slice(None),5,6], 2.)  # with ghost cells
```
Maybe this, using imaginary numbers to refer to ghost cells?
```py
mf[-1j,5,6]  # the first ghost cell on the lower boundary
mf[+1j,5,6]  # the first ghost cell on the upper boundary
mf[(),5,6]  # the full first dimension including ghosts
mf[:,5,6]  # the first dimension without ghosts
```
I prefer this method.