### PR TITLE
`SmallMatrix.__repr__` like NumPy

### DIFF
--- a/src/Base/SmallMatrix.H
+++ b/src/Base/SmallMatrix.H
@@ -130,15 +130,22 @@ namespace
         py::class_< SM > py_sm(m, sm_name.c_str());
         py_sm
             .def("__repr__",
-                 [sm_name](SM const &) {
-                     return "<amrex." + sm_name + ">";
-                 }
-            )
-            .def("__str__",
-                 [sm_name](SM const & sm) {
+                [](SM const & sm) {
+                     // similar look & feel like numpy.ndarray.__repr__
                      std::stringstream ss;
-                     ss << sm;
-                     return ss.str();
+                     for (int i = sm.starting_index; i < sm.row_size + sm.starting_index; ++i) {
+                         if (i > sm.starting_index) { ss << ",\n             "; }
+                         ss << "[";
+                         ss << sm(i, sm.starting_index);
+                         for (int j = 1 + sm.starting_index; j < sm.column_size + sm.starting_index; ++j) {
+                            ss << ", " << sm(i, j);
+                         }
+                         ss << "]";
+                     }
+                     using namespace std::string_literals;
+                     return "SmallMatrix(["s +
+                            ss.str() +
+                            "])"s;
                  }
             )
 


### PR DESCRIPTION
Ensure that printing the `SmallMatrix` looks & feels like the equivalent in `numpy.ndarray`:
```
SmallMatrix([[1, 7, 13, 19, 25, 31],
             [2, 8, 14, 20, 26, 32],
             [3, 9, 15, 21, 27, 33],
             [4, 10, 16, 22, 28, 34],
             [5, 11, 17, 23, 29, 35],
             [6, 12, 18, 24, 30, 36]])
```