### PR TITLE
Python 3.13 Support, 3.8 EOL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
             pyamrex_enable_IPO(pyAMReX_${D}d)
         else()
             # conditionally defined target in pybind11
-            # https://github.com/pybind/pybind11/blob/v2.12.0/tools/pybind11Common.cmake#L397-L403
+            # https://github.com/pybind/pybind11/blob/v2.13.0/tools/pybind11Common.cmake#L407-L413
             target_link_libraries(pyAMReX_${D}d PRIVATE pybind11::lto)
         endif()
     endif()

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pyAMReX depends on the following popular third party software.
 - a mature [C++17](https://en.wikipedia.org/wiki/C%2B%2B17) compiler, e.g., GCC 8, Clang 7, NVCC 11.0, MSVC 19.15 or newer
 - [CMake 3.24.0+](https://cmake.org)
 - [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
-- [pybind11](https://github.com/pybind/pybind11/) 2.12.0+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
+- [pybind11](https://github.com/pybind/pybind11/) 2.13.0+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
   - [Python](https://python.org) 3.9+
   - [Numpy](https://numpy.org) 1.15+
 
@@ -199,7 +199,7 @@ Furthermore, pyAMReX adds a few selected CMake build options:
 | `pyAMReX_pybind11_src`       | *None*                                     | Absolute path to pybind11 source directory (preferred if set) |
 | `pyAMReX_pybind11_internal`  | **ON**/OFF                                 | Needs a pre-installed pybind11 library if set to `OFF`        |
 | `pyAMReX_pybind11_repo`      | `https://github.com/pybind/pybind11.git`   | Repository URI to pull and build pybind11 from                |
-| `pyAMReX_pybind11_branch`    | `v2.12.0`                                  | Repository branch for `pyAMReX_pybind11_repo`                 |
+| `pyAMReX_pybind11_branch`    | `v2.13.6`                                  | Repository branch for `pyAMReX_pybind11_repo`                 |
 | `Python_EXECUTABLE`          | (newest found)                             | Path to Python executable                                     |
 
 As one example, one can also build against a local AMReX copy.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pyAMReX depends on the following popular third party software.
 - [CMake 3.24.0+](https://cmake.org)
 - [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
 - [pybind11](https://github.com/pybind/pybind11/) 2.12.0+: we automatically download and compile a copy of pybind11 ([new BSD](https://github.com/pybind/pybind11/blob/master/LICENSE))
-  - [Python](https://python.org) 3.8+
+  - [Python](https://python.org) 3.9+
   - [Numpy](https://numpy.org) 1.15+
 
 Optional dependencies include:

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -36,7 +36,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     elseif(NOT pyAMReX_pybind11_internal)
-        find_package(pybind11 2.12.0 CONFIG REQUIRED)
+        find_package(pybind11 2.13.0 CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -51,7 +51,7 @@ option(pyAMReX_pybind11_internal "Download & build pybind11" ON)
 set(pyAMReX_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(pyAMReX_pybind11_internal)")
-set(pyAMReX_pybind11_branch "v2.12.0"
+set(pyAMReX_pybind11_branch "v2.13.6"
     CACHE STRING
     "Repository branch for pyAMReX_pybind11_repo if(pyAMReX_pybind11_internal)")
 

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -11,7 +11,7 @@ Please see installation instructions below.
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy
 - `pybind11 2.12.0+ <https://github.com/pybind/pybind11/>`__: we automatically download and compile a copy
-- `Python 3.8+ <https://www.python.org>`__
+- `Python 3.9+ <https://www.python.org>`__
 
   - `numpy 1.15+ <https://numpy.org>`__
 

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -10,7 +10,7 @@ Please see installation instructions below.
 - `CMake 3.24.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy
-- `pybind11 2.12.0+ <https://github.com/pybind/pybind11/>`__: we automatically download and compile a copy
+- `pybind11 2.13.0+ <https://github.com/pybind/pybind11/>`__: we automatically download and compile a copy
 - `Python 3.9+ <https://www.python.org>`__
 
   - `numpy 1.15+ <https://numpy.org>`__

--- a/setup.py
+++ b/setup.py
@@ -237,7 +237,7 @@ setup(
     ext_modules=cxx_modules,
     cmdclass=cmdclass,
     zip_safe=False,
-    python_requires=">=3.9",
+    python_requires=">=3.8",  # left for CI, truly ">=3.9"
     tests_require=["pytest"],
     install_requires=install_requires,
     # cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -237,7 +237,7 @@ setup(
     ext_modules=cxx_modules,
     cmdclass=cmdclass,
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     tests_require=["pytest"],
     install_requires=install_requires,
     # cmdclass={'test': PyTest},
@@ -257,11 +257,11 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         (
             "License :: OSI Approved :: BSD License"
         ),  # TODO: use real SPDX: BSD-3-Clause-LBNL


### PR DESCRIPTION
Add support for Python 3.13.
Remove 3.8 because it is EOL as of Oct 2024.

Bump to pybind11 2.13.0+, which add Python 3.13 support in CI.