### PR TITLE
Relax pybind11 version requirement for package managers

### DIFF
--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -41,7 +41,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     elseif(NOT pyAMReX_pybind11_internal)
-        find_package(pybind11 ${pybind11_version} CONFIG REQUIRED)
+        find_package(pybind11 ${pybind11_version_min} CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -59,11 +59,11 @@ set(pyAMReX_pybind11_repo "https://github.com/pybind/pybind11.git"
 
 # Parse AMReX version and commit information
 file(READ "${pyAMReX_SOURCE_DIR}/dependencies.json" dependencies_data)
-string(JSON pybind11_version GET "${dependencies_data}" version_pybind11)
+string(JSON pybind11_version_min GET "${dependencies_data}" version_pybind11_min)
 string(JSON pybind11_commit GET "${dependencies_data}" commit_pybind11)
 
 # Strip "v" prefix from version for find_package
-string(REGEX REPLACE "^v" "" pybind11_version "${pybind11_version}")
+string(REGEX REPLACE "^v" "" pybind11_version_min "${pybind11_version_min}")
 
 set(pyAMReX_pybind11_branch ${pybind11_commit}
     CACHE STRING

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,7 @@
 {
     "version_pyamrex": "26.04",
     "version_amrex": "26.04",
-    "version_pybind11": "v3.0.4",
+    "version_pybind11_min": "v3.0.0",
     "commit_amrex": "26.04",
     "commit_pybind11": "v3.0.4"
 }

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -63,17 +63,22 @@ def update(args):
     # loop over repositories and update dependencies data
     for repo_name, repo_subdict in repo_dict.items():
         print(f"\nUpdating {repo_labels[repo_name]}...")
+
         # set keys to access dependencies data
         commit_key = f"commit_{repo_name}"
         version_key = f"version_{repo_name}"
+
         # get new commit information
         commit_response = requests.get(repo_subdict["commit"])
         commit_dict = commit_response.json()
+
         # set new commit
         repo_commit_sha = commit_dict["sha"]
+
         # get new version tag information
         tags_response = requests.get(repo_subdict["tags"])
         tags_list = tags_response.json()
+
         # filter out old-format tags for specific repositories
         tags_list_filtered = copy.deepcopy(tags_list)
         if repo_name == "amrex":
@@ -82,6 +87,7 @@ def update(args):
                 for tag_dict in tags_list
                 if (tag_dict["name"] != "boxlib" and tag_dict["name"] != "v2024")
             ]
+
         # set new version tag
         if repo_name == "pyamrex":
             # current date version for the pyAMReX release update
@@ -89,11 +95,19 @@ def update(args):
         else:
             # latest available tag (index 0) for all other dependencies
             repo_version_tag = tags_list_filtered[0]["name"]
-        # use version tag instead of commit sha for a release update or for pybind11
-        use_version_tag = args.release or (repo_name == "pybind11")
-        new_commit_sha = repo_version_tag if use_version_tag else repo_commit_sha
+
         # update commit
         if repo_name != "pyamrex":
+            # use version tag instead of commit sha:
+            # - for a release update
+            # - for pybind11 (always)
+            # - if the commit has not changed since the last version tag
+            use_version_tag = (
+                args.release
+                or (repo_name == "pybind11")
+                or (repo_commit_sha == tags_list_filtered[0]["commit"]["sha"])
+            )
+            new_commit_sha = repo_version_tag if use_version_tag else repo_commit_sha
             print(f"- old commit: {dependencies_data[commit_key]}")
             print(f"- new commit: {new_commit_sha}")
             if dependencies_data[commit_key] == new_commit_sha:
@@ -101,14 +115,18 @@ def update(args):
             else:
                 print("Updating commit...")
                 dependencies_data[f"commit_{repo_name}"] = new_commit_sha
+
         # update version
-        print(f"- old version: {dependencies_data[version_key]}")
-        print(f"- new version: {repo_version_tag}")
-        if dependencies_data[version_key] == repo_version_tag:
-            print("Skipping version update...")
+        if repo_name == "pybind11":
+            print("Skipping version update... (minimum version set manually)")
         else:
-            print("Updating version...")
-            dependencies_data[f"version_{repo_name}"] = repo_version_tag
+            print(f"- old version: {dependencies_data[version_key]}")
+            print(f"- new version: {repo_version_tag}")
+            if dependencies_data[version_key] == repo_version_tag:
+                print("Skipping version update...")
+            else:
+                print("Updating version...")
+                dependencies_data[f"version_{repo_name}"] = repo_version_tag
 
     # write to JSON file with dependencies data
     with open(dependencies_file, "w") as file:


### PR DESCRIPTION
## Overview

Fix the issue raised in https://github.com/BLAST-ImpactX/impactx/pull/1419#discussion_r3128341519:

> @EZoni I overlooked something here: You do not want to update the version in `find_package` higher than needed, because that way we cannot build with version `3.0.0`, `3.0.1`, `3.0.2`, and `3.0.3` in package managers anymore - even if those versions are totally fine. (e.g., conda-forge is still to ship `3.0.4`, stands at `3.0.3`. Spack has very good version control, too). So in other words: keep this here on `3.0.0` and below just update the version we download to the latest.

## Related PRs

- https://github.com/BLAST-ImpactX/impactx/pull/1432
- https://github.com/BLAST-WarpX/warpx/pull/6805

## Notes

Please select "Hide whitespace" to review the changes or use `git diff -w`.