### PR TITLE
`MultiFab`: Allow Dynamic Attributes

### DIFF
--- a/src/Base/MultiFab.cpp
+++ b/src/Base/MultiFab.cpp
@@ -20,7 +20,7 @@ void init_MultiFab(py::module &m, py::class_< amrex::MFIter > & py_MFIter)
 {
     using namespace amrex;
 
-    py::class_< MultiFab, FabArray<FArrayBox> > py_MultiFab(m, "MultiFab");
+    py::class_< MultiFab, FabArray<FArrayBox> > py_MultiFab(m, "MultiFab", py::dynamic_attr());
 
     py_MFIter
         .def("__repr__",


### PR DESCRIPTION
Allow to add attributes dynamically to the `MultiFab` type.

Needed for: https://github.com/BLAST-WarpX/warpx/pull/6344

Background: https://pybind11.readthedocs.io/en/stable/classes.html#dynamic-attributes