### PR TITLE
Refactor Windows DLL loading in Python packages

### DIFF
--- a/src/amrex/_dll.py
+++ b/src/amrex/_dll.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+import os
+from pathlib import Path
+
+# Keep the os.add_dll_directory() handles alive so the registered search paths
+# stay active for the whole interpreter lifetime.
+_DLL_DIRECTORY_HANDLES = {}
+
+
+def _iter_windows_dll_directories(package_file):
+    package_dir = Path(package_file).resolve().parent
+    package_root = package_dir.parent
+    seen = set()
+
+    # Prefer package-local directories first so vendored wheel layouts can load
+    # dependent DLLs even when they never appear on PATH.
+    candidates = (
+        package_dir,
+        package_dir / ".libs",
+        package_root,
+        package_root / ".libs",
+    )
+
+    for candidate in candidates:
+        if candidate.is_dir():
+            candidate_str = str(candidate)
+            if candidate_str not in seen:
+                seen.add(candidate_str)
+                yield candidate_str
+
+    # PATH is still needed for developer/source installs that link against DLLs
+    # provided by an existing AMReX or application environment.
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+
+        path = Path(os.path.expandvars(os.path.expanduser(entry)))
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+
+        if not resolved.exists():
+            continue
+
+        resolved_str = str(resolved)
+        if resolved_str not in seen:
+            seen.add(resolved_str)
+            yield resolved_str
+
+
+def add_windows_dll_directories(package_file):
+    """Keep DLL directories registered for the lifetime of the process.
+
+    Python 3.8+ requires dependent DLL search paths to be registered
+    explicitly before importing the extension module.
+
+    Refs.:
+    - https://github.com/python/cpython/issues/80266
+    - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
+    """
+    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
+        return
+
+    package_dir = str(Path(package_file).resolve().parent)
+    if package_dir in _DLL_DIRECTORY_HANDLES:
+        return
+
+    handles = []
+    for dll_dir in _iter_windows_dll_directories(package_file):
+        try:
+            handles.append(os.add_dll_directory(dll_dir))
+        except OSError:
+            continue
+
+    _DLL_DIRECTORY_HANDLES[package_dir] = handles

--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -1,22 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import os
+from .._dll import add_windows_dll_directories
 
-# Python 3.8+ on Windows: DLL search paths for dependent
-# shared libraries
-# Refs.:
-# - https://github.com/python/cpython/issues/80266
-# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
-if os.name == "nt":
-    # add anything in the current directory
-    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
-    os.add_dll_directory(pwd)
-    # add anything in PATH
-    paths = os.environ.get("PATH", "")
-    for p in paths.split(";"):
-        p_abs = os.path.abspath(os.path.expanduser(os.path.expandvars(p)))
-        if os.path.exists(p_abs):
-            os.add_dll_directory(p_abs)
+# Register dependent DLL locations for the C++ AMReX library and potential
+# shared library dependencies before importing pybind.
+add_windows_dll_directories(__file__)
 
 # import core bindings to C++
 from . import amrex_1d_pybind

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -1,22 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import os
+from .._dll import add_windows_dll_directories
 
-# Python 3.8+ on Windows: DLL search paths for dependent
-# shared libraries
-# Refs.:
-# - https://github.com/python/cpython/issues/80266
-# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
-if os.name == "nt":
-    # add anything in the current directory
-    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
-    os.add_dll_directory(pwd)
-    # add anything in PATH
-    paths = os.environ.get("PATH", "")
-    for p in paths.split(";"):
-        p_abs = os.path.abspath(os.path.expanduser(os.path.expandvars(p)))
-        if os.path.exists(p_abs):
-            os.add_dll_directory(p_abs)
+# Register dependent DLL locations for the C++ AMReX library and potential
+# shared library dependencies before importing pybind.
+add_windows_dll_directories(__file__)
 
 # import core bindings to C++
 from . import amrex_2d_pybind

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -1,22 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import os
+from .._dll import add_windows_dll_directories
 
-# Python 3.8+ on Windows: DLL search paths for dependent
-# shared libraries
-# Refs.:
-# - https://github.com/python/cpython/issues/80266
-# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
-if os.name == "nt":
-    # add anything in the current directory
-    pwd = __file__.rsplit(os.sep, 1)[0] + os.sep
-    os.add_dll_directory(pwd)
-    # add anything in PATH
-    paths = os.environ.get("PATH", "")
-    for p in paths.split(";"):
-        p_abs = os.path.abspath(os.path.expanduser(os.path.expandvars(p)))
-        if os.path.exists(p_abs):
-            os.add_dll_directory(p_abs)
+# Register dependent DLL locations for the C++ AMReX library and potential
+# shared library dependencies before importing pybind.
+add_windows_dll_directories(__file__)
 
 # import core bindings to C++
 from . import amrex_3d_pybind


### PR DESCRIPTION
The existing `space1d`/`space2d`/`space3d` package initializers each carried the same Windows DLL setup code before importing their pybind extension. That logic only added the current package directory plus entries already present on `PATH` via `os.add_dll_directory()`. In practice this was fragile for wheel installs because the extension import could still fail if dependent DLLs were bundled in package-local locations that were not already on `PATH`.

Example: for ImpactX wheels we just build **one** ImpactX wheel that vendors the AMReX and ImpactX libs and both the pyAMReX and pyImpactX sources: https://github.com/BLAST-ImpactX/impactx-wheels/pull/22 (We do not yet publish AMReX wheels.)

Centralize the DLL search setup in `amrex._dll` and call it from each `spaceNd` package before importing `amrex_*d_pybind`. The new helper prefers package-local locations first: the current `spaceNd` directory, `spaceNd/.libs`, the parent amrex package directory, and `amrex/.libs`. It then falls back to `PATH` for source and developer installs.

Keep the `os.add_dll_directory()` handles alive for the lifetime of the process and deduplicate discovered paths. This keeps the Windows import workaround in one place and makes it compatible with vendored wheel layouts as well as traditional shared- library installs.