### PR TITLE
Update pybind11 dependency: 3.0.2

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,7 @@
 {
     "version_pyamrex": "26.02",
     "version_amrex": "26.02",
-    "version_pybind11": "v3.0.1",
+    "version_pybind11": "v3.0.2",
     "commit_amrex": "26.02",
-    "commit_pybind11": "v3.0.1"
+    "commit_pybind11": "v3.0.2"
 }


### PR DESCRIPTION
Update pybind11 version from 3.0.1 to 3.0.2 in preparation for a similar update in WarpX and ImpactX.