### PR TITLE
ParticleContainer: add_particle(other) & make_alike

### DIFF
--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -185,7 +185,8 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
                       const Vector<DistributionMapping>&,
                       const Vector<BoxArray>&,
                       const Vector<IntVect>&>())
-
+    ;
+    py_pc
         .def("make_alike", &ParticleContainerType::template make_alike<>)
 
         .def_property_readonly_static("is_soa_particle", [](const py::object&){return ParticleType::is_soa_particle;})

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -187,7 +187,7 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
                       const Vector<IntVect>&>())
     ;
     py_pc
-        .def("make_alike", &ParticleContainerType::template make_alike<>)
+        .def("make_alike", &ParticleContainerType::template make_alike<Allocator>)
 
         .def_property_readonly_static("is_soa_particle", [](const py::object&){return ParticleType::is_soa_particle;})
         .def_property_readonly_static("num_struct_real", [](const py::object&){return ParticleContainerType::NStructReal; })

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -186,6 +186,8 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
                       const Vector<BoxArray>&,
                       const Vector<IntVect>&>())
 
+        .def("make_alike", &ParticleContainerType::template make_alike<>)
+
         .def_property_readonly_static("is_soa_particle", [](const py::object&){return ParticleType::is_soa_particle;})
         .def_property_readonly_static("num_struct_real", [](const py::object&){return ParticleContainerType::NStructReal; })
         .def_property_readonly_static("num_struct_int", [](const py::object&){return ParticleContainerType::NStructInt; })
@@ -341,6 +343,8 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         // template <class PCType,
         //           std::enable_if_t<IsParticleContainer<PCType>::value, int> foo = 0>
         // void addParticles (const PCType& other, bool local=false);
+        .def("add_particles", py::overload_cast<ParticleContainerType const &, bool>(&ParticleContainerType::template addParticles<ParticleContainerType, true>),
+            py::arg("other"), py::arg("local")=false)
         // template <class F, class PCType,
         //           std::enable_if_t<IsParticleContainer<PCType>::value, int> foo = 0,
         //           std::enable_if_t<! std::is_integral<F>::value, int> bar = 0>


### PR DESCRIPTION
Add bindings to copying from another particle container and to create another particle container from an existing one using the same layout & allocator.