### PR TITLE
CI: Stubs Python 3.10

### DIFF
--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -16,7 +16,7 @@ jobs:
   # Build and install libamrex as AMReX CMake project
   stubs:
     name: Stubs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CC: gcc
       CXX: g++
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Dependencies
       run: |


### PR DESCRIPTION
Update CI for Stubs to Ubuntu 24.10 and Python 3.10