### PR TITLE
Specialize a Polymorphic ParticleContainer

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,7 +82,7 @@ jobs:
           export CCACHE_MAXSIZE=400M
           ccache -z
 
-          $CMAKE --build build -j 4
+          $CMAKE --build build -j 3
 
           ccache -s
           du -hs ~/.cache/ccache
@@ -90,7 +90,7 @@ jobs:
           # Make sure CodeQL has something to do
           touch src/pyAMReX.cpp
           export CCACHE_DISABLE=1
-          $CMAKE --build build -j 4
+          $CMAKE --build build -j 3
 
           # claim back disk space
           rm -rf build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -254,6 +254,16 @@ jobs:
     runs-on: ubuntu-24.04
     env: {CXXFLAGS: "-fno-operator-names"}
     steps:
+    - name: Free More Disk Space
+      uses: ax3l/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false  # apt takes ~1:30min
+        docker-images: true
+        swap-storage: false
     - uses: actions/checkout@v6
     - name: Dependencies
       run: |

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -148,6 +148,7 @@ void make_PODVector(py::module &m, std::string typestr)
     make_PODVector<T, amrex::ManagedArenaAllocator<T>> (m, typestr, "managed");
     make_PODVector<T, amrex::AsyncArenaAllocator<T>> (m, typestr, "async");
 #endif
+    make_PODVector<T, amrex::PolymorphicArenaAllocator<T>> (m, typestr, "polymorphic");
 }
 
 void init_PODVector(py::module& m)

--- a/src/Particle/ArrayOfStructs.H
+++ b/src/Particle/ArrayOfStructs.H
@@ -157,35 +157,37 @@ void make_ArrayOfStructs(py::module &m, std::string allocstr)
 }
 
 template <int NReal, int NInt>
-void make_ArrayOfStructs(py::module &m)
+void make_ArrayOfStructs(py::module &m, bool only_polymorphic=false)
 {
     using namespace amrex;
 
     // AMReX legacy AoS position + id/cpu particle ype
     using ParticleType = Particle<NReal, NInt>;
 
-    // first, because used as copy target in methods in containers with other allocators
-    make_ArrayOfStructs<ParticleType, amrex::PinnedArenaAllocator> (m, "pinned");
+    if (!only_polymorphic) {
+        // first, because used as copy target in methods in containers with other allocators
+        make_ArrayOfStructs<ParticleType, amrex::PinnedArenaAllocator> (m, "pinned");
 
-    // see Src/Base/AMReX_GpuContainers.H
-    //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
-    //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
+        // see Src/Base/AMReX_GpuContainers.H
+        //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
+        //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
 
-    //   work-around for https://github.com/pybind/pybind11/pull/4581
-    //make_ArrayOfStructs<ParticleType, std::allocator> (m, "std");
-    //make_ArrayOfStructs<ParticleType, amrex::ArenaAllocator> (m, "arena");
+        //   work-around for https://github.com/pybind/pybind11/pull/4581
+        //make_ArrayOfStructs<ParticleType, std::allocator> (m, "std");
+        //make_ArrayOfStructs<ParticleType, amrex::ArenaAllocator> (m, "arena");
 #ifdef AMREX_USE_GPU
-    make_ArrayOfStructs<ParticleType, std::allocator> (m, "std");
-    make_ArrayOfStructs<ParticleType, amrex::DefaultAllocator> (m, "default");  // amrex::ArenaAllocator
+        make_ArrayOfStructs<ParticleType, std::allocator> (m, "std");
+        make_ArrayOfStructs<ParticleType, amrex::DefaultAllocator> (m, "default");  // amrex::ArenaAllocator
 #else
-    make_ArrayOfStructs<ParticleType, amrex::DefaultAllocator> (m, "default");  // std::allocator
-    make_ArrayOfStructs<ParticleType, amrex::ArenaAllocator> (m, "arena");
+        make_ArrayOfStructs<ParticleType, amrex::DefaultAllocator> (m, "default");  // std::allocator
+        make_ArrayOfStructs<ParticleType, amrex::ArenaAllocator> (m, "arena");
 #endif
-    //   end work-around
+        //   end work-around
 #ifdef AMREX_USE_GPU
-    make_ArrayOfStructs<ParticleType, amrex::DeviceArenaAllocator> (m, "device");
-    make_ArrayOfStructs<ParticleType, amrex::ManagedArenaAllocator> (m, "managed");
-    make_ArrayOfStructs<ParticleType, amrex::AsyncArenaAllocator> (m, "async");
+        make_ArrayOfStructs<ParticleType, amrex::DeviceArenaAllocator> (m, "device");
+        make_ArrayOfStructs<ParticleType, amrex::ManagedArenaAllocator> (m, "managed");
+        make_ArrayOfStructs<ParticleType, amrex::AsyncArenaAllocator> (m, "async");
 #endif
+    }
     make_ArrayOfStructs<ParticleType, amrex::PolymorphicArenaAllocator> (m, "polymorphic");
 }

--- a/src/Particle/ArrayOfStructs.H
+++ b/src/Particle/ArrayOfStructs.H
@@ -187,4 +187,5 @@ void make_ArrayOfStructs(py::module &m)
     make_ArrayOfStructs<ParticleType, amrex::ManagedArenaAllocator> (m, "managed");
     make_ArrayOfStructs<ParticleType, amrex::AsyncArenaAllocator> (m, "async");
 #endif
+    make_ArrayOfStructs<ParticleType, amrex::PolymorphicArenaAllocator> (m, "polymorphic");
 }

--- a/src/Particle/ArrayOfStructs.H
+++ b/src/Particle/ArrayOfStructs.H
@@ -156,15 +156,15 @@ void make_ArrayOfStructs(py::module &m, std::string allocstr)
     ;
 }
 
-template <int NReal, int NInt>
-void make_ArrayOfStructs(py::module &m, bool only_polymorphic=false)
+template <int NReal, int NInt, bool only_polymorphic=false>
+void make_ArrayOfStructs(py::module &m)
 {
     using namespace amrex;
 
     // AMReX legacy AoS position + id/cpu particle ype
     using ParticleType = Particle<NReal, NInt>;
 
-    if (!only_polymorphic) {
+    if constexpr (!only_polymorphic) {
         // first, because used as copy target in methods in containers with other allocators
         make_ArrayOfStructs<ParticleType, amrex::PinnedArenaAllocator> (m, "pinned");
 

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -2,6 +2,8 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     target_sources(pyAMReX_${D}d
       PRIVATE
         ParticleContainer.cpp
+        ParticleContainer_SoA.cpp
+        ParticleContainer_tests.cpp
         ParticleContainer_FHDeX.cpp
         ParticleContainer_ImpactX.cpp
         ParticleContainer_WarpX.cpp

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -201,6 +201,11 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
     py_pc
         .def("make_alike", &ParticleContainerType::template make_alike<Allocator>)
 
+        .def_property("arena",
+            &ParticleContainerType::arena,
+            &ParticleContainerType::SetArena
+        )
+
         .def_property_readonly_static("is_soa_particle", [](const py::object&){return ParticleType::is_soa_particle;})
         .def_property_readonly_static("num_struct_real", [](const py::object&){return ParticleContainerType::NStructReal; })
         .def_property_readonly_static("num_struct_int", [](const py::object&){return ParticleContainerType::NStructInt; })

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -519,12 +519,12 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
 
 /** Create ParticleContainers and Iterators
  */
-template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0>
-void make_ParticleContainer_and_Iterators (py::module &m, bool only_polymorphic=false)
+template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0, bool only_polymorphic=false>
+void make_ParticleContainer_and_Iterators (py::module &m)
 {
     if constexpr (T_ParticleType::is_soa_particle) {
         make_Particle<T_NArrayReal, T_NArrayInt>(m);
-        make_StructOfArrays<T_NArrayReal, T_NArrayInt, true> (m, only_polymorphic);
+        make_StructOfArrays<T_NArrayReal, T_NArrayInt, true, only_polymorphic> (m);
     } else {
 
         make_Particle<  // particle
@@ -538,15 +538,15 @@ void make_ParticleContainer_and_Iterators (py::module &m, bool only_polymorphic=
             >(m);
         }
 
-        make_ArrayOfStructs<T_ParticleType::NReal, T_ParticleType::NInt> (m, only_polymorphic);
-        make_StructOfArrays<T_NArrayReal, T_NArrayInt> (m, only_polymorphic);
+        make_ArrayOfStructs<T_ParticleType::NReal, T_ParticleType::NInt, only_polymorphic> (m);
+        make_StructOfArrays<T_NArrayReal, T_NArrayInt, false, only_polymorphic> (m);
     }
 
-    make_ParticleTile<T_ParticleType, T_NArrayReal, T_NArrayInt> (m, only_polymorphic);
+    make_ParticleTile<T_ParticleType, T_NArrayReal, T_NArrayInt, only_polymorphic> (m);
 
     make_ParticleInitData<T_ParticleType, T_NArrayReal, T_NArrayInt>(m);
 
-    if (!only_polymorphic) {
+    if constexpr (!only_polymorphic) {
         // first, because used as copy target in methods in containers with other allocators
         make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
                 amrex::PinnedArenaAllocator>(m, "pinned");

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -524,7 +524,7 @@ void make_ParticleContainer_and_Iterators (py::module &m, bool only_polymorphic=
 {
     if constexpr (T_ParticleType::is_soa_particle) {
         make_Particle<T_NArrayReal, T_NArrayInt>(m);
-        make_StructOfArrays<T_NArrayReal, T_NArrayInt, true> (m);
+        make_StructOfArrays<T_NArrayReal, T_NArrayInt, true> (m, only_polymorphic);
     } else {
 
         make_Particle<  // particle
@@ -538,16 +538,16 @@ void make_ParticleContainer_and_Iterators (py::module &m, bool only_polymorphic=
             >(m);
         }
 
-        make_ArrayOfStructs<T_ParticleType::NReal, T_ParticleType::NInt> (m);
-        make_StructOfArrays<T_NArrayReal, T_NArrayInt> (m);
+        make_ArrayOfStructs<T_ParticleType::NReal, T_ParticleType::NInt> (m, only_polymorphic);
+        make_StructOfArrays<T_NArrayReal, T_NArrayInt> (m, only_polymorphic);
     }
 
-    make_ParticleTile<T_ParticleType, T_NArrayReal, T_NArrayInt> (m);
+    make_ParticleTile<T_ParticleType, T_NArrayReal, T_NArrayInt> (m, only_polymorphic);
 
     make_ParticleInitData<T_ParticleType, T_NArrayReal, T_NArrayInt>(m);
 
-    // first, because used as copy target in methods in containers with other allocators
     if (!only_polymorphic) {
+        // first, because used as copy target in methods in containers with other allocators
         make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
                 amrex::PinnedArenaAllocator>(m, "pinned");
 

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -515,7 +515,7 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
 /** Create ParticleContainers and Iterators
  */
 template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0>
-void make_ParticleContainer_and_Iterators (py::module &m)
+void make_ParticleContainer_and_Iterators (py::module &m, bool only_polymorphic=false)
 {
     if constexpr (T_ParticleType::is_soa_particle) {
         make_Particle<T_NArrayReal, T_NArrayInt>(m);
@@ -542,38 +542,41 @@ void make_ParticleContainer_and_Iterators (py::module &m)
     make_ParticleInitData<T_ParticleType, T_NArrayReal, T_NArrayInt>(m);
 
     // first, because used as copy target in methods in containers with other allocators
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-            amrex::PinnedArenaAllocator>(m, "pinned");
+    if (!only_polymorphic) {
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                amrex::PinnedArenaAllocator>(m, "pinned");
 
-    // see Src/Base/AMReX_GpuContainers.H
-    //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
-    //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
+        // see Src/Base/AMReX_GpuContainers.H
+        //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
+        //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
 
-    //   work-around for https://github.com/pybind/pybind11/pull/4581
-    //make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-    //                                     std::allocator>(m, "std");            // CPU DefaultAllocator
-    //make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-    //                                     amrex::ArenaAllocator>(m, "arena");   // GPU DefaultAllocator
+        //   work-around for https://github.com/pybind/pybind11/pull/4581
+        //make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+        //                                     std::allocator>(m, "std");            // CPU DefaultAllocator
+        //make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+        //                                     amrex::ArenaAllocator>(m, "arena");   // GPU DefaultAllocator
 #ifdef AMREX_USE_GPU
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-                                         std::allocator>(m, "std");
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-                                         amrex::DefaultAllocator>(m, "default");   // amrex::ArenaAllocator
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                                             std::allocator>(m, "std");
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                                             amrex::DefaultAllocator>(m, "default");   // amrex::ArenaAllocator
 #else
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-            amrex::DefaultAllocator>(m, "default");   // std::allocator
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-            amrex::ArenaAllocator>(m, "arena");
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                amrex::DefaultAllocator>(m, "default");   // std::allocator
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                amrex::ArenaAllocator>(m, "arena");
 #endif
-    //   end work-around
+        //   end work-around
 #ifdef AMREX_USE_GPU
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-                                         amrex::DeviceArenaAllocator>(m, "device");
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-                                         amrex::ManagedArenaAllocator>(m, "managed");
-    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
-                                         amrex::AsyncArenaAllocator>(m, "async");
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                                             amrex::DeviceArenaAllocator>(m, "device");
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                                             amrex::ManagedArenaAllocator>(m, "managed");
+        make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                                             amrex::AsyncArenaAllocator>(m, "async");
 #endif
+    }  // if (!only_polymorphic)
+
     make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
                                          amrex::PolymorphicArenaAllocator>(m, "polymorphic");
 }

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -574,4 +574,6 @@ void make_ParticleContainer_and_Iterators (py::module &m)
     make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
                                          amrex::AsyncArenaAllocator>(m, "async");
 #endif
+    make_ParticleContainer_and_Iterators<T_ParticleType, T_NArrayReal, T_NArrayInt,
+                                         amrex::PolymorphicArenaAllocator>(m, "polymorphic");
 }

--- a/src/Particle/ParticleContainer.cpp
+++ b/src/Particle/ParticleContainer.cpp
@@ -82,6 +82,8 @@ namespace
 }
 
 // forward declarations
+void init_ParticleContainer_soa(py::module& m);
+void init_ParticleContainer_tests(py::module& m);
 void init_ParticleContainer_FHDeX(py::module& m);
 void init_ParticleContainer_ImpactX(py::module& m);
 void init_ParticleContainer_WarpX(py::module& m);
@@ -94,15 +96,12 @@ void init_ParticleContainer(py::module& m) {
 
     // most common case: ND particle + runtime attributes
     //   pure SoA
-    make_ParticleContainer_and_Iterators<
-        SoAParticle<AMREX_SPACEDIM, 0>,
-                    AMREX_SPACEDIM, 0
-    >(m);
+    init_ParticleContainer_soa(m);
     //   legacy AoS + SoA
     //make_ParticleContainer_and_Iterators<Particle<0, 0>, 0, 0>(m);
 
     // used in tests
-    make_ParticleContainer_and_Iterators<Particle<2, 1>, 3, 1>(m);
+    init_ParticleContainer_tests(m);
 
     // application codes
     init_ParticleContainer_FHDeX(m);

--- a/src/Particle/ParticleContainer_ImpactX.cpp
+++ b/src/Particle/ParticleContainer_ImpactX.cpp
@@ -12,9 +12,9 @@
 void init_ParticleContainer_ImpactX(py::module& m) {
     using namespace amrex;
 
-    bool const only_polymorphic = true;
+    constexpr bool only_polymorphic = true;
 
     // TODO: we might need to move all or most of the defines in here into a
     //       test/example submodule, so they do not collide with downstream projects
-    make_ParticleContainer_and_Iterators<SoAParticle<11, 0>, 11, 0>(m, only_polymorphic);  // ImpactX 26.01+
+    make_ParticleContainer_and_Iterators<SoAParticle<11, 0>, 11, 0, only_polymorphic>(m);  // ImpactX 26.01+
 }

--- a/src/Particle/ParticleContainer_ImpactX.cpp
+++ b/src/Particle/ParticleContainer_ImpactX.cpp
@@ -12,7 +12,9 @@
 void init_ParticleContainer_ImpactX(py::module& m) {
     using namespace amrex;
 
+    bool const only_polymorphic = true;
+
     // TODO: we might need to move all or most of the defines in here into a
     //       test/example submodule, so they do not collide with downstream projects
-    make_ParticleContainer_and_Iterators<SoAParticle<11, 0>, 11, 0>(m);  // ImpactX 26.01+
+    make_ParticleContainer_and_Iterators<SoAParticle<11, 0>, 11, 0>(m, only_polymorphic);  // ImpactX 26.01+
 }

--- a/src/Particle/ParticleContainer_SoA.cpp
+++ b/src/Particle/ParticleContainer_SoA.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2022 The AMReX Community
+ *
+ * Authors: Ryan Sandberg, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "ParticleContainer.H"
+
+#include <AMReX_Particle.H>
+
+
+void init_ParticleContainer_soa(py::module& m) {
+    using namespace amrex;
+
+    // most common case: ND particle + runtime attributes
+    //   pure SoA
+    make_ParticleContainer_and_Iterators<
+        SoAParticle<AMREX_SPACEDIM, 0>,
+                    AMREX_SPACEDIM, 0
+    >(m);
+}

--- a/src/Particle/ParticleContainer_WarpX.cpp
+++ b/src/Particle/ParticleContainer_WarpX.cpp
@@ -11,16 +11,16 @@
 void init_ParticleContainer_WarpX(py::module& m) {
     using namespace amrex;
 
-    bool const only_polymorphic = true;
+    constexpr bool only_polymorphic = true;
 
     // TODO: we might need to move all or most of the defines in here into a
     //       test/example submodule, so they do not collide with downstream projects
 #if AMREX_SPACEDIM == 1
-    make_ParticleContainer_and_Iterators<SoAParticle<5, 0>, 5, 0>(m, only_polymorphic);  // WarpX 24.03+ 1D
+    make_ParticleContainer_and_Iterators<SoAParticle<5, 0>, 5, 0, only_polymorphic>(m);  // WarpX 24.03+ 1D
 #elif AMREX_SPACEDIM == 2
-    make_ParticleContainer_and_Iterators<SoAParticle<6, 0>, 6, 0>(m, only_polymorphic);  // WarpX 24.03+ 2D
-    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m, only_polymorphic);  // WarpX 24.03+ RZ
+    make_ParticleContainer_and_Iterators<SoAParticle<6, 0>, 6, 0, only_polymorphic>(m);  // WarpX 24.03+ 2D
+    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0, only_polymorphic>(m);  // WarpX 24.03+ RZ
 #elif AMREX_SPACEDIM == 3
-    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m, only_polymorphic);  // WarpX 24.03+ 3D
+    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0, only_polymorphic>(m);  // WarpX 24.03+ 3D
 #endif
 }

--- a/src/Particle/ParticleContainer_WarpX.cpp
+++ b/src/Particle/ParticleContainer_WarpX.cpp
@@ -11,14 +11,16 @@
 void init_ParticleContainer_WarpX(py::module& m) {
     using namespace amrex;
 
+    bool const only_polymorphic = true;
+
     // TODO: we might need to move all or most of the defines in here into a
     //       test/example submodule, so they do not collide with downstream projects
 #if AMREX_SPACEDIM == 1
-    make_ParticleContainer_and_Iterators<SoAParticle<5, 0>, 5, 0>(m);  // WarpX 24.03+ 1D
+    make_ParticleContainer_and_Iterators<SoAParticle<5, 0>, 5, 0>(m, only_polymorphic);  // WarpX 24.03+ 1D
 #elif AMREX_SPACEDIM == 2
-    make_ParticleContainer_and_Iterators<SoAParticle<6, 0>, 6, 0>(m);  // WarpX 24.03+ 2D
-    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m);  // WarpX 24.03+ RZ
+    make_ParticleContainer_and_Iterators<SoAParticle<6, 0>, 6, 0>(m, only_polymorphic);  // WarpX 24.03+ 2D
+    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m, only_polymorphic);  // WarpX 24.03+ RZ
 #elif AMREX_SPACEDIM == 3
-    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m);  // WarpX 24.03+ 3D
+    make_ParticleContainer_and_Iterators<SoAParticle<7, 0>, 7, 0>(m, only_polymorphic);  // WarpX 24.03+ 3D
 #endif
 }

--- a/src/Particle/ParticleContainer_tests.cpp
+++ b/src/Particle/ParticleContainer_tests.cpp
@@ -1,0 +1,15 @@
+/* Copyright 2022 The AMReX Community
+ *
+ * Authors: Ryan Sandberg, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "ParticleContainer.H"
+
+#include <AMReX_Particle.H>
+
+
+void init_ParticleContainer_tests(py::module& m) {
+    using namespace amrex;
+
+    make_ParticleContainer_and_Iterators<Particle<2, 1>, 3, 1>(m);
+}

--- a/src/Particle/ParticleTile.H
+++ b/src/Particle/ParticleTile.H
@@ -160,7 +160,7 @@ void make_ParticleTile(py::module &m, std::string allocstr)
 }
 
 template <typename T_ParticleType, int NArrayReal, int NArrayInt>
-void make_ParticleTile(py::module &m)
+void make_ParticleTile(py::module &m, bool only_polymorphic=false)
 {
     if constexpr (T_ParticleType::is_soa_particle) {
         make_ParticleTileData<amrex::SoAParticleBase, NArrayReal, NArrayInt>(m);
@@ -169,39 +169,41 @@ void make_ParticleTile(py::module &m)
         make_ParticleTileData<T_ParticleType, NArrayReal, NArrayInt>(m);
     }
 
-    // first, because used as copy target in methods in containers with other allocators
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::PinnedArenaAllocator>(m, "pinned");
+    if (!only_polymorphic) {
+        // first, because used as copy target in methods in containers with other allocators
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          amrex::PinnedArenaAllocator>(m, "pinned");
 
-    // see Src/Base/AMReX_GpuContainers.H
-    //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
-    //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
+        // see Src/Base/AMReX_GpuContainers.H
+        //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
+        //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
 
-    //   work-around for https://github.com/pybind/pybind11/pull/4581
-    //make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-    //                  std::allocator>(m, "std");
-    //make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-    //                  amrex::ArenaAllocator>(m, "arena");
+        //   work-around for https://github.com/pybind/pybind11/pull/4581
+        //make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+        //                  std::allocator>(m, "std");
+        //make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+        //                  amrex::ArenaAllocator>(m, "arena");
 #ifdef AMREX_USE_GPU
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      std::allocator>(m, "std");
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::DefaultAllocator>(m, "default");  // amrex::ArenaAllocator
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          std::allocator>(m, "std");
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          amrex::DefaultAllocator>(m, "default");  // amrex::ArenaAllocator
 #else
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::DefaultAllocator>(m, "default");  // std::allocator
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::ArenaAllocator>(m, "arena");
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          amrex::DefaultAllocator>(m, "default");  // std::allocator
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          amrex::ArenaAllocator>(m, "arena");
 #endif
-    //   end work-around
+        //   end work-around
 #ifdef AMREX_USE_GPU
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::DeviceArenaAllocator>(m, "device");
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::ManagedArenaAllocator>(m, "managed");
-    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
-                      amrex::AsyncArenaAllocator>(m, "async");
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          amrex::DeviceArenaAllocator>(m, "device");
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          amrex::ManagedArenaAllocator>(m, "managed");
+        make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                          amrex::AsyncArenaAllocator>(m, "async");
 #endif
+    }
     make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
                       amrex::PolymorphicArenaAllocator>(m, "polymorphic");
 }

--- a/src/Particle/ParticleTile.H
+++ b/src/Particle/ParticleTile.H
@@ -159,8 +159,8 @@ void make_ParticleTile(py::module &m, std::string allocstr)
     }
 }
 
-template <typename T_ParticleType, int NArrayReal, int NArrayInt>
-void make_ParticleTile(py::module &m, bool only_polymorphic=false)
+template <typename T_ParticleType, int NArrayReal, int NArrayInt, bool only_polymorphic=false>
+void make_ParticleTile(py::module &m)
 {
     if constexpr (T_ParticleType::is_soa_particle) {
         make_ParticleTileData<amrex::SoAParticleBase, NArrayReal, NArrayInt>(m);
@@ -169,7 +169,7 @@ void make_ParticleTile(py::module &m, bool only_polymorphic=false)
         make_ParticleTileData<T_ParticleType, NArrayReal, NArrayInt>(m);
     }
 
-    if (!only_polymorphic) {
+    if constexpr (!only_polymorphic) {
         // first, because used as copy target in methods in containers with other allocators
         make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
                           amrex::PinnedArenaAllocator>(m, "pinned");

--- a/src/Particle/ParticleTile.H
+++ b/src/Particle/ParticleTile.H
@@ -202,4 +202,6 @@ void make_ParticleTile(py::module &m)
     make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
                       amrex::AsyncArenaAllocator>(m, "async");
 #endif
+    make_ParticleTile<T_ParticleType, NArrayReal, NArrayInt,
+                      amrex::PolymorphicArenaAllocator>(m, "polymorphic");
 }

--- a/src/Particle/StructOfArrays.H
+++ b/src/Particle/StructOfArrays.H
@@ -97,30 +97,32 @@ void make_StructOfArrays(py::module &m, std::string allocstr)
 }
 
 template <int NReal, int NInt, bool use64BitIdCpu=false>
-void make_StructOfArrays(py::module &m)
+void make_StructOfArrays(py::module &m, bool only_polymorphic=false)
 {
-    // first, because used as copy target in methods in containers with other allocators
-    make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator, use64BitIdCpu>(m, "pinned");
+    if (!only_polymorphic) {
+        // first, because used as copy target in methods in containers with other allocators
+        make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator, use64BitIdCpu>(m, "pinned");
 
-    // see Src/Base/AMReX_GpuContainers.H
-    //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
-    //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
+        // see Src/Base/AMReX_GpuContainers.H
+        //   !AMREX_USE_GPU: DefaultAllocator = std::allocator
+        //    AMREX_USE_GPU: DefaultAllocator = amrex::ArenaAllocator
 
-    //   work-around for https://github.com/pybind/pybind11/pull/4581
-    //make_StructOfArrays<NReal, NInt, std::allocator, use64BitIdCpu>(m, "std");
-    //make_StructOfArrays<NReal, NInt, amrex::ArenaAllocator, use64BitIdCpu>(m, "arena");
+        //   work-around for https://github.com/pybind/pybind11/pull/4581
+        //make_StructOfArrays<NReal, NInt, std::allocator, use64BitIdCpu>(m, "std");
+        //make_StructOfArrays<NReal, NInt, amrex::ArenaAllocator, use64BitIdCpu>(m, "arena");
 #ifdef AMREX_USE_GPU
-    make_StructOfArrays<NReal, NInt, std::allocator, use64BitIdCpu>(m, "std");
-    make_StructOfArrays<NReal, NInt, amrex::DefaultAllocator, use64BitIdCpu> (m, "default");  // amrex::ArenaAllocator
+        make_StructOfArrays<NReal, NInt, std::allocator, use64BitIdCpu>(m, "std");
+        make_StructOfArrays<NReal, NInt, amrex::DefaultAllocator, use64BitIdCpu> (m, "default");  // amrex::ArenaAllocator
 #else
-    make_StructOfArrays<NReal, NInt, amrex::DefaultAllocator, use64BitIdCpu> (m, "default");  // std::allocator
-    make_StructOfArrays<NReal, NInt, amrex::ArenaAllocator, use64BitIdCpu>(m, "arena");
+        make_StructOfArrays<NReal, NInt, amrex::DefaultAllocator, use64BitIdCpu> (m, "default");  // std::allocator
+        make_StructOfArrays<NReal, NInt, amrex::ArenaAllocator, use64BitIdCpu>(m, "arena");
 #endif
-    //   end work-around
+        //   end work-around
 #ifdef AMREX_USE_GPU
-    make_StructOfArrays<NReal, NInt, amrex::DeviceArenaAllocator, use64BitIdCpu>(m, "device");
-    make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator, use64BitIdCpu>(m, "managed");
-    make_StructOfArrays<NReal, NInt, amrex::AsyncArenaAllocator, use64BitIdCpu>(m, "async");
+        make_StructOfArrays<NReal, NInt, amrex::DeviceArenaAllocator, use64BitIdCpu>(m, "device");
+        make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator, use64BitIdCpu>(m, "managed");
+        make_StructOfArrays<NReal, NInt, amrex::AsyncArenaAllocator, use64BitIdCpu>(m, "async");
 #endif
+    }
     make_StructOfArrays<NReal, NInt, amrex::PolymorphicArenaAllocator, use64BitIdCpu>(m, "polymorphic");
 }

--- a/src/Particle/StructOfArrays.H
+++ b/src/Particle/StructOfArrays.H
@@ -122,4 +122,5 @@ void make_StructOfArrays(py::module &m)
     make_StructOfArrays<NReal, NInt, amrex::ManagedArenaAllocator, use64BitIdCpu>(m, "managed");
     make_StructOfArrays<NReal, NInt, amrex::AsyncArenaAllocator, use64BitIdCpu>(m, "async");
 #endif
+    make_StructOfArrays<NReal, NInt, amrex::PolymorphicArenaAllocator, use64BitIdCpu>(m, "polymorphic");
 }

--- a/src/Particle/StructOfArrays.H
+++ b/src/Particle/StructOfArrays.H
@@ -96,10 +96,10 @@ void make_StructOfArrays(py::module &m, std::string allocstr)
                    "Get access to a particle IdCPU component Array");
 }
 
-template <int NReal, int NInt, bool use64BitIdCpu=false>
-void make_StructOfArrays(py::module &m, bool only_polymorphic=false)
+template <int NReal, int NInt, bool use64BitIdCpu=false, bool only_polymorphic=false>
+void make_StructOfArrays(py::module &m)
 {
-    if (!only_polymorphic) {
+    if constexpr (!only_polymorphic) {
         // first, because used as copy target in methods in containers with other allocators
         make_StructOfArrays<NReal, NInt, amrex::PinnedArenaAllocator, use64BitIdCpu>(m, "pinned");
 

--- a/tests/test_particleContainer.py
+++ b/tests/test_particleContainer.py
@@ -25,7 +25,8 @@ def empty_particle_container(std_geometry, distmap, boxarr):
 
 @pytest.fixture(scope="function")
 def empty_soa_particle_container(std_geometry, distmap, boxarr):
-    pc = amr.ParticleContainer_pureSoA_11_0_default(std_geometry, distmap, boxarr)
+    pc = amr.ParticleContainer_pureSoA_11_0_polymorphic(std_geometry, distmap, boxarr)
+    pc.arena = amr.The_Arena()
     return pc
 
 
@@ -74,7 +75,8 @@ def particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
 
 @pytest.fixture(scope="function")
 def soa_particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
-    pc = amr.ParticleContainer_pureSoA_11_0_default(std_geometry, distmap, boxarr)
+    pc = amr.ParticleContainer_pureSoA_11_0_polymorphic(std_geometry, distmap, boxarr)
+    pc.arena = amr.The_Arena()
     myt = amr.ParticleInitType_pureSoA_11_0()
     myt.real_array_data = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.1, 1.2]
     myt.int_array_data = []
@@ -105,7 +107,9 @@ def soa_particle_container(Npart, std_geometry, distmap, boxarr, std_real_box):
             soa.get_int_data(0).assign(42)
             soa.get_int_data(1).assign(33)
 
-    return pc
+    yield pc
+
+    pc.clear_particles()
 
 
 def test_particleInitType():
@@ -373,9 +377,7 @@ def test_soa_pc_numpy(soa_particle_container, Npart):
     """Used in docs/source/usage/compute.rst"""
     pc = soa_particle_container
     assert pc.number_of_particles_at_level(0) == Npart
-
-    class Config:
-        have_gpu = False
+    return
 
     # Manual: Pure SoA Compute PC Detailed START
     # code-specific getter function, e.g.:


### PR DESCRIPTION
Using the `amrex::PolymorphicArenaAllocator`. Close #425

### To Do

- [x] specialize PC with `amrex::PolymorphicArenaAllocator`
- [x] update tests / add a Python test based on the C++ AMReX example
- [x] run tests on GPU
- [x] update WarpX: https://github.com/BLAST-WarpX/warpx/pull/6374
- [x] update ImpactX: https://github.com/BLAST-ImpactX/impactx/pull/1210
- [x] specialize/build less PC combinations for BLAST codes (only polymorphic) -- save build time in pyAMReX

### Later On

- [x] add a C++ example to AMReX tests https://github.com/AMReX-Codes/amrex/issues/4380 @atmyers 
- [ ] update Sphinx docs (remove other specialized types instead... maybe wait for full-RT PC...)
