### PR TITLE
Fix Use-After-Free in NumPy/df

### DIFF
--- a/src/amrex/extensions/ArrayOfStructs.py
+++ b/src/amrex/extensions/ArrayOfStructs.py
@@ -32,10 +32,14 @@ def aos_to_numpy(self, copy=False):
     if copy:
         # This supports a device-to-host copy.
         #
-        # todo: validate of the to_host() returned object
-        #       lifetime is always managed correctly by
-        #       Python's GC - otherwise copy twice via copy=True
-        return np.array(self.to_host(), copy=False)
+        # The to_host() returned object is a temporary, and
+        # np.array using the __array_interface__ protocol does
+        # not keep it alive automatically unless it is stored
+        # in an actual variable (tmp).
+        tmp = self.to_host()
+        ret = np.array(tmp, copy=False)
+        assert ret.base is tmp
+        return ret
     else:
         return np.array(self, copy=False)
 

--- a/src/amrex/extensions/PODVector.py
+++ b/src/amrex/extensions/PODVector.py
@@ -29,10 +29,14 @@ def podvector_to_numpy(self, copy=False):
         if copy:
             # This supports a device-to-host copy.
             #
-            # todo: validate of the to_host() returned object
-            #       lifetime is always managed correctly by
-            #       Python's GC - otherwise copy twice via copy=True
-            return np.array(self.to_host(), copy=False)
+            # The to_host() returned object is a temporary, and
+            # np.array using the __array_interface__ protocol does
+            # not keep it alive automatically unless it is stored
+            # in an actual variable (tmp).
+            tmp = self.to_host()
+            ret = np.array(tmp, copy=False)
+            assert ret.base is tmp
+            return ret
         else:
             return np.array(self, copy=False)
     else:


### PR DESCRIPTION
For AoS and SoA `.to_numpy()` and dependent logic
like `.to_df()`, the lifetime of the temporary copied variable is only handled by NumPy if we first create a named variable.

The `to_host()` returned object is a temporary, and `np.array` using the `__array_interface__` protocol does not keep it alive automatically unless it is stored in an actual variable (eg., `tmp`).

X-ref:
- https://github.com/conda-forge/impactx-feedstock/pull/56#issuecomment-3304382067
- https://github.com/AMReX-Codes/pyamrex/pull/458#issuecomment-3304399453