### PR TITLE
RTD: Fix GA Integration

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,3 +19,4 @@ sphinx_rtd_theme>=1.1.1
 # reference system
 #sphinxcontrib-bibtex
 #sphinxcontrib-napoleon
+sphinxcontrib-googleanalytics

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,8 +47,13 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_rtd_theme",
+    "sphinxcontrib.googleanalytics",
     "breathe",
 ]
+
+# Google Analytics
+googleanalytics_id = "G-TSZZK2V8V4"
+googleanalytics_enabled = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
GA was dropped from RTD in early Oct, 2024. This adds it again.