### PR TITLE
Fix: `Config.precision`

### DIFF
--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -102,7 +102,7 @@ void init_AMReX(py::module& m)
         .def_property_readonly_static(
             "precision",
             [](py::object){
-#ifdef AMREX_SINGLE_PRECISION
+#ifdef AMREX_USE_FLOAT
                 return "SINGLE";
 #else
                 return "DOUBLE";


### PR DESCRIPTION
Only `AMREX_USE_FLOAT` exists...

X-ref https://github.com/conda-forge/impactx-feedstock/pull/56#issuecomment-3323003288