### PR TITLE
`MultiFab.__len__()`

### DIFF
--- a/src/Base/FabArray.cpp
+++ b/src/Base/FabArray.cpp
@@ -288,6 +288,8 @@ init_FabArray(py::module &m)
             "Return number of variables (aka components) associated with each point.")
         .def_property_readonly("size", &FabArrayBase::size,
             "Return the number of FABs in the FabArray.")
+        .def("__len__", &FabArrayBase::size,
+            "Return the number of FABs in the FabArray.")
 
         .def_property_readonly("n_grow_vect", &FabArrayBase::nGrowVect,
             "Return the grow factor (per direction) that defines the region of definition.")

--- a/tests/test_imultifab.py
+++ b/tests/test_imultifab.py
@@ -240,6 +240,8 @@ def test_imfab_ops(boxarr, distmap, nghost):
 
 
 def test_imfab_mfiter(imfab):
+    assert len(imfab) == 8
+
     assert iter(imfab).is_valid
     assert iter(imfab).length == 8
 

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -260,6 +260,8 @@ def test_mfab_ops(boxarr, distmap, nghost):
 
 
 def test_mfab_mfiter(mfab):
+    assert len(mfab) == 8
+
     assert iter(mfab).is_valid
     assert iter(mfab).length == 8
 


### PR DESCRIPTION
We already have `.size` and we can iterate the `FabArray`, so we should support `len(mf)`, too.

Seen in https://github.com/ECP-WarpX/WarpX/pull/4817