### PR TITLE
Docs: Fix HTTP Error 403

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,21 @@ import urllib.request
 # https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html
 import sphinx_rtd_theme  # noqa
 
+
+def download_with_headers(url, filename):
+    """Download a file with proper User-Agent header to avoid 403 errors."""
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "pyAMReX-docs-builder"}
+        )
+        with urllib.request.urlopen(req) as response:
+            with open(filename, "wb") as f:
+                f.write(response.read())
+    except Exception as e:
+        print(f"Could not download {filename} from {url}: {e}")
+        print("Continuing build without cross-reference file...")
+
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -196,8 +211,10 @@ primary_domain = "cpp"
 highlight_language = "cpp"
 
 # Download AMReX Doxygen Tagfiles to interlink Doxygen docs
-url = "https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml"
-urllib.request.urlretrieve(url, "../amrex-doxygen-web.tag.xml")
+download_with_headers(
+    url="https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml",
+    filename="../amrex-doxygen-web.tag.xml",
+)
 
 # Build Doxygen
 subprocess.call(


### PR DESCRIPTION
Repeat Read the Docs CI bug fix as in https://github.com/BLAST-WarpX/warpx/pull/6151. Not appearing here yet, but prevented this way.