### PR TITLE
Update bindings for latest AMReX particle/vector APIs

### DIFF
--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -68,7 +68,7 @@ namespace
 
         if constexpr (dim >= 1 && dim <=3) {
             py_iv.def("dim3",
-               [](const iv_type& iv) { return iv.dim3(); });
+               py::overload_cast<>(&iv_type::dim3, py::const_));
         }
 
         py_iv

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -68,7 +68,7 @@ namespace
 
         if constexpr (dim >= 1 && dim <=3) {
             py_iv.def("dim3",
-               py::overload_cast<>(&iv_type::template dim3<dim>, py::const_));
+               [](const iv_type& iv) { return iv.dim3(); });
         }
 
         py_iv

--- a/src/Base/IntVect.cpp
+++ b/src/Base/IntVect.cpp
@@ -68,7 +68,7 @@ namespace
 
         if constexpr (dim >= 1 && dim <=3) {
             py_iv.def("dim3",
-               py::overload_cast<>(&iv_type::dim3, py::const_));
+               [](const iv_type& iv) { return iv.dim3(); });
         }
 
         py_iv

--- a/src/Base/RealVect.cpp
+++ b/src/Base/RealVect.cpp
@@ -93,11 +93,7 @@ void init_RealVect(py::module &m) {
           .def(py::self * py::self)
           .def("dotProduct", &RealVect::dotProduct, "Return dot product of this vector with another")
 #if (AMREX_SPACEDIM == 3)
-          .def("crossProduct",
-               [](const RealVect& lhs, const RealVect& rhs) {
-                   return lhs.crossProduct(rhs);
-               },
-               "Return cross product of this vector with another")
+          .def("crossProduct", &RealVect::crossProduct, "Return cross product of this vector with another")
 #endif
           .def("__mul__",
                py::overload_cast<Real>(&RealVect::operator*, py::const_))

--- a/src/Base/RealVect.cpp
+++ b/src/Base/RealVect.cpp
@@ -93,7 +93,11 @@ void init_RealVect(py::module &m) {
           .def(py::self * py::self)
           .def("dotProduct", &RealVect::dotProduct, "Return dot product of this vector with another")
 #if (AMREX_SPACEDIM == 3)
-          .def("crossProduct", &RealVect::crossProduct, "Return cross product of this vector with another")
+          .def("crossProduct",
+               [](const RealVect& lhs, const RealVect& rhs) {
+                   return lhs.crossProduct(rhs);
+               },
+               "Return cross product of this vector with another")
 #endif
           .def("__mul__",
                py::overload_cast<Real>(&RealVect::operator*, py::const_))

--- a/src/Base/RealVect.cpp
+++ b/src/Base/RealVect.cpp
@@ -93,7 +93,11 @@ void init_RealVect(py::module &m) {
           .def(py::self * py::self)
           .def("dotProduct", &RealVect::dotProduct, "Return dot product of this vector with another")
 #if (AMREX_SPACEDIM == 3)
-          .def("crossProduct", &RealVect::crossProduct<>, "Return cross product of this vector with another")
+          .def("crossProduct",
+               [](const RealVect& lhs, const RealVect& rhs) {
+                   return lhs.crossProduct(rhs);
+               },
+               "Return cross product of this vector with another")
 #endif
           .def("__mul__",
                py::overload_cast<Real>(&RealVect::operator*, py::const_))

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -382,10 +382,7 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         // template <class PCType,
         // requires (IsParticleContainer<PCType>::value)
         // void addParticles (const PCType& other, bool local=false);
-        .def("add_particles",
-            [](ParticleContainerType& pc, ParticleContainerType const& other, bool local) {
-                pc.template addParticles<ParticleContainerType>(other, local);
-            },
+        .def("add_particles", py::overload_cast<ParticleContainerType const &, bool>(&ParticleContainerType::template addParticles<ParticleContainerType>),
             py::arg("other"), py::arg("local")=false)
         // template <class F, class PCType,
         // requires ((IsParticleContainer<PCType>::value) && (!std::is_integral_v<F>))

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -377,20 +377,21 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
 
         .def("clear_particles", &ParticleContainerType::clearParticles)
         // template <class PCType,
-        //           std::enable_if_t<IsParticleContainer<PCType>::value, int> foo = 0>
+        // requires (IsParticleContainer<PCType>::value)
         // void copyParticles (const PCType& other, bool local=false);
         // template <class PCType,
-        //           std::enable_if_t<IsParticleContainer<PCType>::value, int> foo = 0>
+        // requires (IsParticleContainer<PCType>::value)
         // void addParticles (const PCType& other, bool local=false);
-        .def("add_particles", py::overload_cast<ParticleContainerType const &, bool>(&ParticleContainerType::template addParticles<ParticleContainerType, true>),
+        .def("add_particles",
+            [](ParticleContainerType& pc, ParticleContainerType const& other, bool local) {
+                pc.template addParticles<ParticleContainerType>(other, local);
+            },
             py::arg("other"), py::arg("local")=false)
         // template <class F, class PCType,
-        //           std::enable_if_t<IsParticleContainer<PCType>::value, int> foo = 0,
-        //           std::enable_if_t<! std::is_integral<F>::value, int> bar = 0>
+        // requires ((IsParticleContainer<PCType>::value) && (!std::is_integral_v<F>))
         // void copyParticles (const PCType& other, F&&f, bool local=false);
         // template <class F, class PCType,
-        //           std::enable_if_t<IsParticleContainer<PCType>::value, int> foo = 0,
-        //           std::enable_if_t<! std::is_integral<F>::value, int> bar = 0>
+        // requires ((IsParticleContainer<PCType>::value) && (!std::is_integral_v<F>))
         // void addParticles (const PCType& other, F&& f, bool local=false);
         // void WriteParticleRealData (void* data, size_t size, std::ostream& os) const;
         // // void ReadParticleRealData (void* data, size_t size, std::istream& is);
@@ -422,23 +423,44 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
              },
              py::arg("dir"), py::arg("name")
         )
-        // template <class F, typename std::enable_if<!std::is_same<F, Vector<std::string>&>::value>::type* = nullptr>
-        // void WritePlotFile (const std::string& dir, const std::string& name, F&& f) const;
+        // void WritePlotFile (const std::string& dir, const std::string& name) const;
+        // template <class F>
+        // void WritePlotFile (const std::string& dir, const std::string& name, F const& f) const;
         // void WritePlotFile (const std::string& dir, const std::string& name,
         //                 const Vector<std::string>& real_comp_names,
         //                 const Vector<std::string>&  int_comp_names) const;
+        // template <class F>
+        // void WritePlotFile (const std::string& dir, const std::string& name,
+        //                 const Vector<std::string>& real_comp_names,
+        //                 const Vector<std::string>&  int_comp_names, F const& f) const;
         // void WritePlotFile (const std::string& dir, const std::string& name,
         //                     const Vector<std::string>& real_comp_names) const;
+        // template <class F>
+        // void WritePlotFile (const std::string& dir, const std::string& name,
+        //                     const Vector<std::string>& real_comp_names, F const& f) const;
         // void WritePlotFile (const std::string& dir,
         //                     const std::string& name,
         //                     const Vector<int>& write_real_comp,
         //                     const Vector<int>& write_int_comp) const;
+        // template <class F>
+        // void WritePlotFile (const std::string& dir,
+        //                     const std::string& name,
+        //                     const Vector<int>& write_real_comp,
+        //                     const Vector<int>& write_int_comp, F const& f) const;
         // void WritePlotFile (const std::string& dir,
         //                     const std::string& name,
         //                     const Vector<int>& write_real_comp,
         //                     const Vector<int>& write_int_comp,
         //                     const Vector<std::string>& real_comp_names,
         //                     const Vector<std::string>&  int_comp_names) const;
+        // template <class F>
+        // void WritePlotFile (const std::string& dir,
+        //                     const std::string& name,
+        //                     const Vector<int>& write_real_comp,
+        //                     const Vector<int>& write_int_comp,
+        //                     const Vector<std::string>& real_comp_names,
+        //                     const Vector<std::string>&  int_comp_names,
+        //                     F const& f) const;
         // void WritePlotFilePre ();
 
         // void WritePlotFilePost ();

--- a/src/Particle/ParticleTile.H
+++ b/src/Particle/ParticleTile.H
@@ -48,13 +48,22 @@ void make_ParticleTileData(py::module &m)
             .def_property_readonly("m_num_runtime_real", [](ParticleTileDataType const & ptd){ return ptd.m_num_runtime_real; })
             .def_property_readonly("m_num_runtime_int", [](ParticleTileDataType const & ptd){ return ptd.m_num_runtime_int; })
 
-            .def("get_super_particle", &ParticleTileDataType::template getSuperParticle<ParticleType>)
-            .def("set_super_particle", &ParticleTileDataType::template setSuperParticle<ParticleType>)
+            .def("get_super_particle",
+                 [](ParticleTileDataType &pdt, int const v) -> SuperParticleType {
+                     return pdt.getSuperParticle(v);
+                 })
+            .def("set_super_particle",
+                 [](ParticleTileDataType &pdt, int const v,
+                    SuperParticleType const& sp) {
+                     pdt.setSuperParticle(sp, v);
+                 })
             // setter & getter
             .def("__setitem__", [](ParticleTileDataType &pdt, int const v,
                                    SuperParticleType const value) { pdt.setSuperParticle(value, v); })
             .def("__getitem__",
-                 [](ParticleTileDataType &pdt, int const v) { return pdt.getSuperParticle(v); })
+                 [](ParticleTileDataType &pdt, int const v) -> SuperParticleType {
+                     return pdt.getSuperParticle(v);
+                 })
 
     ;
 }

--- a/src/Particle/ParticleTile.H
+++ b/src/Particle/ParticleTile.H
@@ -48,22 +48,13 @@ void make_ParticleTileData(py::module &m)
             .def_property_readonly("m_num_runtime_real", [](ParticleTileDataType const & ptd){ return ptd.m_num_runtime_real; })
             .def_property_readonly("m_num_runtime_int", [](ParticleTileDataType const & ptd){ return ptd.m_num_runtime_int; })
 
-            .def("get_super_particle",
-                 [](ParticleTileDataType &pdt, int const v) -> SuperParticleType {
-                     return pdt.getSuperParticle(v);
-                 })
-            .def("set_super_particle",
-                 [](ParticleTileDataType &pdt, int const v,
-                    SuperParticleType const& sp) {
-                     pdt.setSuperParticle(sp, v);
-                 })
+            .def("get_super_particle", [](ParticleTileDataType &pdt, int const v) -> SuperParticleType { return pdt.getSuperParticle(v); })
+            .def("set_super_particle", [](ParticleTileDataType &pdt, SuperParticleType const& sp, int const v) { pdt.setSuperParticle(sp, v); })
             // setter & getter
             .def("__setitem__", [](ParticleTileDataType &pdt, int const v,
                                    SuperParticleType const value) { pdt.setSuperParticle(value, v); })
             .def("__getitem__",
-                 [](ParticleTileDataType &pdt, int const v) -> SuperParticleType {
-                     return pdt.getSuperParticle(v);
-                 })
+                 [](ParticleTileDataType &pdt, int const v) { return pdt.getSuperParticle(v); })
 
     ;
 }


### PR DESCRIPTION
Adapt pybind bindings to AMReX C++20 interface changes:
- update IntVectND::dim3 and RealVect::crossProduct
- update ParticleContainer::add_particles for requires-based addParticles
- refresh ParticleContainer comments for addParticles and WritePlotFile overloads
- update ParticleTile setSuperParticle/getSuperParticle