### PR TITLE
For MuliFab indexing, () means all cells in all dimension, valid and ghost

### DIFF
--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -316,9 +316,9 @@ def _process_index(self, index):
         # If only one slice or integer passed in, it was not wrapped in a tuple
         index = [index]
     elif isinstance(index, tuple):
-        if len(index) == 0:
-            # The empty tuple specifies all valid and ghost cells
-            index = [index]
+        if len(index) == 0: 
+            # The empty tuple specifies all valid and ghost cells for all axis
+            index = dims*[index]
         else:
             index = list(index)
             for i in range(len(index)):

--- a/src/amrex/extensions/MultiFab.py
+++ b/src/amrex/extensions/MultiFab.py
@@ -316,9 +316,9 @@ def _process_index(self, index):
         # If only one slice or integer passed in, it was not wrapped in a tuple
         index = [index]
     elif isinstance(index, tuple):
-        if len(index) == 0: 
+        if len(index) == 0:
             # The empty tuple specifies all valid and ghost cells for all axis
-            index = dims*[index]
+            index = dims * [index]
         else:
             index = list(index)
             for i in range(len(index)):

--- a/tests/test_multifab.py
+++ b/tests/test_multifab.py
@@ -77,7 +77,10 @@ def test_mfab_numpy(mfab):
         # Config = sim.extension.Config
 
         # Using global indexing
-        # Set all valid cells (and internal ghost cells)
+        # Set all cells, valid and ghost cells, using the empty tuple
+        mfab[()] = np.pi
+
+        # Set all valid cells (and ghost cells overlapping valid cells), using the Ellipsis
         mfab[...] = 42.0
 
         # Set a range of cells. Indices are in Fortran order.
@@ -87,7 +90,7 @@ def test_mfab_numpy(mfab):
         # Third dimension, sets all valid and ghost cells
         #  - The empty tuple is used to specify the range to include all valid and ghost cells.
         # Components dimension, sets first component.
-        mfab[-1j:2j, :, (), 0] = 42.0
+        mfab[-1j:2j, :, (), 0] = 37.0
 
         # Get a range of cells
         # Get the data along the valid cells in the first dimension (gathering data across blocks


### PR DESCRIPTION
This PR clarifies the use of the empty tuple index, `()`, for MultiFabs. Giving the empty tuple as the only index of a MultiFab will return the full array, both valid and ghost cells. This is in contrast to the `Ellipsis` that will return the array with only value cells.
For example
```
mf = MultiFab()
mf[()]  # returns valid and ghost cells
mf[...]  # returns only valid cells
```
