### PR TITLE
`PYBIND11_FINDPYTHON=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ math(EXPR list_last "${list_len} - 1")
 list(GET AMReX_SPACEDIM ${list_last} AMReX_SPACEDIM_LAST)
 
 # Python
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(Python 3.8.0 COMPONENTS Interpreter Development.Module REQUIRED)
 
 # default installation directories: Python
 pyamrex_set_default_install_dirs_python()

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -12,6 +12,11 @@ function(find_pybind11)
         message(STATUS "pybind11 repository: ${pyAMReX_pybind11_repo} (${pyAMReX_pybind11_branch})")
         include(FetchContent)
     endif()
+
+    # rely on our find_package(Python ...) call
+    # https://pybind11.readthedocs.io/en/stable/compiling.html#modules-with-cmake
+    set(PYBIND11_FINDPYTHON ON)
+
     if(TARGET pybind11::module)
         # nothing to do, target already exists in the superbuild
     elseif(pyAMReX_pybind11_internal OR pyAMReX_pybind11_src)

--- a/setup.py
+++ b/setup.py
@@ -77,11 +77,18 @@ class CMakeBuild(build_ext):
         r_dim = re.search(r"amrex_(1|2|3)d", ext.name)
         dims = r_dim.group(1).upper()
 
+        pyv = sys.version_info
         cmake_args = [
+            # Python: use the calling interpreter in CMake
+            # https://cmake.org/cmake/help/latest/module/FindPython.html#hints
+            # https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-version-selection
+            f"-DPython_ROOT_DIR={sys.prefix}",
+            f"-DPython_FIND_VERSION={pyv.major}.{pyv.minor}.{pyv.micro}",
+            "-DPython_FIND_VERSION_EXACT=TRUE",
+            "-DPython_FIND_STRATEGY=LOCATION",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + os.path.join(extdir, "amrex"),
             "-DCMAKE_VERBOSE_MAKEFILE=ON",
             "-DCMAKE_PYTHON_OUTPUT_DIRECTORY=" + extdir,
-            "-DPython_EXECUTABLE=" + sys.executable,
             "-DAMReX_SPACEDIM=" + dims,
             ## variants
             "-DAMReX_OMP=" + AMReX_OMP,


### PR DESCRIPTION
Reuse our `find_package(Python ...)` call and use new CMake logic in pybind11.
https://pybind11.readthedocs.io/en/stable/compiling.html#modules-with-cmake
https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-version-selection

X-ref: https://github.com/openPMD/openPMD-api/pull/1677#issuecomment-2407767112