### PR TITLE
Pip Install: Skip Plot & Checkpoint Dirs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,7 +16,9 @@ prune cmake-build*
 prune .spack-env*
 
 # exclude diagnostics output directories (see .gitignore)
+prune diags*
 prune plt*
 prune chk*
+prune **/diags*
 prune **/plt*
 prune **/chk*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,9 @@ global-exclude *.pyc
 # see .gitignore
 prune cmake-build*
 prune .spack-env*
+
+# exclude diagnostics output directories (see .gitignore)
+prune plt*
+prune chk*
+prune **/plt*
+prune **/chk*

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,12 @@ class CopyPreBuild(build):
 
         # copy Python module artifacts and sources
         dst_path = os.path.join(self.build_lib, "amrex")
-        shutil.copytree(PYAMREX_libdir, dst_path, dirs_exist_ok=True)
+        shutil.copytree(
+            PYAMREX_libdir,
+            dst_path,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("plt*", "chk*"),
+        )
 
 
 class CMakeExtension(Extension):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class CopyPreBuild(build):
             PYAMREX_libdir,
             dst_path,
             dirs_exist_ok=True,
-            ignore=shutil.ignore_patterns("plt*", "chk*"),
+            ignore=shutil.ignore_patterns("chk*", "diags*", "plt*"),
         )
 
 


### PR DESCRIPTION
## Summary

- Exclude `plt*` and `chk*` output directories from `pip wheel` builds via `MANIFEST.in` prune rules and `shutil.copytree` ignore patterns in `setup.py`
- If one has run in-source testing, these can bloat the wheel (zip) file, slow the process, and hit the ZIP limit (>4GB) where it fails to build

Mirrors the fix in ImpactX: https://github.com/BLAST-ImpactX/impactx/pull/1296 (for https://github.com/BLAST-ImpactX/impactx/issues/1294)

## Changes

- **`MANIFEST.in`**: Added `prune` rules for `plt*`, `chk*`, `**/plt*`, `**/chk*`
- **`setup.py`**: Added `ignore=shutil.ignore_patterns("plt*", "chk*")` to `shutil.copytree()` in `CopyPreBuild.run()`

Made with [Cursor](https://cursor.com) based on the ImpactX PR of the same kind.