### PR TITLE
`PodVector_*.from_*` NumPy/CuPy

### DIFF
--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -8,6 +8,7 @@
 #include <AMReX_PODVector.H>
 #include <AMReX_GpuContainers.H>
 
+#include <algorithm>
 #include <sstream>
 
 
@@ -55,6 +56,7 @@ namespace
         } else
 #endif
         {
+            amrex::ignore_unused(podvector);
             return true;
         }
     }
@@ -113,6 +115,51 @@ namespace
         }
 #endif
         podvector[index] = value;
+    }
+
+    /** Bulk-copy a host (NumPy) array into an existing PODVector.
+     *
+     * The source array is normalized on the host by pybind11
+     * (``c_style | forcecast``): a non-contiguous or differently-typed
+     * input is staged into a contiguous, ``T``-typed temporary before the
+     * copy.  The destination is filled with a single contiguous transfer:
+     * a host copy for host-accessible allocators, or
+     * ``Gpu::copyAsync(hostToDevice, ...)`` for device memory.  This keeps
+     * the host-to-device path free of any CuPy dependency.
+     */
+    template <class T, class Allocator>
+    void
+    copy_from_host(
+        PODVector<T, Allocator> & podvector,
+        py::array_t<T, py::array::c_style | py::array::forcecast> const & arr
+    )
+    {
+        auto const buf = arr.request();
+        if (buf.ndim != 1) {
+            throw py::value_error("copy_from_host: expected a 1-D array");
+        }
+        if (static_cast<std::size_t>(buf.shape[0]) != podvector.size()) {
+            throw py::value_error(
+                "copy_from_host: array size does not match PODVector size");
+        }
+        if (podvector.empty()) {
+            return;
+        }
+
+        auto const * src = static_cast<T const *>(buf.ptr);
+#ifdef AMREX_USE_GPU
+        if (!is_host_accessible(podvector)) {
+            Gpu::copyAsync(
+                Gpu::hostToDevice,
+                src,
+                src + podvector.size(),
+                podvector.begin()
+            );
+            Gpu::streamSynchronize();
+            return;
+        }
+#endif
+        std::copy(src, src + podvector.size(), podvector.begin());
     }
 }
 
@@ -223,6 +270,14 @@ void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
         // setter & getter
         .def("__setitem__", &set_item<T, Allocator>)
         .def("__getitem__", &get_item<T, Allocator>)
+
+        // bulk copy from a host (NumPy) array into this vector
+        .def("copy_from_host", &copy_from_host<T, Allocator>,
+             py::arg("arr"),
+             "Copy a 1-D host (NumPy) array into this vector.\n\n"
+             "The input is cast to the vector's element type and made "
+             "contiguous as needed. Device memory is filled via an AMReX "
+             "host-to-device copy.")
     ;
 }
 

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -42,6 +42,78 @@ namespace
             .append(allocstr);
         return podv_name;
     }
+
+    template <class T, class Allocator>
+    bool
+    is_host_accessible(PODVector<T, Allocator> const & podvector)
+    {
+#ifdef AMREX_USE_GPU
+        if constexpr (IsArenaAllocator<Allocator>::value) {
+            return static_cast<Allocator const &>(podvector)
+                .arena()
+                ->isHostAccessible();
+        } else
+#endif
+        {
+            return true;
+        }
+    }
+
+    template <class PODVector_type>
+    std::size_t
+    checked_index(PODVector_type const & podvector, int const v)
+    {
+        auto index = static_cast<std::ptrdiff_t>(v);
+        auto const size = static_cast<std::ptrdiff_t>(podvector.size());
+        if (index < 0) {
+            index += size;
+        }
+        if (index < 0 || index >= size) {
+            throw py::index_error("PODVector index out of range");
+        }
+        return static_cast<std::size_t>(index);
+    }
+
+    template <class T, class Allocator>
+    T
+    get_item(PODVector<T, Allocator> const & podvector, int const v)
+    {
+        auto const index = checked_index(podvector, v);
+#ifdef AMREX_USE_GPU
+        if (!is_host_accessible(podvector)) {
+            T value;
+            Gpu::copyAsync(
+                Gpu::deviceToHost,
+                podvector.begin() + index,
+                podvector.begin() + index + 1,
+                &value
+            );
+            Gpu::streamSynchronize();
+            return value;
+        }
+#endif
+        return podvector[index];
+    }
+
+    template <class T, class Allocator>
+    void
+    set_item(PODVector<T, Allocator> & podvector, int const v, T const value)
+    {
+        auto const index = checked_index(podvector, v);
+#ifdef AMREX_USE_GPU
+        if (!is_host_accessible(podvector)) {
+            Gpu::copyAsync(
+                Gpu::hostToDevice,
+                &value,
+                &value + 1,
+                podvector.begin() + index
+            );
+            Gpu::streamSynchronize();
+            return;
+        }
+#endif
+        podvector[index] = value;
+    }
 }
 
 template <class T, class Allocator = std::allocator<T> >
@@ -149,8 +221,8 @@ void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
             return d;
         })
         // setter & getter
-        .def("__setitem__", [](PODVector_type & podvector, int const v, T const value){ podvector[v] = value; })
-        .def("__getitem__", [](PODVector_type & pv, int const v){ return pv[v]; })
+        .def("__setitem__", &set_item<T, Allocator>)
+        .def("__getitem__", &get_item<T, Allocator>)
     ;
 }
 

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -117,33 +117,30 @@ namespace
         podvector[index] = value;
     }
 
-    /** Bulk-copy a host (NumPy) array into an existing PODVector.
+    /** Create a new PODVector with a copy of a host (NumPy) array.
      *
-     * The source array is normalized on the host by pybind11
-     * (``c_style | forcecast``): a non-contiguous or differently-typed
-     * input is staged into a contiguous, ``T``-typed temporary before the
-     * copy.  The destination is filled with a single contiguous transfer:
-     * a host copy for host-accessible allocators, or
+     * Always copies: a ``PODVector`` owns its memory through its allocator,
+     * so a zero-copy view is not possible.  The source array is normalized on
+     * the host by pybind11 (``c_style | forcecast``): a non-contiguous or
+     * differently-typed input is staged into a contiguous, ``T``-typed
+     * temporary before the copy.  The destination is filled with a single
+     * contiguous transfer: a host copy for host-accessible allocators, or
      * ``Gpu::copyAsync(hostToDevice, ...)`` for device memory.  This keeps
      * the host-to-device path free of any CuPy dependency.
      */
     template <class T, class Allocator>
-    void
-    copy_from_host(
-        PODVector<T, Allocator> & podvector,
-        py::array_t<T, py::array::c_style | py::array::forcecast> const & arr
-    )
+    PODVector<T, Allocator>
+    from_numpy(py::array_t<T, py::array::c_style | py::array::forcecast> const & arr)
     {
         auto const buf = arr.request();
         if (buf.ndim != 1) {
-            throw py::value_error("copy_from_host: expected a 1-D array");
+            throw py::value_error("from_numpy: expected a 1-D array");
         }
-        if (static_cast<std::size_t>(buf.shape[0]) != podvector.size()) {
-            throw py::value_error(
-                "copy_from_host: array size does not match PODVector size");
-        }
-        if (podvector.empty()) {
-            return;
+        auto const n = static_cast<std::size_t>(buf.shape[0]);
+
+        PODVector<T, Allocator> podvector(n);
+        if (n == 0) {
+            return podvector;
         }
 
         auto const * src = static_cast<T const *>(buf.ptr);
@@ -152,14 +149,15 @@ namespace
             Gpu::copyAsync(
                 Gpu::hostToDevice,
                 src,
-                src + podvector.size(),
+                src + n,
                 podvector.begin()
             );
             Gpu::streamSynchronize();
-            return;
+            return podvector;
         }
 #endif
-        std::copy(src, src + podvector.size(), podvector.begin());
+        std::copy(src, src + n, podvector.begin());
+        return podvector;
     }
 }
 
@@ -271,13 +269,26 @@ void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
         .def("__setitem__", &set_item<T, Allocator>)
         .def("__getitem__", &get_item<T, Allocator>)
 
-        // bulk copy from a host (NumPy) array into this vector
-        .def("copy_from_host", &copy_from_host<T, Allocator>,
+        // create a new vector with a copy of a host (NumPy) array
+        .def_static("from_numpy", &from_numpy<T, Allocator>,
              py::arg("arr"),
-             "Copy a 1-D host (NumPy) array into this vector.\n\n"
-             "The input is cast to the vector's element type and made "
-             "contiguous as needed. Device memory is filled via an AMReX "
-             "host-to-device copy.")
+             py::return_value_policy::move,
+             R"(Create a new PODVector from a NumPy array (or array-like).
+
+Always copies the data into a newly allocated PODVector. The input is cast to
+the vector's element type and made contiguous as needed. The copy into
+device-only memory uses an AMReX host-to-device copy and does not require CuPy.
+
+Parameters
+----------
+arr : array_like
+    Input data, convertible to a NumPy array.
+
+Returns
+-------
+PODVector
+    A new PODVector with a copy of the data.
+)")
     ;
 }
 

--- a/src/Base/PODVector.cpp
+++ b/src/Base/PODVector.cpp
@@ -162,8 +162,8 @@ namespace
 }
 
 template <class T, class Allocator = std::allocator<T> >
-void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
-{
+py::class_<PODVector<T, Allocator> >
+make_PODVector(py::module &m, std::string typestr, std::string allocstr) {
     using namespace amrex;
 
     using PODVector_type = PODVector<T, Allocator>;
@@ -176,7 +176,7 @@ void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
         .append(allocstr)
         .append("' allocation.");
 
-    py::class_<PODVector_type>(m, podv_name.c_str(), podv_doc.c_str())
+    auto cl = py::class_<PODVector_type>(m, podv_name.c_str(), podv_doc.c_str())
         .def("__repr__",
              [typestr](PODVector_type const & pv) {
                  std::stringstream s, rs;
@@ -224,15 +224,6 @@ void make_PODVector(py::module &m, std::string typestr, std::string allocstr)
             py::arg("strategy") = GrowthStrategy::Poisson
         )
         .def("shrink_to_fit", &PODVector_type::shrink_to_fit)
-        .def("to_host", [](PODVector_type const & pv) {
-            PODVector<T, amrex::PinnedArenaAllocator<T>> h_data(pv.size());
-            amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost,
-               pv.begin(), pv.end(),
-               h_data.begin()
-            );
-            Gpu::streamSynchronize();
-            return h_data;
-        }, py::return_value_policy::move)
 
         // front
         // back
@@ -290,21 +281,102 @@ PODVector
     A new PODVector with a copy of the data.
 )")
     ;
+
+    return cl;
+}
+
+/** Bind the host/device copy helpers ``to_host`` and ``to_device`` on a
+ * single PODVector class.
+ *
+ * Both return a different PODVector allocator type than ``cl`` (``to_host`` a
+ * pinned vector, ``to_device`` a ``Gpu::DeviceVector`` = ``arena`` on GPU,
+ * ``std`` on CPU). Binding them only after every allocator class exists lets
+ * pybind11 stubgen resolve those return types to registered Python types.
+ */
+template <class T, class Allocator>
+void bind_host_device(py::class_<PODVector<T, Allocator> > & cl)
+{
+    using namespace amrex;
+
+    cl.def("to_host",
+        [](PODVector<T, Allocator> const & src) {
+            PODVector<T, amrex::PinnedArenaAllocator<T>> h_data(src.size());
+            amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost,
+               src.begin(), src.end(),
+               h_data.begin()
+            );
+            Gpu::streamSynchronize();
+            return h_data;
+        },
+        py::return_value_policy::move,
+        "Copy this vector into a new pinned (host) PODVector. Mirrors to_device().")
+
+      .def("to_device",
+        [](PODVector<T, Allocator> const & src) -> amrex::Gpu::DeviceVector<T> {
+            amrex::Gpu::DeviceVector<T> dst(src.size());
+            if (src.empty()) {
+                return dst;
+            }
+#ifdef AMREX_USE_GPU
+            bool const src_host = is_host_accessible(src);
+            bool const dst_host = is_host_accessible(dst);
+            if (src_host && !dst_host) {
+                Gpu::copyAsync(Gpu::hostToDevice, src.begin(), src.end(), dst.begin());
+                Gpu::streamSynchronize();
+                return dst;
+            } else if (!src_host && dst_host) {
+                Gpu::copyAsync(Gpu::deviceToHost, src.begin(), src.end(), dst.begin());
+                Gpu::streamSynchronize();
+                return dst;
+            } else if (!src_host && !dst_host) {
+                Gpu::copyAsync(Gpu::deviceToDevice, src.begin(), src.end(), dst.begin());
+                Gpu::streamSynchronize();
+                return dst;
+            }
+#endif
+            std::copy(src.begin(), src.end(), dst.begin());
+            return dst;
+        },
+        py::return_value_policy::move,
+        "Copy this vector into a new amrex Gpu::DeviceVector (the arena "
+        "allocator on GPU, std on CPU), transferring across memory spaces "
+        "as needed. Mirrors to_host().");
+}
+
+/** Bind ``to_host``/``to_device`` on each of the given PODVector classes. */
+template <class... PODVectorClass>
+void add_host_device(PODVectorClass &... cls)
+{
+    (bind_host_device(cls), ...);
 }
 
 template <class T>
 void make_PODVector(py::module &m, std::string typestr)
 {
     // see Src/Base/AMReX_GpuContainers.H
-    make_PODVector<T, amrex::PinnedArenaAllocator<T>> (m, typestr, "pinned");
-    make_PODVector<T, amrex::ArenaAllocator<T>> (m, typestr, "arena");
-    make_PODVector<T, std::allocator<T>> (m, typestr, "std");
+    auto pv_pinned = make_PODVector<T, amrex::PinnedArenaAllocator<T>> (m, typestr, "pinned");
+    auto pv_arena = make_PODVector<T, amrex::ArenaAllocator<T>> (m, typestr, "arena");
+    auto pv_std = make_PODVector<T, std::allocator<T>> (m, typestr, "std");
 #ifdef AMREX_USE_GPU
-    make_PODVector<T, amrex::DeviceArenaAllocator<T>> (m, typestr, "device");
-    make_PODVector<T, amrex::ManagedArenaAllocator<T>> (m, typestr, "managed");
-    make_PODVector<T, amrex::AsyncArenaAllocator<T>> (m, typestr, "async");
+    auto pv_device = make_PODVector<T, amrex::DeviceArenaAllocator<T>> (m, typestr, "device");
+    auto pv_managed = make_PODVector<T, amrex::ManagedArenaAllocator<T>> (m, typestr, "managed");
+    auto pv_async = make_PODVector<T, amrex::AsyncArenaAllocator<T>> (m, typestr, "async");
 #endif
-    make_PODVector<T, amrex::PolymorphicArenaAllocator<T>> (m, typestr, "polymorphic");
+    auto pv_polymorphic = make_PODVector<T, amrex::PolymorphicArenaAllocator<T>> (m, typestr, "polymorphic");
+
+    // bind to_host/to_device now that every PODVector allocator class is
+    // registered, so their PODVector return types resolve to known Python types
+    add_host_device(
+        pv_pinned,
+        pv_arena,
+        pv_std,
+#ifdef AMREX_USE_GPU
+        pv_device,
+        pv_managed,
+        pv_async,
+#endif
+        pv_polymorphic
+    );
 
     // Implement AMReX_GpuContainers.H
     // Alias matching Gpu::DeviceVector<T> etc. — resolves per platform:

--- a/src/amrex/extensions/PODVector.py
+++ b/src/amrex/extensions/PODVector.py
@@ -126,40 +126,6 @@ def _is_host_accessible(cls):
     return arenas[suffix]().is_host_accessible
 
 
-def podvector_from_numpy(cls, arr):
-    """
-    Create a new PODVector from a NumPy array (or array-like).
-
-    Always copies the data into a newly allocated PODVector. The input is
-    cast to the vector's element type and made contiguous as needed. The
-    copy into device-only memory uses an AMReX host-to-device copy and does
-    not require CuPy.
-
-    Parameters
-    ----------
-    cls : type
-        The PODVector type to construct.
-    arr : array_like
-        Input data, convertible to a NumPy array.
-
-    Returns
-    -------
-    PODVector
-        A new PODVector with a copy of the data.
-
-    """
-    import numpy as np
-
-    arr_np = np.asarray(arr)
-    n = len(arr_np)
-    if n == 0:
-        return cls()
-
-    pv = cls(n)
-    pv.copy_from_host(arr_np)
-    return pv
-
-
 def podvector_from_cupy(cls, arr):
     """
     Create a new PODVector from a CuPy array (or array-like).
@@ -246,6 +212,6 @@ def register_PODVector_extension(amr):
         POD_type.to_xp = podvector_to_xp
 
         # class methods: array -> PODVector
-        POD_type.from_numpy = classmethod(podvector_from_numpy)
+        # (from_numpy is provided in C++ as a static method)
         POD_type.from_cupy = classmethod(podvector_from_cupy)
         POD_type.from_xp = classmethod(podvector_from_xp)

--- a/src/amrex/extensions/PODVector.py
+++ b/src/amrex/extensions/PODVector.py
@@ -98,6 +98,137 @@ def podvector_to_xp(self, copy=False):
     return self.to_cupy(copy) if amr.Config.have_gpu else self.to_numpy(copy)
 
 
+def _is_host_accessible(cls):
+    """Check if a PODVector type's allocator provides host-accessible memory.
+
+    On CPU builds all allocators are host-accessible.  On GPU builds, AMReX
+    arenas decide this at runtime; this matters for the default and
+    polymorphic arenas.
+    """
+    import inspect
+
+    amr = inspect.getmodule(cls)
+    if not amr.Config.have_gpu:
+        return True
+
+    suffix = cls.__name__.rsplit("_", 1)[-1]
+    if suffix == "std":
+        return True
+
+    arenas = {
+        "arena": amr.The_Arena,
+        "device": amr.The_Device_Arena,
+        "pinned": amr.The_Pinned_Arena,
+        "managed": amr.The_Managed_Arena,
+        "async": amr.The_Async_Arena,
+        "polymorphic": amr.The_Arena,
+    }
+    return arenas[suffix]().is_host_accessible
+
+
+def podvector_from_numpy(cls, arr):
+    """
+    Create a new PODVector from a NumPy array (or array-like).
+
+    Always copies the data into a newly allocated PODVector.
+    For device-only allocators, the input is staged through CuPy.
+
+    Parameters
+    ----------
+    cls : type
+        The PODVector type to construct.
+    arr : array_like
+        Input data, convertible to a NumPy array.
+
+    Returns
+    -------
+    PODVector
+        A new PODVector with a copy of the data.
+
+    """
+    import numpy as np
+
+    arr_np = np.asarray(arr)
+    n = len(arr_np)
+    if n == 0:
+        return cls()
+
+    pv = cls(n)
+    if _is_host_accessible(cls):
+        np.array(pv, copy=False)[:] = arr_np
+    else:
+        import cupy as cp
+
+        cp.asarray(pv)[:] = cp.asarray(arr_np)
+    return pv
+
+
+def podvector_from_cupy(cls, arr):
+    """
+    Create a new PODVector from a CuPy array (or array-like).
+
+    Always copies the data into a newly allocated PODVector.
+    Works for every allocator type: for host-only allocators the
+    data is staged to the host through NumPy automatically.
+
+    Parameters
+    ----------
+    cls : type
+        The PODVector type to construct.
+    arr : array_like
+        Input data, convertible to a CuPy array.
+
+    Returns
+    -------
+    PODVector
+        A new PODVector with a copy of the data.
+    """
+    import cupy as cp
+
+    arr_cp = cp.asarray(arr)
+    n = len(arr_cp)
+    if n == 0:
+        return cls()
+    pv = cls(n)
+    if _is_host_accessible(cls):
+        import numpy as np
+
+        np.array(pv, copy=False)[:] = cp.asnumpy(arr_cp)
+    else:
+        cp.asarray(pv)[:] = arr_cp
+    return pv
+
+
+def podvector_from_xp(cls, arr):
+    """
+    Create a new PODVector from a NumPy or CuPy array,
+    depending on amr.Config.have_gpu .
+
+    Always copies the data into a newly allocated PODVector.
+    Unlike :meth:`to_xp`, a zero-copy view is not possible here because
+    PODVector always owns its memory through its allocator.
+
+    This function is similar to CuPy's xp naming suggestion for CPU/GPU agnostic code:
+    https://docs.cupy.dev/en/stable/user_guide/basic.html#how-to-write-cpu-gpu-agnostic-code
+
+    Parameters
+    ----------
+    cls : type
+        The PODVector type to construct.
+    arr : array_like
+        Input data (NumPy or CuPy array).
+
+    Returns
+    -------
+    PODVector
+        A new PODVector with a copy of the data.
+    """
+    if _is_host_accessible(cls):
+        return cls.from_numpy(arr)
+    else:
+        return cls.from_cupy(arr)
+
+
 def register_PODVector_extension(amr):
     """PODVector helper methods"""
     import inspect
@@ -112,6 +243,12 @@ def register_PODVector_extension(amr):
             and member.__name__.startswith("PODVector_")
         ),
     ):
+        # instance methods: PODVector -> array
         POD_type.to_numpy = podvector_to_numpy
         POD_type.to_cupy = podvector_to_cupy
         POD_type.to_xp = podvector_to_xp
+
+        # class methods: array -> PODVector
+        POD_type.from_numpy = classmethod(podvector_from_numpy)
+        POD_type.from_cupy = classmethod(podvector_from_cupy)
+        POD_type.from_xp = classmethod(podvector_from_xp)

--- a/src/amrex/extensions/PODVector.py
+++ b/src/amrex/extensions/PODVector.py
@@ -130,8 +130,10 @@ def podvector_from_numpy(cls, arr):
     """
     Create a new PODVector from a NumPy array (or array-like).
 
-    Always copies the data into a newly allocated PODVector.
-    For device-only allocators, the input is staged through CuPy.
+    Always copies the data into a newly allocated PODVector. The input is
+    cast to the vector's element type and made contiguous as needed. The
+    copy into device-only memory uses an AMReX host-to-device copy and does
+    not require CuPy.
 
     Parameters
     ----------
@@ -154,12 +156,7 @@ def podvector_from_numpy(cls, arr):
         return cls()
 
     pv = cls(n)
-    if _is_host_accessible(cls):
-        np.array(pv, copy=False)[:] = arr_np
-    else:
-        import cupy as cp
-
-        cp.asarray(pv)[:] = cp.asarray(arr_np)
+    pv.copy_from_host(arr_np)
     return pv
 
 

--- a/tests/test_podvector.py
+++ b/tests/test_podvector.py
@@ -90,6 +90,50 @@ def test_from_numpy_normalizes_input():
     np.testing.assert_array_equal(result2, np.array([4.0, 5.0, 6.0], result2.dtype))
 
 
+def test_to_device_empty():
+    podv = amr.PODVector_int_std()
+    device = podv.to_device()
+    assert isinstance(device, amr.DeviceVector_int)
+    assert device.size() == 0
+    assert device.empty()
+
+
+def test_to_device_from_host_vector():
+    import numpy as np
+
+    values = np.array([1, -2, 5, 8], dtype=np.int32)
+    podv = amr.PODVector_int_std.from_numpy(values)
+    device = podv.to_device()
+
+    assert isinstance(device, amr.DeviceVector_int)
+    assert device.size() == values.size
+    result = device.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, values.astype(result.dtype))
+
+    podv[0] = 99
+    np.testing.assert_array_equal(
+        device.to_numpy(copy=True), values.astype(result.dtype)
+    )
+
+
+def test_to_device_from_device_vector():
+    import numpy as np
+
+    values = np.array([1.0, 2.5, -3.0], dtype=np.float64)
+    podv = amr.DeviceVector_real.from_numpy(values)
+    device = podv.to_device()
+
+    assert isinstance(device, amr.DeviceVector_real)
+    assert device.size() == values.size
+    result = device.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, values.astype(result.dtype))
+
+    podv[1] = 7.0
+    np.testing.assert_array_equal(
+        device.to_numpy(copy=True), values.astype(result.dtype)
+    )
+
+
 @pytest.mark.skipif(not amr.Config.have_gpu, reason="requires AMReX GPU support")
 def test_from_numpy_device_only():
     # device-only allocator: the host-to-device copy must work without CuPy

--- a/tests/test_podvector.py
+++ b/tests/test_podvector.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 import amrex.space3d as amr
 
 
@@ -41,3 +43,86 @@ def test_array_interface():
 
     podv[1] = 5
     assert arr[1] == podv[1] == 5
+
+
+def test_from_numpy():
+    import numpy as np
+
+    # basic roundtrip
+    arr = np.array([1.0, 2.5, 3.7, 4.0], dtype=np.float64)
+    podv = amr.DeviceVector_real.from_numpy(arr)
+    assert podv.size() == 4
+    result = podv.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, arr)
+
+    # from_numpy creates a copy, not a view
+    arr[0] = 999.0
+    assert podv[0] != 999.0
+
+    # empty array
+    empty = np.array([], dtype=np.float64)
+    podv_empty = amr.DeviceVector_real.from_numpy(empty)
+    assert podv_empty.size() == 0
+
+    # from list (array-like)
+    podv_list = amr.DeviceVector_real.from_numpy([10.0, 20.0])
+    assert podv_list.size() == 2
+    assert podv_list[1] == 20.0
+
+
+def test_from_xp():
+    import numpy as np
+
+    arr = np.array([1.0, 2.0, 3.0])
+    podv = amr.DeviceVector_real.from_xp(arr)
+    assert podv.size() == 3
+    result = podv.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, arr)
+
+
+def test_from_xp_default():
+    import numpy as np
+
+    arr = np.array([5.0, 6.0, 7.0])
+    podv = amr.DeviceVector_real.from_xp(arr)
+    assert podv.size() == 3
+    result = podv.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, arr)
+
+
+@pytest.mark.skipif(not amr.Config.have_gpu, reason="requires AMReX GPU support")
+def test_from_cp():
+    cp = pytest.importorskip("cupy")
+
+    arr = cp.array([1.0, 2.5, 3.7, 4.0], dtype=cp.float64)
+    podv = amr.DeviceVector_real.from_cupy(arr)
+    assert podv.size() == 4
+    cp.testing.assert_array_equal(podv.to_cupy(), arr)
+
+    arr[0] = 999.0
+    assert podv[0] != 999.0
+
+    empty = cp.array([], dtype=cp.float64)
+    podv_empty = amr.DeviceVector_real.from_cupy(empty)
+    assert podv_empty.size() == 0
+
+    podv_list = amr.DeviceVector_real.from_cupy([10.0, 20.0])
+    assert podv_list.size() == 2
+    cp.testing.assert_array_equal(
+        podv_list.to_cupy(),
+        cp.array([10.0, 20.0], dtype=cp.float64),
+    )
+
+
+@pytest.mark.skipif(not amr.Config.have_gpu, reason="requires AMReX GPU support")
+def test_host_from_cp():
+    cp = pytest.importorskip("cupy")
+    import numpy as np
+
+    arr = cp.array([1.0, 2.5, 3.7, 4.0], dtype=cp.float64)
+    podv = amr.HostVector_real.from_cupy(arr)
+    assert podv.size() == 4
+    np.testing.assert_array_equal(podv.to_numpy(), cp.asnumpy(arr))
+
+    arr[0] = 999.0
+    assert podv[0] != 999.0

--- a/tests/test_podvector.py
+++ b/tests/test_podvector.py
@@ -48,12 +48,13 @@ def test_array_interface():
 def test_from_numpy():
     import numpy as np
 
-    # basic roundtrip
+    # basic roundtrip (cast to the vector's element type so the test is
+    # precision-agnostic, e.g. single-precision builds)
     arr = np.array([1.0, 2.5, 3.7, 4.0], dtype=np.float64)
     podv = amr.DeviceVector_real.from_numpy(arr)
     assert podv.size() == 4
     result = podv.to_numpy(copy=True)
-    np.testing.assert_array_equal(result, arr)
+    np.testing.assert_array_equal(result, arr.astype(result.dtype))
 
     # from_numpy creates a copy, not a view
     arr[0] = 999.0
@@ -70,6 +71,38 @@ def test_from_numpy():
     assert podv_list[1] == 20.0
 
 
+def test_from_numpy_normalizes_input():
+    import numpy as np
+
+    # non-contiguous (strided) input is made contiguous on the host
+    base = np.array([1.0, 9.0, 2.0, 9.0, 3.0, 9.0], dtype=np.float64)
+    strided = base[::2]
+    assert not strided.flags["C_CONTIGUOUS"]
+    podv = amr.DeviceVector_real.from_numpy(strided)
+    assert podv.size() == 3
+    result = podv.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0], result.dtype))
+
+    # mismatched dtype is cast to the vector's element type
+    ints = np.array([4, 5, 6], dtype=np.int32)
+    podv2 = amr.DeviceVector_real.from_numpy(ints)
+    result2 = podv2.to_numpy(copy=True)
+    np.testing.assert_array_equal(result2, np.array([4.0, 5.0, 6.0], result2.dtype))
+
+
+@pytest.mark.skipif(not amr.Config.have_gpu, reason="requires AMReX GPU support")
+def test_from_numpy_device_only():
+    # device-only allocator: the host-to-device copy must work without CuPy
+    import numpy as np
+
+    arr = np.array([1.0, 2.5, 3.7, 4.0], dtype=np.float64)
+    podv = amr.NonManagedDeviceVector_real.from_numpy(arr)
+    assert podv.size() == 4
+    # read back through an AMReX device-to-host copy (no CuPy either)
+    result = podv.to_host().to_numpy(copy=True)
+    np.testing.assert_array_equal(result, arr.astype(result.dtype))
+
+
 def test_from_xp():
     import numpy as np
 
@@ -77,17 +110,7 @@ def test_from_xp():
     podv = amr.DeviceVector_real.from_xp(arr)
     assert podv.size() == 3
     result = podv.to_numpy(copy=True)
-    np.testing.assert_array_equal(result, arr)
-
-
-def test_from_xp_default():
-    import numpy as np
-
-    arr = np.array([5.0, 6.0, 7.0])
-    podv = amr.DeviceVector_real.from_xp(arr)
-    assert podv.size() == 3
-    result = podv.to_numpy(copy=True)
-    np.testing.assert_array_equal(result, arr)
+    np.testing.assert_array_equal(result, arr.astype(result.dtype))
 
 
 @pytest.mark.skipif(not amr.Config.have_gpu, reason="requires AMReX GPU support")


### PR DESCRIPTION
Helpers to copy data directly from `NumPy`/`CuPy` to simplify user code, e.g., to add particles in AMReX codes.

- [x] test on CI for CPU
- [x] test locally on GPU (use names from #545 for uniform test name?)