### PR TITLE
Fix case when only empty tuple is passed in

### DIFF
--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -314,13 +314,17 @@ def _process_index(self, index):
         # If only one slice or integer passed in, it was not wrapped in a tuple
         index = [index]
     elif isinstance(index, tuple):
-        index = list(index)
-        for i in range(len(index)):
-            if index[i] == Ellipsis:
-                index = (
-                    index[:i] + (dims + 2 - len(index)) * [slice(None)] + index[i + 1 :]
-                )
-                break
+        if len(index) == 0:
+            # The empty tuple specifies all valid and ghost cells
+            index = [index]
+        else:
+            index = list(index)
+            for i in range(len(index)):
+                if index[i] == Ellipsis:
+                    index = (
+                        index[:i] + (dims + 2 - len(index)) * [slice(None)] + index[i + 1 :]
+                    )
+                    break
     else:
         raise Exception("MultiFab.__getitem__: unexpected index type")
 

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -322,7 +322,9 @@ def _process_index(self, index):
             for i in range(len(index)):
                 if index[i] == Ellipsis:
                     index = (
-                        index[:i] + (dims + 2 - len(index)) * [slice(None)] + index[i + 1 :]
+                        index[:i]
+                        + (dims + 2 - len(index)) * [slice(None)]
+                        + index[i + 1 :]
                     )
                     break
     else:


### PR DESCRIPTION
One more fix for the global indexing of MultiFabs. I hadn't taken care of the case when only the empty tuple is passed in (for example for 1D). This PR fixes this case.