### PR TITLE
Fix more iMultiFab Tests (CUDA)

### DIFF
--- a/src/Base/iMultiFab.cpp
+++ b/src/Base/iMultiFab.cpp
@@ -7,6 +7,7 @@
 #include "MultiFab.H"
 
 #include <AMReX_FabArray.H>
+#include <AMReX_FabArrayUtility.H>
 #include <AMReX_IArrayBox.H>
 #include <AMReX_iMultiFab.H>
 
@@ -20,4 +21,27 @@ void init_iMultiFab(py::module &m)
 
     m.def("copy_mfab", py::overload_cast< iMultiFab &, iMultiFab const &, int, int, int, int >(&iMultiFab::Copy), py::arg("dst"), py::arg("src"), py::arg("srccomp"), py::arg("dstcomp"), py::arg("numcomp"), py::arg("nghost"))
      .def("copy_mfab", py::overload_cast< iMultiFab &, iMultiFab const &, int, int, int, IntVect const & >(&iMultiFab::Copy), py::arg("dst"), py::arg("src"), py::arg("srccomp"), py::arg("dstcomp"), py::arg("numcomp"), py::arg("nghost"));
+
+    // host-device copies for integer FabArrays (iMultiFab)
+    m.def("htod_memcpy",
+          py::overload_cast< FabArray<IArrayBox> &, FabArray<IArrayBox> const & >(&htod_memcpy<IArrayBox>),
+          py::arg("dest"), py::arg("src"),
+          "Copy from a host to device FabArray."
+    );
+    m.def("htod_memcpy",
+          py::overload_cast< FabArray<IArrayBox> &, FabArray<IArrayBox> const &, int, int, int >(&htod_memcpy<IArrayBox>),
+          py::arg("dest"), py::arg("src"), py::arg("scomp"), py::arg("dcomp"), py::arg("ncomp"),
+          "Copy from a host to device FabArray for a specific (number of) component(s)."
+    );
+
+    m.def("dtoh_memcpy",
+          py::overload_cast< FabArray<IArrayBox> &, FabArray<IArrayBox> const & >(&dtoh_memcpy<IArrayBox>),
+          py::arg("dest"), py::arg("src"),
+          "Copy from a device to host FabArray."
+    );
+    m.def("dtoh_memcpy",
+          py::overload_cast< FabArray<IArrayBox> &, FabArray<IArrayBox> const &, int, int, int >(&dtoh_memcpy<IArrayBox>),
+          py::arg("dest"), py::arg("src"), py::arg("scomp"), py::arg("dcomp"), py::arg("ncomp"),
+          "Copy from a device to host FabArray for a specific (number of) component(s)."
+    );
 }

--- a/tests/test_imultifab.py
+++ b/tests/test_imultifab.py
@@ -424,7 +424,7 @@ def test_imfab_ops_cuda_cuml(imfab_device):
 def test_imfab_dtoh_copy(imfab_device):
     class MfabPinnedContextManager:
         def __enter__(self):
-            self.imfab = amr.MultiFab(
+            self.imfab = amr.iMultiFab(
                 imfab_device.box_array(),
                 imfab_device.dm(),
                 imfab_device.n_comp,


### PR DESCRIPTION
Fix the last failing CUDA test w/ Claude:

## Test: fix iMultiFab dtoh host buffer type

test_imfab_dtoh_copy allocated its pinned host buffer as a real MultiFab but ran dtoh_memcpy/htod_memcpy against an integer iMultiFab on the device, a type mismatch that fails once the iMultiFab memcpy overloads exist. Allocate the host buffer as an iMultiFab so both sides share the IArrayBox type.

## iMultiFab: host-device memcpy bindings

Add htod_memcpy and dtoh_memcpy overloads for FabArray<IArrayBox>, so integer iMultiFab data can be copied between host and device. Only the FArrayBox (real MultiFab) overloads existed before, so any dtoh/htod copy involving an iMultiFab raised a TypeError for unsupported argument types. The free functions are FAB-templated in AMReX, so this just instantiates them for IArrayBox and exposes the same 2- and 5-argument signatures already offered for MultiFab.
