### PR TITLE
CMake: Skip on Win `GNUInstallDirs`

### DIFF
--- a/cmake/pyAMReXFunctions.cmake
+++ b/cmake/pyAMReXFunctions.cmake
@@ -75,7 +75,9 @@ endmacro()
 #
 macro(pyamrex_set_default_install_dirs)
     if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-        include(GNUInstallDirs)
+        if(NOT WIN32)
+            include(GNUInstallDirs)
+        endiF()
         if(NOT CMAKE_INSTALL_CMAKEDIR)
             set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake"
                 CACHE PATH "CMake config package location for installed targets")


### PR DESCRIPTION
Checking if this causes issues on Conda-Forge for Windows now... Somehow
```
GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_LIBDIR CMAKE_INSTALL_LIBDIR LIBDIR )
```
might expand our relative `lib` for `CMAKE_INSTALL_LIBDIR` to `/<SRC>/lib`...?