### PR TITLE
Strip "v" prefix from version for find_package

### DIFF
--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -62,6 +62,9 @@ file(READ "${pyAMReX_SOURCE_DIR}/dependencies.json" dependencies_data)
 string(JSON pybind11_version GET "${dependencies_data}" version_pybind11)
 string(JSON pybind11_commit GET "${dependencies_data}" commit_pybind11)
 
+# Strip "v" prefix from version for find_package
+string(REGEX REPLACE "^v" "" pybind11_version "${pybind11_version}")
+
 set(pyAMReX_pybind11_branch ${pybind11_commit}
     CACHE STRING
     "Repository branch for pyAMReX_pybind11_repo if(pyAMReX_pybind11_internal)")


### PR DESCRIPTION
Somehow this fails in the builds for the conda-forge feedstock with
```
CMake Error at cmake/dependencies/pybind11.cmake:44 (find_package):
    find_package called with invalid argument "v3.0.1"
```

However, it doesn't fail in local builds, which is why I didn't catch it before the 25.10 release.

I will need to add this as a patch to https://github.com/conda-forge/pyamrex-feedstock/pull/52.