### PR TITLE
Add `ParmParse.to_dict()`

### DIFF
--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -9,8 +9,10 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_ParmParse.H>
 
+#include <functional>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 
@@ -111,6 +113,7 @@ void init_ParmParse(py::module &m)
 
                 auto g_table = pp.table();
 
+                // sort all keys
                 std::vector<std::string> sorted_names;
                 sorted_names.reserve(g_table.size());
                 for (auto const& [name, entry] : g_table) {
@@ -118,27 +121,53 @@ void init_ParmParse(py::module &m)
                 }
                 std::sort(sorted_names.begin(), sorted_names.end());
 
+                // helper function to unroll any nested parameter.sub.options into dict of dict of value
+                auto add_nested = [&d](auto && value, std::string_view s) {
+                    py::dict d_inner = d;  // just hold a handle to the current dict
+
+                    while (true) {
+                        auto pos = s.find('.');
+                        bool last = pos == std::string_view::npos;
+                        py::str key(s.substr(0, pos));
+
+                        if (last) {
+                            d_inner[key] = value;
+                            break;
+                        } else {
+                            // Create nested dict if missing or wrong type
+                            if (!d_inner.contains(key) ||
+                                !py::isinstance<py::dict>(d_inner[key])) {
+                                d_inner[key] = py::dict();
+                            }
+
+                            // Move one level deeper (safe, keeps reference alive)
+                            d_inner = d_inner[key].cast<py::dict>();
+                        }
+                        s.remove_prefix(pos + 1);
+                    }
+                };
+
                 for (auto const& name : sorted_names) {
                     auto const& entry = g_table[name];
                     for (auto const & vals : entry.m_vals) {
                         if (vals.size() == 1) {
                             std::visit(
-                                [&d,&name,&pp](auto&& arg) {
+                                [&](auto&& arg) {
                                     using T = std::remove_pointer_t<std::decay_t<decltype(arg)>>;
                                     T v;
                                     pp.get(name.c_str(), v);
-                                    d[name.c_str()] = v;
+                                    add_nested(v, name);
                                 },
                                 entry.m_typehint
                             );
                         } else {
                             std::visit(
-                                [&d,&name,&pp](auto&& arg) {
+                                [&](auto&& arg) {
                                     using T = std::remove_pointer_t<std::decay_t<decltype(arg)>>;
                                     if constexpr (!std::is_same_v<T, bool>) {
                                         std::vector<T> valarr;
                                         pp.getarr(name.c_str(), valarr);
-                                        d[name.c_str()] = valarr;
+                                        add_nested(valarr, name);
                                     }
                                 },
                                 entry.m_typehint
@@ -149,7 +178,18 @@ void init_ParmParse(py::module &m)
 
                 return d;
             },
-            "DOC GOES HERE TODO TODO"
+            R"(Convert to a nested Python dictionary.
+
+.. code-block:: python
+
+    # Example: dump all ParmParse entries to YAML or TOML
+    import toml
+    import yaml
+
+    pp = amr.ParmParse("").to_dict()
+    yaml_string = yaml.dump(d)
+    toml_string = toml.dumps(d)
+)"
         )
     ;
 }

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -103,5 +103,53 @@ void init_ParmParse(py::module &m)
         )
 
         // TODO: dumpTable, hasUnusedInputs, getUnusedInputs, getEntries
+
+        .def(
+            "to_dict",
+            [](ParmParse &pp) {
+                py::dict d;
+
+                auto g_table = pp.table();
+
+                std::vector<std::string> sorted_names;
+                sorted_names.reserve(g_table.size());
+                for (auto const& [name, entry] : g_table) {
+                    sorted_names.push_back(name);
+                }
+                std::sort(sorted_names.begin(), sorted_names.end());
+
+                for (auto const& name : sorted_names) {
+                    auto const& entry = g_table[name];
+                    for (auto const & vals : entry.m_vals) {
+                        if (vals.size() == 1) {
+                            std::visit(
+                                [&d,&name,&pp](auto&& arg) {
+                                    using T = std::remove_pointer_t<std::decay_t<decltype(arg)>>;
+                                    T v;
+                                    pp.get(name.c_str(), v);
+                                    d[name.c_str()] = v;
+                                },
+                                entry.m_typehint
+                            );
+                        } else {
+                            std::visit(
+                                [&d,&name,&pp](auto&& arg) {
+                                    using T = std::remove_pointer_t<std::decay_t<decltype(arg)>>;
+                                    if constexpr (!std::is_same_v<T, bool>) {
+                                        std::vector<T> valarr;
+                                        pp.getarr(name.c_str(), valarr);
+                                        d[name.c_str()] = valarr;
+                                    }
+                                },
+                                entry.m_typehint
+                            );
+                        }
+                    }
+                }
+
+                return d;
+            },
+            "DOC GOES HERE TODO TODO"
+        )
     ;
 }

--- a/tests/test_parmparse.py
+++ b/tests/test_parmparse.py
@@ -35,16 +35,22 @@ def test_parmparse():
 
     # type hints
     d = pp.to_dict()
-    assert isinstance(d["param.ncell"], int)  # overwritten
-    assert isinstance(d["param.dt"], str)  # file
-    assert isinstance(d["param.do_pml"], str)  # file
-    assert isinstance(d["param.question"], str)
-    assert isinstance(d["param.answer"], int)
-    assert d["param.answer"] == 42  # last wins
-    assert isinstance(d["param.pi_approx"], float)
-    assert isinstance(d["param.floats"], list)
-    assert isinstance(d["param.ints"], list)
-    assert isinstance(d["param.strs"], list)
-    assert d["param.floats"] == [1.0, 2.0, 3.0]
-    assert d["param.ints"] == [4, 5, 6]
-    assert d["param.strs"] == ["Who", "Where", "What", "When", "How"]
+    assert isinstance(d["param"]["ncell"], int)  # overwritten
+    assert isinstance(d["param"]["dt"], str)  # file
+    assert isinstance(d["param"]["do_pml"], str)  # file
+    assert isinstance(d["param"]["question"], str)
+    assert isinstance(d["param"]["answer"], int)
+    assert d["param"]["answer"] == 42  # last wins
+    assert isinstance(d["param"]["pi_approx"], float)
+    assert isinstance(d["param"]["floats"], list)
+    assert isinstance(d["param"]["ints"], list)
+    assert isinstance(d["param"]["strs"], list)
+    assert d["param"]["floats"] == [1.0, 2.0, 3.0]
+    assert d["param"]["ints"] == [4, 5, 6]
+    assert d["param"]["strs"] == ["Who", "Where", "What", "When", "How"]
+
+    # You can now dump to YAML or TOML or any other format
+    # import toml
+    # import yaml
+    # yaml_string = yaml.dump(d)
+    # toml_string = toml.dumps(d)

--- a/tests/test_parmparse.py
+++ b/tests/test_parmparse.py
@@ -15,8 +15,36 @@ def test_parmparse():
     dt = pp_param.get_real("dt")
     dopml = pp_param.get_bool("do_pml")
 
+    pp_param.add("ncell", 42)  # overwrite file
+    pp_param.add(
+        "question", "What is the answer to life, the universe, and everything?"
+    )
+    pp_param.add("answer", 41)
+    pp_param.add("answer", 42)  # last wins
+    pp_param.add("pi_approx", 3.1415)
+    pp_param.addarr("floats", [1.0, 2.0, 3.0])
+    pp_param.addarr("ints", [4, 5, 6])
+    pp_param.addarr("strs", ["Who", "Where", "What", "When", "How"])
+
     assert dopml
     assert np.isclose(dt, 1.0e-5)
     assert ncell == 100
 
+    # printing
     pp.pretty_print_table()
+
+    # type hints
+    d = pp.to_dict()
+    assert isinstance(d["param.ncell"], int)  # overwritten
+    assert isinstance(d["param.dt"], str)  # file
+    assert isinstance(d["param.do_pml"], str)  # file
+    assert isinstance(d["param.question"], str)
+    assert isinstance(d["param.answer"], int)
+    assert d["param.answer"] == 42  # last wins
+    assert isinstance(d["param.pi_approx"], float)
+    assert isinstance(d["param.floats"], list)
+    assert isinstance(d["param.ints"], list)
+    assert isinstance(d["param.strs"], list)
+    assert d["param.floats"] == [1.0, 2.0, 3.0]
+    assert d["param.ints"] == [4, 5, 6]
+    assert d["param.strs"] == ["Who", "Where", "What", "When", "How"]


### PR DESCRIPTION
Convert the `ParmParse` entries to a dict. Use type hints whenever possible to create a proper value variable. Only file inputs and CLI inputs are string values that way.

- [x] works & tested
- [x] needs https://github.com/AMReX-Codes/amrex/pull/4364
- [x] should nested attributes in pp (separated by `.`) create a nested dict? Yes!

## Future Ideas

- The whole `ParmParse` object should just behave like a readable and writeable nested dict of values on `[]` (`__getitem__`)
- Import from Python dictionary to `amrex::ParmParse` (similar to `.addfile`, but with dicts/yaml/toml/...)

## Cool new use cases

You can now finally serialize your whole simulation input into a modern data format. This is useful when you need to query your input parameters later on, e.g., when analyzing your data or creating ML training data archives, etc.

Just use a standard conformant TOML/YAML/JSON/XML/whatever reader and query your AMReX input values (that you exported into a TOML/YAML/JSON/XML file with the below few-liners.)

### Export ParmParse to YAML
```py
import yaml

pp = amr.ParmParse("")
yaml_string = yaml.dump(pp.to_dict())

print(yaml_string)
```
```yaml
DistributionMapping:
  verbose: 0
amrex:
  abort_on_out_of_gpu_memory: false
  abort_on_unused_inputs: false
  async_out: false
  async_out_nfiles: 64
  init_snan: false
  mf:
    alloc_single_chunk: false
  signal_handling: '0'
  the_arena_defragmentation: true
  the_arena_init_size: '0'
  the_arena_is_managed: '0'
  # ...
  verbose: '1'
eb2:
  extend_domain_face: true
  max_grid_size: 64
  num_coarsen_opt: 0
fabarray:
  comm_tile_size:
  - 1024000
  - 1024000
  - 1024000
  mfiter_tile_size:
  - 1024000
  - 8
  - 8
param:
  answer: 42
  do_pml: '1'
  dt: '1.e-5'
  floats:
  - 1.0
  - 2.0
  - 3.0
  ints:
  - 4
  - 5
  - 6
  ncell: 42
  pi_approx: 3.1414999961853027
  question: What is the answer to life, the universe, and everything?
  strs:
  - Who
  - Where
  - What
  - When
  - How
tiny_profiler:
  enabled: '0'
```

### Export ParmParse to TOML
```py
import toml

pp = amr.ParmParse("")
toml_string = toml.dumps(pp.to_dict())

print(toml_string)
```
```toml
[DistributionMapping]
verbose = 0

[amrex]
abort_on_out_of_gpu_memory = false
abort_on_unused_inputs = false
async_out = false
async_out_nfiles = 64
init_snan = false
signal_handling = "0"
the_arena_defragmentation = true
the_arena_init_size = "0"
the_arena_is_managed = "0"
the_arena_release_threshold = 9223372036854775807
the_async_arena_release_threshold = 9223372036854775807
the_comms_arena_defragmentation = true
the_comms_arena_init_size = 8388608
the_comms_arena_release_threshold = 9223372036854775807
the_device_arena_defragmentation = true
the_device_arena_init_size = 8388608
the_device_arena_release_threshold = 9223372036854775807
the_managed_arena_defragmentation = true
the_managed_arena_init_size = 8388608
the_managed_arena_release_threshold = 9223372036854775807
the_pinned_arena_defragmentation = true
the_pinned_arena_init_size = 8388608
the_pinned_arena_release_threshold = 9223372036854775807
throw_exception = "1"
use_gpu_aware_mpi = false
vector_growth_factor = 1.5
verbose = "1"

[eb2]
extend_domain_face = true
max_grid_size = 64
num_coarsen_opt = 0

[fabarray]
comm_tile_size = [ 1024000, 1024000, 1024000,]
mfiter_tile_size = [ 1024000, 8, 8,]

[param]
answer = 42
do_pml = "1"
dt = "1.e-5"
floats = [ 1.0, 2.0, 3.0,]
ints = [ 4, 5, 6,]
ncell = 42
pi_approx = 3.1414999961853027
question = "What is the answer to life, the universe, and everything?"
strs = [ "Who", "Where", "What", "When", "How",]

[tiny_profiler]
enabled = "0"

[amrex.mf]
alloc_single_chunk = false
```