### PR TITLE
Always use version tag in pybind11 dependency update

### DIFF
--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -89,8 +89,9 @@ def update(args):
         else:
             # latest available tag (index 0) for all other dependencies
             repo_version_tag = tags_list_filtered[0]["name"]
-        # use version tag instead of commit sha for a release update
-        new_commit_sha = repo_version_tag if args.release else repo_commit_sha
+        # use version tag instead of commit sha for a release update or for pybind11
+        use_version_tag = args.release or (repo_name == "pybind11")
+        new_commit_sha = repo_version_tag if use_version_tag else repo_commit_sha
         # update commit
         if repo_name != "pyamrex":
             print(f"- old commit: {dependencies_data[commit_key]}")


### PR DESCRIPTION
Always use the version tag for pybind11 as we don't want to track updates on a weekly basis.

Related PRs:
- #474
- #486

@ax3l Does this fix the issue that we discussed offline?
