### PR TITLE
PODVector: Add `_default` Platform Aliases

### DIFF
--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -43,7 +43,14 @@ void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
     auto const podv_name = std::string("PODVector_").append(typestr)
                            .append("_").append(allocstr);
 
-    py::class_<PODVector_type>(m, podv_name.c_str())
+    auto const podv_doc = std::string(
+        "A plain-old-data (POD) vector of '")
+        .append(typestr)
+        .append("' elements with '")
+        .append(allocstr)
+        .append("' allocation.");
+
+    py::class_<PODVector_type>(m, podv_name.c_str(), podv_doc.c_str())
         .def("__repr__",
              [typestr](PODVector_type const & pv) {
                  std::stringstream s, rs;

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -151,6 +151,21 @@ void make_PODVector(py::module &m, std::string typestr)
     make_PODVector<T, amrex::AsyncArenaAllocator<T>> (m, typestr, "async");
 #endif
     make_PODVector<T, amrex::PolymorphicArenaAllocator<T>> (m, typestr, "polymorphic");
+
+    // Alias matching Gpu::DeviceVector<T> — resolves per platform:
+    //   CPU: PODVector_<type>_std,  GPU: PODVector_<type>_arena
+    auto const default_name = std::string("PODVector_")
+        .append(typestr)
+        .append("_default");
+    m.attr(default_name.c_str()) = m
+        .attr(std::string("PODVector_")
+        .append(typestr)
+#ifdef AMREX_USE_GPU
+        .append("_arena")
+#else
+        .append("_std")
+#endif
+        .c_str());
 }
 
 void init_PODVector(py::module& m)

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -32,6 +32,16 @@ namespace
         d["version"] = 3;
         return d;
     }
+
+    std::string
+    str_PODVector(std::string typestr, std::string allocstr)
+    {
+        auto const podv_name = std::string("PODVector_")
+            .append(typestr)
+            .append("_")
+            .append(allocstr);
+        return podv_name;
+    }
 }
 
 template <class T, class Allocator = std::allocator<T> >
@@ -40,8 +50,7 @@ void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
     using namespace amrex;
 
     using PODVector_type = PODVector<T, Allocator>;
-    auto const podv_name = std::string("PODVector_").append(typestr)
-                           .append("_").append(allocstr);
+    auto const podv_name = str_PODVector(typestr, allocstr);
 
     auto const podv_doc = std::string(
         "A plain-old-data (POD) vector of '")
@@ -161,18 +170,13 @@ void make_PODVector(py::module &m, std::string typestr)
 
     // Alias matching Gpu::DeviceVector<T> — resolves per platform:
     //   CPU: PODVector_<type>_std,  GPU: PODVector_<type>_arena
-    auto const default_name = std::string("PODVector_")
-        .append(typestr)
-        .append("_default");
-    m.attr(default_name.c_str()) = m
-        .attr(std::string("PODVector_")
-        .append(typestr)
+    auto const default_name = str_PODVector(typestr, "default");
+    m.attr(default_name.c_str()) =
 #ifdef AMREX_USE_GPU
-        .append("_arena")
+        m.attr(str_PODVector(typestr, "arena").c_str());
 #else
-        .append("_std")
+        m.attr(str_PODVector(typestr, "std").c_str());
 #endif
-        .c_str());
 }
 
 void init_PODVector(py::module& m)

--- a/src/amrex/extensions/PODVector.py
+++ b/src/amrex/extensions/PODVector.py
@@ -103,12 +103,6 @@ def register_PODVector_extension(amr):
     import inspect
     import sys
 
-    # The parent package (e.g., amrex.space3d) does `from .amrex_3d_pybind
-    # import *` before calling this function.  That star-import is a one-time
-    # snapshot, so new attributes added to the pybind sub-module (amr) won't
-    # be visible on the package.  We therefore also set aliases on the parent.
-    _parent = sys.modules.get(amr.__name__.rsplit(".", 1)[0], None)
-
     # register member functions for every PODVector_* type
     for _, POD_type in inspect.getmembers(
         sys.modules[amr.__name__],
@@ -121,14 +115,3 @@ def register_PODVector_extension(amr):
         POD_type.to_numpy = podvector_to_numpy
         POD_type.to_cupy = podvector_to_cupy
         POD_type.to_xp = podvector_to_xp
-
-        # Provide a platform-agnostic alias matching Gpu::DeviceVector<T>:
-        #   CPU: PODVector_<type>_std  -> PODVector_<type>_default
-        #   GPU: PODVector_<type>_arena -> PODVector_<type>_default
-        _gpu_suffix = "_arena" if amr.Config.have_gpu else "_std"
-        _name = POD_type.__name__
-        if _name.endswith(_gpu_suffix):
-            _default_name = _name[: -len(_gpu_suffix)] + "_default"
-            setattr(amr, _default_name, POD_type)
-            if _parent is not None:
-                setattr(_parent, _default_name, POD_type)

--- a/src/amrex/extensions/PODVector.py
+++ b/src/amrex/extensions/PODVector.py
@@ -103,6 +103,12 @@ def register_PODVector_extension(amr):
     import inspect
     import sys
 
+    # The parent package (e.g., amrex.space3d) does `from .amrex_3d_pybind
+    # import *` before calling this function.  That star-import is a one-time
+    # snapshot, so new attributes added to the pybind sub-module (amr) won't
+    # be visible on the package.  We therefore also set aliases on the parent.
+    _parent = sys.modules.get(amr.__name__.rsplit(".", 1)[0], None)
+
     # register member functions for every PODVector_* type
     for _, POD_type in inspect.getmembers(
         sys.modules[amr.__name__],
@@ -115,3 +121,14 @@ def register_PODVector_extension(amr):
         POD_type.to_numpy = podvector_to_numpy
         POD_type.to_cupy = podvector_to_cupy
         POD_type.to_xp = podvector_to_xp
+
+        # Provide a platform-agnostic alias matching Gpu::DeviceVector<T>:
+        #   CPU: PODVector_<type>_std  -> PODVector_<type>_default
+        #   GPU: PODVector_<type>_arena -> PODVector_<type>_default
+        _gpu_suffix = "_arena" if amr.Config.have_gpu else "_std"
+        _name = POD_type.__name__
+        if _name.endswith(_gpu_suffix):
+            _default_name = _name[: -len(_gpu_suffix)] + "_default"
+            setattr(amr, _default_name, POD_type)
+            if _parent is not None:
+                setattr(_parent, _default_name, POD_type)


### PR DESCRIPTION
Update: Renamed what was added here in PR #545.
What I actually meant with this PR is `amrex::Gpu::DeviceVector<amrex::Real>`. When Cuda is off, all these containers revert to `amrex::Gpu::PODVector`.
https://github.com/AMReX-Codes/amrex/blob/26.03/Src/Base/AMReX_GpuContainers.H#L23-L24
https://github.com/AMReX-Codes/amrex/blob/26.03/Src/Base/AMReX_GpuContainers.H#L79-L81


Register `PODVector_{real,int,uint64}_default` as aliases that resolve to `_std` on CPU builds and `_arena` on GPU builds, matching the C++ `Gpu::DeviceVector<T>` type per platform.
For other containers like PC & MF we an just use the default arena, but PODVector is implemented a bit special, relying on a `std::allocator` instead of the default arena on CPU.

This helps to write CPU/GPU agnostic interfaces, e.g., in https://github.com/BLAST-ImpactX/impactx/pull/1305
