### PR TITLE
Fix getitem for cases with incomplete domains

### DIFF
--- a/src/Base/BoxArray.cpp
+++ b/src/Base/BoxArray.cpp
@@ -129,13 +129,15 @@ void init_BoxArray(py::module &m) {
     //! \brief Apply surroundingNodes(Box,int) to each Box in
     //! BoxArray.  See the documentation of Box for details.
     BoxArray& surroundingNodes (int dir);
+*/
 
     //! Apply Box::enclosedCells() to each Box in the BoxArray.
-    BoxArray& enclosedCells ();
+    .def("enclosed_cells",
+            py::overload_cast<>(&BoxArray::enclosedCells))
+    .def("enclosed_cells",
+            py::overload_cast<int>(&BoxArray::enclosedCells))
 
-    //! Apply Box::enclosedCells(int) to each Box in the BoxArray.
-    BoxArray& enclosedCells  (int dir);
-
+/*
     //! Apply Box::convert(IndexType) to each Box in the BoxArray.
     BoxArray& convert (IndexType typ);
 

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -536,9 +536,10 @@ def __getitem__(self, index, with_internal_ghosts=False):
     # including internal ghost cells, and the second time without. The second time is needed
     # to ensure that in places where ghost cells overlap with valid cells, that the data
     # from the valid cells is used.
-    # This check is whether the domain is complete is approximate (since it doesn't
-    # account for cases where boxes overlap each other).
-    domain_complete = self.box_array().numPts >= self.box_array().minimal_box().numPts()
+    # The domain is complete if the number of cells in the box array is the same as
+    # the number of cells in the minimal box.
+    cell_centered_box_array = self.box_array().enclosed_cells()
+    domain_complete = cell_centered_box_array.numPts == cell_centered_box_array.minimal_box().numPts()
 
     if domain_complete or with_internal_ghosts:
         result_global = None

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -539,7 +539,9 @@ def __getitem__(self, index, with_internal_ghosts=False):
     # The domain is complete if the number of cells in the box array is the same as
     # the number of cells in the minimal box.
     cell_centered_box_array = self.box_array().enclosed_cells()
-    domain_complete = cell_centered_box_array.numPts == cell_centered_box_array.minimal_box().numPts()
+    domain_complete = (
+        cell_centered_box_array.numPts == cell_centered_box_array.minimal_box().numPts()
+    )
 
     if domain_complete or with_internal_ghosts:
         result_global = None

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -493,7 +493,9 @@ def __getitem__(self, index, with_internal_ghosts=False):
     # Gather the data to be included in a list to be sent to other processes
     datalist = []
     for mfi in self:
-        block_slices, global_slices = _get_intersect_slice(self, mfi, index4, with_internal_ghosts)
+        block_slices, global_slices = _get_intersect_slice(
+            self, mfi, index4, with_internal_ghosts
+        )
         if global_slices is not None:
             # Note that the array will always have 4 dimensions.
             device_arr = _get_field(self, mfi)
@@ -536,7 +538,7 @@ def __getitem__(self, index, with_internal_ghosts=False):
     # from the valid cells is used.
     # This check is whether the domain is complete is approximate (since it doesn't
     # account for cases where boxes overlap each other).
-    domain_complete = (self.box_array().numPts >= self.box_array().minimal_box().numPts())
+    domain_complete = self.box_array().numPts >= self.box_array().minimal_box().numPts()
 
     if domain_complete or with_internal_ghosts:
         result_global = None


### PR DESCRIPTION
This is a fix for the global indexing mechanism in `MultiFab` that is needed in cases where the box array does not fully cover the domain. In those cases, the `__getitem__` is done twice, once to get all of the data including places where the ghost cells internal to the domain cover places that are not covered by valid cells, and a second time to ensure that in places where the ghost cells do overlap valid cells, that the data used is from the valid cells.