### PR TITLE
PODVector `from_array`

### DIFF
--- a/src/amrex/extensions/PODVector.py
+++ b/src/amrex/extensions/PODVector.py
@@ -192,6 +192,89 @@ def podvector_from_xp(cls, arr):
         return cls.from_cupy(arr)
 
 
+def _podvector_copy_to(cls, src):
+    """Copy a PODVector ``src`` of any allocator into a new ``cls`` PODVector.
+
+    Stays free of any CuPy dependency by reusing the AMReX copy primitives:
+    the ``to_device``/``to_host`` fast paths for the two common targets, and a
+    host-staged ``from_numpy`` for the remaining allocators.
+
+    Converting between two *distinct device-only* allocators stages through the
+    host (device -> host -> device) rather than a direct device-to-device copy.
+    """
+    import inspect
+
+    amr = inspect.getmodule(cls)
+    suffix = cls.__name__.rsplit("_", 1)[-1]
+
+    # to_host() returns the pinned (HostVector) allocator
+    if suffix == "pinned":
+        return src.to_host()
+
+    # to_device() returns the Gpu::DeviceVector alias: arena on GPU, std on CPU
+    device_suffix = "arena" if amr.Config.have_gpu else "std"
+    if suffix == device_suffix:
+        return src.to_device()
+
+    # general target (device, managed, async, polymorphic, CPU arena, ...):
+    # ensure a host-accessible source, then host -> target via from_numpy
+    host = src if _is_host_accessible(type(src)) else src.to_host()
+    return cls.from_numpy(host)
+
+
+def podvector_from_array(cls, arr):
+    """
+    Create a PODVector from arbitrary array input, mirroring ``numpy.asarray``.
+
+    Accepts ``None``, a NumPy or CuPy array (or array-like such as a list or
+    tuple), or any pyAMReX ``PODVector``. The element type and target allocator
+    are those of ``cls`` (e.g. ``DeviceVector_real``, ``PODVector_int_std``).
+
+    Dispatch:
+
+    - ``None`` returns a new **empty** PODVector (size 0).
+    - An input that is already an instance of ``cls`` is returned **unchanged**
+      (no copy), like ``numpy.asarray`` on a matching array.
+    - Any other ``PODVector`` is copied into ``cls`` across memory spaces as
+      needed, without requiring CuPy.
+    - A CuPy (or other ``__cuda_array_interface__``) array goes through
+      :meth:`from_cupy`.
+    - A NumPy array or array-like goes through :meth:`from_numpy`, which casts
+      to the element type and requires 1-D input.
+
+    Parameters
+    ----------
+    cls : type
+        The PODVector type to construct.
+    arr : None or array_like or PODVector
+        Input data.
+
+    Returns
+    -------
+    PODVector
+        The input itself when it already is a ``cls`` instance, otherwise a new
+        ``cls`` PODVector with a copy of the data.
+    """
+    # None -> empty vector
+    if arr is None:
+        return cls()
+
+    # already the exact target type: no-copy passthrough (numpy.asarray-like)
+    if isinstance(arr, cls):
+        return arr
+
+    # any other PODVector allocator: CuPy-free cross-allocator copy
+    if type(arr).__name__.startswith("PODVector_"):
+        return _podvector_copy_to(cls, arr)
+
+    # CuPy (and other device) arrays expose the CUDA array interface
+    if hasattr(arr, "__cuda_array_interface__"):
+        return cls.from_cupy(arr)
+
+    # NumPy arrays and array-likes (lists, tuples, ...)
+    return cls.from_numpy(arr)
+
+
 def register_PODVector_extension(amr):
     """PODVector helper methods"""
     import inspect
@@ -215,3 +298,4 @@ def register_PODVector_extension(amr):
         # (from_numpy is provided in C++ as a static method)
         POD_type.from_cupy = classmethod(podvector_from_cupy)
         POD_type.from_xp = classmethod(podvector_from_xp)
+        POD_type.from_array = classmethod(podvector_from_array)

--- a/tests/test_podvector.py
+++ b/tests/test_podvector.py
@@ -193,3 +193,98 @@ def test_host_from_cp():
 
     arr[0] = 999.0
     assert podv[0] != 999.0
+
+
+def test_from_array_none():
+    # None -> a new empty vector (mirrors a sensible asarray of nothing)
+    podv = amr.DeviceVector_real.from_array(None)
+    assert isinstance(podv, amr.DeviceVector_real)
+    assert podv.size() == 0
+    assert podv.empty()
+
+
+def test_from_array_numpy_and_list():
+    import numpy as np
+
+    # NumPy array
+    arr = np.array([1.0, 2.5, 3.7, 4.0], dtype=np.float64)
+    podv = amr.DeviceVector_real.from_array(arr)
+    assert podv.size() == 4
+    result = podv.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, arr.astype(result.dtype))
+
+    # from_array creates a copy, not a view
+    arr[0] = 999.0
+    assert podv[0] != 999.0
+
+    # array-likes: list and tuple
+    podv_list = amr.DeviceVector_real.from_array([10.0, 20.0])
+    assert podv_list.size() == 2
+    assert podv_list[1] == 20.0
+    podv_tuple = amr.DeviceVector_real.from_array((10.0, 20.0, 30.0))
+    assert podv_tuple.size() == 3
+    assert podv_tuple[2] == 30.0
+
+
+def test_from_array_dtype_cast():
+    # mismatched dtype is cast to the vector's element type
+    import numpy as np
+
+    ints = np.array([4, 5, 6], dtype=np.int32)
+    podv = amr.DeviceVector_real.from_array(ints)
+    result = podv.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, np.array([4.0, 5.0, 6.0], result.dtype))
+
+
+def test_from_array_same_type_is_noop():
+    import numpy as np
+
+    src = amr.DeviceVector_real.from_numpy(np.array([1.0, 2.0, 3.0]))
+    # already the target type: returned unchanged, no copy (asarray-like)
+    assert amr.DeviceVector_real.from_array(src) is src
+
+
+def test_from_array_other_podvector():
+    import numpy as np
+
+    # pinned and arena are distinct classes on both CPU and GPU builds, so this
+    # always exercises the cross-allocator copy (not the no-copy passthrough)
+    values = np.array([1, -2, 5, 8], dtype=np.int32)
+    src = amr.PODVector_int_pinned.from_numpy(values)
+    dst = amr.PODVector_int_arena.from_array(src)
+
+    assert isinstance(dst, amr.PODVector_int_arena)
+    assert dst.size() == values.size
+    result = dst.to_numpy(copy=True)
+    np.testing.assert_array_equal(result, values.astype(result.dtype))
+
+    # the copy is independent of the source
+    src[0] = 99
+    np.testing.assert_array_equal(dst.to_numpy(copy=True), values.astype(result.dtype))
+
+
+@pytest.mark.skipif(not amr.Config.have_gpu, reason="requires AMReX GPU support")
+def test_from_array_cupy():
+    cp = pytest.importorskip("cupy")
+
+    # CuPy input is routed through from_cupy
+    arr = cp.array([1.0, 2.5, 3.7, 4.0], dtype=cp.float64)
+    podv = amr.DeviceVector_real.from_array(arr)
+    assert podv.size() == 4
+    cp.testing.assert_array_equal(podv.to_cupy(), arr)
+
+    arr[0] = 999.0
+    assert podv[0] != 999.0
+
+
+@pytest.mark.skipif(not amr.Config.have_gpu, reason="requires AMReX GPU support")
+def test_from_array_device_only_source():
+    # a device-only source converts correctly (CuPy-free, staged as needed)
+    import numpy as np
+
+    values = np.array([1.0, 2.5, 3.7, 4.0], dtype=np.float64)
+    src = amr.NonManagedDeviceVector_real.from_numpy(values)
+    device = amr.DeviceVector_real.from_array(src)
+    assert isinstance(device, amr.DeviceVector_real)
+    result = device.to_host().to_numpy(copy=True)
+    np.testing.assert_array_equal(result, values.astype(result.dtype))


### PR DESCRIPTION
- [x] Generalize #556 further to pick whatever is passed (numpy, cupy, etc.), see https://github.com/BLAST-ImpactX/impactx/pull/1488
- [ ] so var vibed, need to review.