### PR TITLE
Python 3.11+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -259,7 +259,7 @@ setup(
     ext_modules=cxx_modules,
     cmdclass=cmdclass,
     zip_safe=False,
-    python_requires=">=3.8",  # left for CI, truly ">=3.10"
+    python_requires=">=3.8",  # left for CI, truly ">=3.11"
     tests_require=["pytest"],
     install_requires=install_requires,
     # cmdclass={'test': PyTest},
@@ -279,7 +279,6 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Document that we currently support Python 3.11-3.14. Python 3.10 is EOL end of Oct and does not support the same level of typing that we want to use more across our SW stacks.