### PR TITLE
Python: Use `setuptools[core]`

### DIFF
--- a/.github/workflows/dependencies/dependencies_mac.sh
+++ b/.github/workflows/dependencies/dependencies_mac.sh
@@ -15,5 +15,5 @@ brew install ccache || true
 
 python3 -m venv venv
 source venv/bin/activate
-python3 -m pip install -U pip setuptools wheel pytest
+python3 -m pip install -U pip setuptools[core] wheel pytest
 python3 -m pip install -U cmake

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -40,7 +40,7 @@ jobs:
 
         export CC=$(which icx)
         export CXX=$(which icpx)
-        python3 -m pip install -U pip setuptools wheel
+        python3 -m pip install -U pip setuptools[core] wheel
         python3 -m pip install -U cmake
         python3 -m pip install -U pytest mpi4py
 
@@ -87,7 +87,7 @@ jobs:
 
         export CC=$(which icx)
         export CXX=$(which icpx)
-        python3 -m pip install -U pip setuptools wheel
+        python3 -m pip install -U pip setuptools[core] wheel
         python3 -m pip install -U cmake
         python3 -m pip install -U pytest mpi4py
 

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -61,7 +61,7 @@ jobs:
         export CCACHE_MAXSIZE=200M
         ccache -z
 
-        python3 -m pip install -U pip setuptools wheel
+        python3 -m pip install -U pip setuptools[core] wheel
         python3 -m pip install -U pip mpi4py pytest pybind11-stubgen pre-commit
         cmake -S . -B build -DAMReX_SPACEDIM="1;2;3" -DpyAMReX_IPO=OFF
         cmake --build build -j 4 --target pip_install

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
         export CMAKE_BUILD_PARALLEL_LEVEL=4
 
         python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools wheel
+        python3 -m pip install -U build packaging setuptools[core] wheel
         python3 -m pip install -U cmake pytest
         AMREX_MPI=ON python3 -m pip install -v .
         python3 -c "import amrex.space1d as amr; print(amr.__version__)"
@@ -83,7 +83,7 @@ jobs:
         export CC=$(which gcc-10)
         export CXX=$(which g++-10)
         python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools wheel
+        python3 -m pip install -U build packaging setuptools[core] wheel
         python3 -m pip install -U cmake
         python3 -m pip install -U pandas pytest mpi4py
 
@@ -137,7 +137,7 @@ jobs:
         export CC=$(which clang-6.0)
         export CXX=$(which clang++-6.0)
         python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools wheel
+        python3 -m pip install -U build packaging setuptools[core] wheel
         python3 -m pip install -U cmake pytest
         python3 -m pip install -v .
         python3 -c "import amrex.space1d as amr; print(amr.__version__)"
@@ -182,7 +182,7 @@ jobs:
         export CMAKE_BUILD_PARALLEL_LEVEL=4
 
         python3 -m pip install -U pip
-        python3 -m pip install -U build packaging setuptools wheel
+        python3 -m pip install -U build packaging setuptools[core] wheel
         python3 -m pip install -U cmake
         python3 -m pip install -U pandas pytest
         python3 -m pip install -v .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build
       run: |
-        python3 -m pip install -U pip setuptools wheel pytest
+        python3 -m pip install -U pip setuptools[core] wheel pytest
         python3 -m pip install -U cmake
         python3 -m pip install -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Now, `cmake --version` should be at version 3.24.0 or newer.
 Or go:
 ```bash
 python3 -m pip install -U pip
-python3 -m pip install -U build packaging setuptools wheel
+python3 -m pip install -U build packaging setuptools[core] wheel
 python3 -m pip install -U cmake
 ```
 

--- a/docs/source/developers/testing.rst
+++ b/docs/source/developers/testing.rst
@@ -13,7 +13,7 @@ In order to run our tests, you need to have a few :ref:`Python packages installe
 .. code-block:: sh
 
    python3 -m pip install -U pip
-   python3 -m pip install -U build packaging setuptools wheel pytest
+   python3 -m pip install -U build packaging setuptools[core] wheel pytest
    python3 -m pip install -r requirements.txt
 
 

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -34,7 +34,7 @@ On your development machine, :ref:`follow the instructions here <install-depende
    .. code-block:: bash
 
       python3 -m pip install -U pip
-      python3 -m pip install -U build packaging setuptools wheel pytest
+      python3 -m pip install -U build packaging setuptools[core] wheel pytest
       python3 -m pip install -U -r requirements.txt
 
 


### PR DESCRIPTION
Install instructions for `setuptools` pip packages changed.
https://setuptools.pypa.io/en/latest/userguide/quickstart.html

Removes CI issues of this kind: https://github.com/pypa/setuptools/issues/4483#issuecomment-2236528158