### PR TITLE
Swap `get_type` to `py::type::of`

### DIFF
--- a/src/Base/MPMD.cpp
+++ b/src/Base/MPMD.cpp
@@ -105,7 +105,7 @@ void init_MPMD(py::module &m) {
               // only checks same layout, e.g. an `int` in `PyObject` could
               // pass this
               if (!py::isinstance<py::class_<pyAMReX_PyMPIIntracommObject> >(
-                      app_comm_py.get_type()))
+                      py::type::of(app_comm_py))
                   // TODO add mpi4py version from above import check to error
                   // message
                   throw std::runtime_error(

--- a/src/Base/MPMD.cpp
+++ b/src/Base/MPMD.cpp
@@ -105,7 +105,7 @@ void init_MPMD(py::module &m) {
               // only checks same layout, e.g. an `int` in `PyObject` could
               // pass this
               if (!py::isinstance<py::class_<pyAMReX_PyMPIIntracommObject> >(
-                      py::type::of(app_comm_py))
+                      py::type::of(app_comm_py)))
                   // TODO add mpi4py version from above import check to error
                   // message
                   throw std::runtime_error(


### PR DESCRIPTION
This fixes a new failure in WarpX CI (see https://github.com/BLAST-WarpX/warpx/actions/runs/16272157144/job/45942282535?pr=5872) due to deprecation of `get_type()`.

```
/Users/runner/work/warpx/warpx/build_sp/_deps/fetchedpyamrex-src/src/Base/MPMD.cpp:108:35: error: 'get_type' is deprecated: Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type() [-Werror,-Wdeprecated-declarations]
                      app_comm_py.get_type()))
                                  ^
/opt/homebrew/include/pybind11/detail/../pytypes.h:215:5: note: 'get_type' has been explicitly marked deprecated here
    PYBIND11_DEPRECATED("Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type()")
    ^
/opt/homebrew/include/pybind11/detail/common.h:171:43: note: expanded from macro 'PYBIND11_DEPRECATED'
#    define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
                                          ^
1 error generated.
```