### PR TITLE
Particle Reading (Runtime SoA)

### DIFF
--- a/docs/source/usage/api.rst
+++ b/docs/source/usage/api.rst
@@ -273,6 +273,12 @@ Utility
 
 .. autofunction:: amrex.space3d.write_single_level_plotfile
 
+.. autofunction:: amrex.space3d.write_multi_level_plotfile
+
+.. autoclass:: amrex.space3d.PlotFileData
+   :members:
+   :undoc-members:
+
 
 .. _usage-api-amrcore:
 
@@ -407,6 +413,17 @@ This is for the legacy, AoS + SoA particle containers only:
 ``amrex::Particle<T_NReal, T_NInt>`` is implemented for many numbers of extra Real and Int arguments, e.g.,
 
 .. autoclass:: amrex.space3d.Particle_2_1
+   :members:
+   :undoc-members:
+
+I/O
+"""
+
+Read back particle data from plotfiles and checkpoints, see :ref:`Read Back Plotfiles <usage-how-to-read-plotfiles>`:
+
+.. autofunction:: amrex.space3d.read_particles
+
+.. autoclass:: amrex.space3d.ParticleHeader
    :members:
    :undoc-members:
 

--- a/docs/source/usage/workflows.rst
+++ b/docs/source/usage/workflows.rst
@@ -1,19 +1,19 @@
+.. _usage-how-to:
 .. _usage-workflows:
 
-Workflows
-=========
+How-To Guides
+=============
 
 This section collects typical user workflows and best practices for pyAMReX.
-
-.. note::
-
-   TODO: Add more workflows as in https://warpx.readthedocs.io/en/latest/usage/workflows.html
 
 .. toctree::
    :maxdepth: 2
 
+   workflows/read_plotfiles
 ..   workflows/parallelization
 ..   workflows/profiling
-   workflows/debugging
-..   workflows/libensemble
-..   workflows/plot_distribution_mapping
+..   workflows/debugging
+
+.. note::
+
+   TODO: Add more workflows as in https://warpx.readthedocs.io/en/latest/usage/workflows.html

--- a/docs/source/usage/workflows/read_plotfiles.rst
+++ b/docs/source/usage/workflows/read_plotfiles.rst
@@ -1,0 +1,72 @@
+.. _usage-how-to-read-plotfiles:
+
+Read Back Plotfiles
+===================
+
+AMReX applications write field (mesh) and particle data as `plotfiles and checkpoint files <https://amrex-codes.github.io/amrex/docs_html/IO.html>`__.
+This page shows how to read such files back into pyAMReX objects, using the same AMReX C++ reader logic that applications use for restarts.
+
+The returned objects are regular pyAMReX containers:
+field and particle data can be accessed with :ref:`zero-copy views <usage-zerocopy>` from NumPy, CuPy, and other libraries and processed as shown in :ref:`Compute <usage-compute>`.
+
+.. note::
+
+   For quick data analysis and visualization of AMReX plotfiles, `yt <https://yt-project.org>`__ is a feature-rich, dedicated package.
+   Reading plotfiles directly with pyAMReX, as shown here, is ideal when the data shall be placed 1:1 into AMReX data structures again, e.g., to initialize or restart a simulation, to couple codes, or to post-process with the exact AMReX block-structure, zero-copy math and MPI-parallelism.
+
+
+Field (Mesh) Data
+-----------------
+
+Use :py:class:`~amrex.space3d.PlotFileData` to open a plotfile, query its meta-data and read per-level field data as :py:class:`~amrex.space3d.MultiFab`:
+
+.. literalinclude:: ../../../../tests/test_plotfiledata.py
+   :language: python3
+   :dedent: 4
+   :start-after: # Manual: Read Plotfile Mesh START
+   :end-before: # Manual: Read Plotfile Mesh END
+
+
+Particle Data
+-------------
+
+Particle data in a plotfile or checkpoint is stored in a sub-directory (often called ``particles``, per species name, or similar).
+Use :py:func:`~amrex.space3d.read_particles` to read it back into a particle container - no prior knowledge of the writing container's compile-time layout is needed, the number and names of the particle components are discovered from the file:
+
+.. literalinclude:: ../../../../tests/test_readparticles.py
+   :language: python3
+   :dedent: 4
+   :start-after: # Manual: Read Plotfile Particles START
+   :end-before: # Manual: Read Plotfile Particles END
+
+For multi-level files, particles from all levels are read.
+The auto-created container is single-level: all particles are placed on level 0, preserving their positions and components (only the mesh-refinement level association is flattened).
+To move particles on MR levels again, an explicit call to ``Redistribute`` needs to be made after reading.
+
+To only inspect the on-disk layout, e.g., to check which components a file contains before reading it, use :py:class:`~amrex.space3d.ParticleHeader`:
+
+.. literalinclude:: ../../../../tests/test_readparticles.py
+   :language: python3
+   :dedent: 4
+   :start-after: # Manual: Read Particle Header START
+   :end-before: # Manual: Read Particle Header END
+
+
+Read Into an Existing Container
+-------------------------------
+
+:py:func:`~amrex.space3d.read_particles` can also fill an existing, geometry-defined container, via its ``container`` argument.
+Use this to control the container type, MPI decomposition and mesh-refinement levels - or when the geometry cannot be recovered from the file itself:
+application *checkpoints* store their top-level ``Header`` in an application-specific format, so their AMR geometry must be defined by the application before reading.
+
+.. literalinclude:: ../../../../tests/test_readparticles.py
+   :language: python3
+   :dedent: 4
+   :start-after: # Manual: Read Particles Existing Container START
+   :end-before: # Manual: Read Particles Existing Container END
+
+Related low-level APIs, mirroring the AMReX C++ workflows for restarts:
+
+* ``pc.restart_checkpoint(dir, file, is_checkpoint)``: restore particles from a checkpoint/plotfile into a live container,
+* ``VisMF.Read(name)`` / ``VisMF.Write(mf, name)``: read/write a single :py:class:`~amrex.space3d.MultiFab` at the raw multifab-file granularity,
+* :py:func:`~amrex.space3d.write_single_level_plotfile` / :py:func:`~amrex.space3d.write_multi_level_plotfile` and ``pc.write_plotfile(dir, name, real_comp_names, int_comp_names)``: write fields and particles, e.g., to generate the files read back above.

--- a/src/Base/PlotFileUtil.cpp
+++ b/src/Base/PlotFileUtil.cpp
@@ -9,7 +9,9 @@
 #include <AMReX_Vector.H>
 
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace py = pybind11;
 using namespace amrex;
@@ -21,6 +23,47 @@ void init_PlotFileUtil(py::module &m) {
         py::arg("level_step"), py::arg("versionName") = "HyperCLaw-V1.1",
         py::arg("levelPrefix") = "Level_", py::arg("mfPrefix") = "Cell",
         py::arg_v("extra_dirs", Vector<std::string>(), "list[str]"));
+
+  m.def("write_multi_level_plotfile",
+        [](std::string const & plotfilename,
+           std::vector<MultiFab const *> const & mf,
+           std::vector<std::string> const & varnames,
+           std::vector<Geometry> const & geom,
+           Real time,
+           std::vector<int> const & level_steps,
+           std::vector<IntVect> const & ref_ratio,
+           std::string const & versionName,
+           std::string const & levelPrefix,
+           std::string const & mfPrefix,
+           std::vector<std::string> const & extra_dirs)
+        {
+            auto const nlevels = static_cast<int>(mf.size());
+            if (static_cast<int>(geom.size()) != nlevels ||
+                static_cast<int>(level_steps.size()) != nlevels ||
+                static_cast<int>(ref_ratio.size()) < nlevels - 1)
+            {
+                throw std::invalid_argument(
+                    "write_multi_level_plotfile: mf, geom and level_steps need "
+                    "one entry per level and ref_ratio one per coarse level");
+            }
+            WriteMultiLevelPlotfile(
+                plotfilename, nlevels,
+                Vector<MultiFab const *>(mf.begin(), mf.end()),
+                Vector<std::string>(varnames.begin(), varnames.end()),
+                Vector<Geometry>(geom.begin(), geom.end()),
+                time,
+                Vector<int>(level_steps.begin(), level_steps.end()),
+                Vector<IntVect>(ref_ratio.begin(), ref_ratio.end()),
+                versionName, levelPrefix, mfPrefix,
+                Vector<std::string>(extra_dirs.begin(), extra_dirs.end()));
+        },
+        "Writes a multi-level plotfile: one MultiFab, Geometry and level step "
+        "per level, and one refinement ratio per coarse level.",
+        py::arg("plotfilename"), py::arg("mf"), py::arg("varnames"),
+        py::arg("geom"), py::arg("time"), py::arg("level_steps"),
+        py::arg("ref_ratio"), py::arg("versionName") = "HyperCLaw-V1.1",
+        py::arg("levelPrefix") = "Level_", py::arg("mfPrefix") = "Cell",
+        py::arg_v("extra_dirs", std::vector<std::string>(), "list[str]"));
 
   py::class_<PlotFileData>(m, "PlotFileData")
       // explicitly provide constructor argument types

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -2,6 +2,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     target_sources(pyAMReX_${D}d
       PRIVATE
         ParticleContainer.cpp
+        ParticleHeader.cpp
     )
 
     # this is primarily to save compile-time

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -430,6 +430,17 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
              },
              py::arg("dir"), py::arg("name")
         )
+        .def("write_plotfile",
+             [](ParticleContainerType const & pc, std::string const & dir, std::string const & name,
+                Vector<std::string> const & real_comp_names, Vector<std::string> const & int_comp_names){
+                return pc.WritePlotFile(dir, name, real_comp_names, int_comp_names);
+             },
+             py::arg("dir"), py::arg("name"),
+             py::arg("real_comp_names"), py::arg("int_comp_names"),
+             "Write a particle plotfile, naming the real and integer components.\n"
+             "For pure SoA containers, real_comp_names excludes the AMREX_SPACEDIM "
+             "position components."
+        )
         // void WritePlotFile (const std::string& dir, const std::string& name) const;
         // template <class F>
         // void WritePlotFile (const std::string& dir, const std::string& name, F const& f) const;

--- a/src/Particle/ParticleHeader.cpp
+++ b/src/Particle/ParticleHeader.cpp
@@ -1,0 +1,66 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_ParticleHeader.H>
+
+#include <string>
+
+
+void init_ParticleHeader(py::module& m)
+{
+    using namespace amrex;
+
+    py::class_<ParticleHeader>(m, "ParticleHeader")
+        .def(py::init<>())
+
+        .def_static("read", &ParticleHeader::read,
+            py::arg("dir"), py::arg("file"),
+            "Read and parse the ``Header`` of a particle plotfile/checkpoint.\n\n"
+            "This discovers the on-disk layout (number and names of real/int\n"
+            "components, precision, checkpoint flag, ...) without constructing a\n"
+            "matching ParticleContainer first.\n\n"
+            "Parameters\n"
+            "----------\n"
+            "dir : str\n"
+            "    plotfile/checkpoint directory\n"
+            "file : str\n"
+            "    particle sub-directory name (e.g. ``\"particle0\"``)")
+
+        .def_readwrite("version", &ParticleHeader::version,
+            "raw version string of the file format")
+        .def_readwrite("how", &ParticleHeader::how,
+            "precision the data was written in: 'single' or 'double'")
+        .def_readwrite("convert_ids", &ParticleHeader::convert_ids,
+            "whether particle ids need conversion (Version_Two_Dot_One+)")
+        .def_readwrite("dim", &ParticleHeader::dim,
+            "AMREX_SPACEDIM the file was written with")
+        .def_readwrite("num_real", &ParticleHeader::num_real,
+            "number of real components (pure SoA: excludes the positions)")
+        .def_readwrite("real_comp_names", &ParticleHeader::real_comp_names,
+            "names of the real components (len == num_real)")
+        .def_readwrite("num_int", &ParticleHeader::num_int,
+            "number of integer components")
+        .def_readwrite("int_comp_names", &ParticleHeader::int_comp_names,
+            "names of the integer components (len == num_int)")
+        .def_readwrite("is_checkpoint", &ParticleHeader::is_checkpoint,
+            "True if the file is a checkpoint, False for a plotfile")
+        .def_readwrite("num_particles", &ParticleHeader::num_particles,
+            "total number of particles in the file")
+        .def_readwrite("next_id", &ParticleHeader::next_id,
+            "the next particle id to hand out")
+        .def_readwrite("finest_level", &ParticleHeader::finest_level,
+            "finest level present in the file")
+
+        .def("__repr__",
+            [](ParticleHeader const & h) {
+                return "<amrex.ParticleHeader: " +
+                    std::to_string(h.num_particles) + " particles, " +
+                    std::to_string(h.num_real) + " real + " +
+                    std::to_string(h.num_int) + " int comps, " +
+                    (h.is_checkpoint ? "checkpoint" : "plotfile") + ">";
+            })
+        ;
+}

--- a/src/amrex/extensions/ParticleContainer.py
+++ b/src/amrex/extensions/ParticleContainer.py
@@ -171,6 +171,82 @@ def pc_to_df(self, local=True, comm=None, root_rank=0):
     return df
 
 
+def read_particles(
+    amr, plotfile, particle_dir="particles", communicate=True, container=None
+):
+    """Read AMReX particle data from a plotfile or checkpoint.
+
+    The on-disk layout (number and names of the real/int components, the
+    precision and whether the file is a checkpoint) is discovered via
+    :py:class:`amrex.ParticleHeader`, which uses the same AMReX C++ header reader
+    as ``ParticleContainer::Restart``. A polymorphic, pure Struct-of-Arrays
+    ParticleContainer is then configured with matching runtime components and
+    restarted from the file - so no prior knowledge of the container's
+    compile-time layout is required.
+
+    Parameters
+    ----------
+    amr : module
+        The dimension-specific pyAMReX module (e.g. ``amrex.space3d``).
+    plotfile : str
+        Path to the plotfile / checkpoint directory.
+    particle_dir : str, optional
+        Name of the particle sub-directory inside ``plotfile``
+        (default: ``"particles"``).
+    communicate : bool, optional
+        Whether the added runtime components participate in redistribution
+        (default: ``True``).
+    container : ParticleContainer, optional
+        An existing, geometry-defined container to restart into. If ``None``
+        (default), the geometry is recovered from the plotfile's
+        :py:class:`amrex.PlotFileData` and a fresh polymorphic pure-SoA
+        container is created.
+
+    Returns
+    -------
+    ParticleContainer
+        The populated particle container. Iterate the data via, e.g.,
+        ``for pti in pc.iterator(level=0): soa = pti.soa()``.
+    """
+    header = amr.ParticleHeader.read(plotfile, particle_dir)
+
+    pc = container
+    if pc is None:
+        # recover the AMR geometry from the plotfile metadata
+        plt = amr.PlotFileData(plotfile)
+        finest = plt.finestLevel()
+        prob_domain = plt.probDomain(0)
+        domain_box = amr.Box(prob_domain.small_end, prob_domain.big_end)
+        real_box = amr.RealBox(plt.probLo(), plt.probHi())
+        geom = amr.Geometry(
+            domain_box, real_box, plt.coordSys(), [0] * amr.Config.spacedim
+        )
+
+        pc_type_name = f"ParticleContainer_pureSoA_{amr.Config.spacedim}_0_polymorphic"
+        try:
+            pc_type = getattr(amr, pc_type_name)
+        except AttributeError as e:
+            raise AttributeError(
+                f"pyAMReX was built without the pure-SoA container '{pc_type_name}'."
+            ) from e
+        pc = pc_type(geom, plt.DistributionMap(finest), plt.boxArray(finest))
+        # the polymorphic allocator needs an arena before any tile allocation
+        pc.arena = amr.The_Arena()
+
+    # configure the runtime SoA components to match the on-disk layout. For pure
+    # SoA particles the AMREX_SPACEDIM positions are compile-time components and
+    # header.{real,int}_comp_names list exactly the runtime components to add.
+    for name in header.real_comp_names:
+        if not pc.has_real_comp(name):
+            pc.add_real_comp(name, communicate)
+    for name in header.int_comp_names:
+        if not pc.has_int_comp(name):
+            pc.add_int_comp(name, communicate)
+
+    pc.restart_checkpoint(plotfile, particle_dir, header.is_checkpoint)
+    return pc
+
+
 def register_ParticleContainer_extension(amr):
     """ParticleContainer helper methods"""
     import inspect

--- a/src/amrex/extensions/ParticleContainer.py
+++ b/src/amrex/extensions/ParticleContainer.py
@@ -6,6 +6,7 @@ Authors: Axel Huebl
 License: BSD-3-Clause-LBNL
 """
 
+import os
 import warnings
 
 from .Iterator import getitem, next
@@ -199,22 +200,63 @@ def read_particles(
     container : ParticleContainer, optional
         An existing, geometry-defined container to restart into. If ``None``
         (default), the geometry is recovered from the plotfile's
-        :py:class:`amrex.PlotFileData` and a fresh polymorphic pure-SoA
-        container is created.
+        :py:class:`amrex.PlotFileData` and a fresh polymorphic pure-SoA,
+        single-level container is created. Particles from all levels in the
+        file are read; in the auto-created container they are all placed on
+        level 0 (positions are preserved, the MR level assignment is not).
+        Since plotfiles do not record periodicity, the auto-created geometry
+        is non-periodic. Application *checkpoints* store their geometry in an
+        application-specific format, so reading those requires passing a
+        ``container``.
 
     Returns
     -------
     ParticleContainer
         The populated particle container. Iterate the data via, e.g.,
         ``for pti in pc.iterator(level=0): soa = pti.soa()``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If there is no particle ``Header`` under ``plotfile/particle_dir``, or
+        if ``container`` is ``None`` and there is no top-level plotfile
+        ``Header`` to recover the AMR geometry from.
+    ValueError
+        If ``container`` is ``None`` and ``plotfile`` is an application
+        checkpoint, whose top-level ``Header`` does not describe the geometry.
     """
+    particle_header = os.path.join(plotfile, particle_dir, "Header")
+    if not os.path.isfile(particle_header):
+        raise FileNotFoundError(
+            f"read_particles: no particle Header found at '{particle_header}'. "
+            f"Check that '{plotfile}' is an AMReX plotfile/checkpoint directory "
+            f"and that it contains particle output under '{particle_dir}/'."
+        )
     header = amr.ParticleHeader.read(plotfile, particle_dir)
 
     pc = container
     if pc is None:
-        # recover the AMR geometry from the plotfile metadata
+        # recover the AMR geometry from the plotfile metadata. Conforming
+        # particle plotfiles always contain a top-level plotfile Header: AMReX
+        # writes a dummy MultiFab for pure-particle outputs to ensure that.
+        plotfile_header = os.path.join(plotfile, "Header")
+        if not os.path.isfile(plotfile_header):
+            raise FileNotFoundError(
+                f"read_particles: no plotfile Header found at "
+                f"'{plotfile_header}', so the AMR geometry cannot be "
+                "recovered. To read anyway, pass an existing, geometry-defined "
+                "'container'."
+            )
+        with open(plotfile_header) as f:
+            first_line = f.readline().strip()
+        if first_line.startswith("CheckPointVersion"):
+            raise ValueError(
+                f"read_particles: '{plotfile}' is an application checkpoint, "
+                "not a plotfile; its top-level Header does not describe the "
+                "AMR geometry. Pass an existing, geometry-defined 'container' "
+                "to read into instead."
+            )
         plt = amr.PlotFileData(plotfile)
-        finest = plt.finestLevel()
         prob_domain = plt.probDomain(0)
         domain_box = amr.Box(prob_domain.small_end, prob_domain.big_end)
         real_box = amr.RealBox(plt.probLo(), plt.probHi())
@@ -229,7 +271,10 @@ def read_particles(
             raise AttributeError(
                 f"pyAMReX was built without the pure-SoA container '{pc_type_name}'."
             ) from e
-        pc = pc_type(geom, plt.DistributionMap(finest), plt.boxArray(finest))
+        # a single-level container defined on the coarsest level: Restart reads
+        # particles from every level in the file and Redistribute() then places
+        # them all on level 0
+        pc = pc_type(geom, plt.DistributionMap(0), plt.boxArray(0))
         # the polymorphic allocator needs an arena before any tile allocation
         pc.arena = amr.The_Arena()
 

--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -48,3 +48,18 @@ register_SmallMatrix_extension(amrex_1d_pybind)
 register_SoA_extension(amrex_1d_pybind)
 register_AoS_extension(amrex_1d_pybind)
 register_ParticleContainer_extension(amrex_1d_pybind)
+
+
+from ..extensions.ParticleContainer import read_particles as _read_particles
+
+
+def read_particles(
+    plotfile, particle_dir="particles", communicate=True, container=None
+):
+    """Read AMReX particle data from a plotfile/checkpoint into a container.
+
+    See :py:func:`amrex.extensions.ParticleContainer.read_particles` for details.
+    """
+    return _read_particles(
+        amrex_1d_pybind, plotfile, particle_dir, communicate, container
+    )

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -48,3 +48,18 @@ register_SmallMatrix_extension(amrex_2d_pybind)
 register_SoA_extension(amrex_2d_pybind)
 register_AoS_extension(amrex_2d_pybind)
 register_ParticleContainer_extension(amrex_2d_pybind)
+
+
+from ..extensions.ParticleContainer import read_particles as _read_particles
+
+
+def read_particles(
+    plotfile, particle_dir="particles", communicate=True, container=None
+):
+    """Read AMReX particle data from a plotfile/checkpoint into a container.
+
+    See :py:func:`amrex.extensions.ParticleContainer.read_particles` for details.
+    """
+    return _read_particles(
+        amrex_2d_pybind, plotfile, particle_dir, communicate, container
+    )

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -48,3 +48,18 @@ register_SmallMatrix_extension(amrex_3d_pybind)
 register_SoA_extension(amrex_3d_pybind)
 register_AoS_extension(amrex_3d_pybind)
 register_ParticleContainer_extension(amrex_3d_pybind)
+
+
+from ..extensions.ParticleContainer import read_particles as _read_particles
+
+
+def read_particles(
+    plotfile, particle_dir="particles", communicate=True, container=None
+):
+    """Read AMReX particle data from a plotfile/checkpoint into a container.
+
+    See :py:func:`amrex.extensions.ParticleContainer.read_particles` for details.
+    """
+    return _read_particles(
+        amrex_3d_pybind, plotfile, particle_dir, communicate, container
+    )

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -44,6 +44,7 @@ void init_ParallelDescriptor(py::module &);
 void init_ParGDB(py::module &);
 void init_ParmParse(py::module &);
 void init_ParticleContainer(py::module &);
+void init_ParticleHeader(py::module &);
 void init_Periodicity(py::module &);
 void init_PhysBCFunct(py::module &);
 void init_PlotFileUtil(py::module &);
@@ -158,10 +159,12 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     // containers (they reference it in member signatures), while its member
     // functions are added after ParGDB (get_par_gdb returns an AmrParGDB)
     init_TagBox(m);
+
     init_AmrMesh(m);
     init_AmrCore_class(m);      // after AmrMesh (its pybind base)
     init_ParGDB(m);             // after the AmrCore class declaration
     init_ParticleContainer(m);  // after ParGDB (constructible from it)
+    init_ParticleHeader(m);
     init_AmrCore(m);            // after ParGDB (AmrParGDB in signatures)
 
 #ifdef AMREX_USE_MPI

--- a/tests/test_plotfiledata.py
+++ b/tests/test_plotfiledata.py
@@ -70,3 +70,37 @@ def test_plotfiledata_read():
             nboxes += 1
 
         assert nboxes == 1
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_plotfiledata_read_docs():
+    """Read a plotfile: compact example included in the manual."""
+    plt_filename = "test_plt00200_docs"
+    write_test_plotfile(plt_filename)
+
+    # Manual: Read Plotfile Mesh START
+    plt = amr.PlotFileData(plt_filename)
+
+    # meta-data: AMR levels, domain extent and cell sizes
+    finest_level = plt.finestLevel()
+    prob_lo = plt.probLo()  # physical coordinates of the lower domain corner
+    prob_hi = plt.probHi()  # ... and the upper domain corner
+    cell_size = plt.cellSize(0)  # cell sizes (dx, dy, dz) on level 0
+    var_names = plt.varNames()  # stored field components, e.g., ["density"]
+
+    # read a field component on a level as a MultiFab ...
+    mf_density = plt.get(0, "density")
+
+    # ... and access its blocks as numpy/cupy arrays (zero-copy views)
+    total = 0.0
+    for mfi in mf_density:
+        marr_xp = mf_density.array(mfi).to_xp()
+        total += marr_xp.sum()  # compute, plot, analyze, ...
+    # Manual: Read Plotfile Mesh END
+
+    assert finest_level == 0
+    assert prob_lo == [-0.5, -0.5, -0.5]
+    assert prob_hi == [0.5, 0.5, 0.5]
+    assert cell_size == [1.0 / 32.0] * 3
+    assert var_names == amr.Vector_string(["density"])
+    assert np.isclose(total, np.pi * 32**3)

--- a/tests/test_readparticles.py
+++ b/tests/test_readparticles.py
@@ -67,7 +67,16 @@ def test_read_particles_header():
     n_part = 15
     real_names, int_names = write_test_plotfile(plt_file_name, n_part)
 
+    # Manual: Read Particle Header START
+    # inspect the on-disk particle component layout, without reading the data
     header = amr.ParticleHeader.read(plt_file_name, "particles")
+
+    print(header.real_comp_names)  # e.g., ["w"]
+    print(header.int_comp_names)  # e.g., ["i1", "i2"]
+    print(header.num_particles)  # e.g., 15
+    print(header.is_checkpoint)  # False for plotfiles, True for checkpoints
+    # Manual: Read Particle Header END
+
     assert header.dim == 3
     # pure SoA: the AMREX_SPACEDIM positions are implicit, so only the runtime
     # real component "w" is counted here
@@ -88,7 +97,22 @@ def test_read_particles_roundtrip():
     n_part = 15
     real_names, int_names = write_test_plotfile(plt_file_name, n_part)
 
+    # Manual: Read Plotfile Particles START
+    # read all particles from <plotfile>/particles/ into a new container;
+    # the component names and layout are discovered from the file
     pc = amr.read_particles(plt_file_name, "particles")
+
+    # access the data per tile, e.g., as zero-copy numpy/cupy arrays ...
+    w_idx = pc.get_real_comp_index("w")  # runtime component from the file
+    for lvl in range(pc.finest_level + 1):
+        for pti in pc.iterator(level=lvl):
+            soa = pti.soa()
+            x = soa.get_real_data(0).to_xp()  # position x
+            w = soa.get_real_data(w_idx).to_xp()  # runtime component "w"
+
+    # ... or copy all (MPI rank-local) particles into a pandas DataFrame
+    # df = pc.to_df()
+    # Manual: Read Plotfile Particles END
 
     # the runtime layout was reconstructed from the file
     for name in real_names:
@@ -98,13 +122,8 @@ def test_read_particles_roundtrip():
     assert pc.total_number_of_particles() == n_part
 
     # and the runtime component values round-tripped
-    w_idx = pc.get_real_comp_index("w")
-    for lvl in range(pc.finest_level + 1):
-        for pti in pc.iterator(level=lvl):
-            soa = pti.soa()
-            np.testing.assert_allclose(
-                soa.get_real_data(w_idx).to_numpy(copy=False), 1.2345
-            )
+    assert x.size == n_part
+    np.testing.assert_allclose(w, 1.2345)
 
     shutil.rmtree(plt_file_name)
 
@@ -159,9 +178,13 @@ def test_read_particles_particle_only_output():
         amr.read_particles(plt_file_name, "particles")
 
     # reading into an explicitly geometry-defined container works
+    # Manual: Read Particles Existing Container START
+    # define the geometry in the application, e.g., for a checkpoint restart,
+    # then fill the container from the file
     pc_read = amr.ParticleContainer_pureSoA_3_0_polymorphic(geom, dm, ba)
     pc_read.arena = amr.The_Arena()
     pc_read = amr.read_particles(plt_file_name, "particles", container=pc_read)
+    # Manual: Read Particles Existing Container END
     assert pc_read.total_number_of_particles() == n_part
 
     shutil.rmtree(plt_file_name)

--- a/tests/test_readparticles.py
+++ b/tests/test_readparticles.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 import shutil
 
 import numpy as np
@@ -104,5 +105,181 @@ def test_read_particles_roundtrip():
             np.testing.assert_allclose(
                 soa.get_real_data(w_idx).to_numpy(copy=False), 1.2345
             )
+
+    shutil.rmtree(plt_file_name)
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_read_particles_missing_header():
+    """Wrong paths raise a catchable Python exception instead of aborting."""
+    plt_file_name = "plt_read_missing"
+    write_test_plotfile(plt_file_name, 5)
+
+    # wrong particle sub-directory
+    with pytest.raises(FileNotFoundError, match="particle Header"):
+        amr.read_particles(plt_file_name, "no_such_dir")
+
+    # non-existing plotfile directory
+    with pytest.raises(FileNotFoundError, match="particle Header"):
+        amr.read_particles("no_such_plotfile", "particles")
+
+    shutil.rmtree(plt_file_name)
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_read_particles_particle_only_output():
+    """A bare particle output without a top-level plotfile Header raises with
+    container=None and reads fine into a user-provided container.
+
+    Note: conforming AMReX particle plotfiles always include a top-level
+    plotfile Header (applications write a dummy MultiFab for pure-particle
+    outputs to ensure that), so this layout is off-spec - but it must fail
+    with a clear Python exception, not an amrex::Abort.
+    """
+    plt_file_name = "plt_read_ponly"
+    n_part = 10
+
+    domain_box = amr.Box([0, 0, 0], [31, 31, 31])
+    real_box = amr.RealBox([-0.5, -0.5, -0.5], [0.5, 0.5, 0.5])
+    geom = amr.Geometry(domain_box, real_box, amr.CoordSys.cartesian, [0, 0, 0])
+    ba = amr.BoxArray(domain_box)
+    dm = amr.DistributionMapping(ba, 1)
+
+    pc = amr.ParticleContainer_pureSoA_3_0_polymorphic(geom, dm, ba)
+    pc.arena = amr.The_Arena()
+    myt = amr.ParticleInitType_pureSoA_3_0()
+    myt.real_array_data = [0.0, 0.0, 0.0]  # x, y, z (overwritten by init_random)
+    myt.int_array_data = []
+    pc.init_random(n_part, 1, myt, False, real_box)
+    pc.write_plotfile(
+        plt_file_name, "particles", amr.Vector_string([]), amr.Vector_string([])
+    )
+
+    with pytest.raises(FileNotFoundError, match="plotfile Header"):
+        amr.read_particles(plt_file_name, "particles")
+
+    # reading into an explicitly geometry-defined container works
+    pc_read = amr.ParticleContainer_pureSoA_3_0_polymorphic(geom, dm, ba)
+    pc_read.arena = amr.The_Arena()
+    pc_read = amr.read_particles(plt_file_name, "particles", container=pc_read)
+    assert pc_read.total_number_of_particles() == n_part
+
+    shutil.rmtree(plt_file_name)
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_read_particles_checkpoint_needs_container():
+    """An application checkpoint's top-level Header is not in plotfile format:
+    geometry recovery must fail with a clear error pointing to 'container'."""
+    plt_file_name = "plt_read_chk_src"
+    chk_file_name = "chk_read_fake"
+    write_test_plotfile(plt_file_name, 5)
+
+    # fake an application checkpoint: valid particle data next to a
+    # checkpoint-format top-level Header (as written by amrex::Amr::checkPoint)
+    os.makedirs(chk_file_name)
+    shutil.copytree(
+        os.path.join(plt_file_name, "particles"),
+        os.path.join(chk_file_name, "particles"),
+    )
+    with open(os.path.join(chk_file_name, "Header"), "w") as f:
+        f.write("CheckPointVersion_1.0\n")
+
+    with pytest.raises(ValueError, match="container"):
+        amr.read_particles(chk_file_name, "particles")
+
+    shutil.rmtree(plt_file_name)
+    shutil.rmtree(chk_file_name)
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_read_particles_multilevel():
+    """Particles from a multi-level plotfile are read back completely: the
+    auto-created container is single-level and gathers them all on level 0."""
+    plt_file_name = "plt_read_ml"
+    n_part = 24
+
+    # two-level AmrCore hierarchy over [-0.5, 0.5]^3 with 16^3 coarse cells;
+    # only the upper-x half of the domain is refined, so particles end up
+    # distributed over both levels and the fine-level BoxArray covers neither
+    # the whole domain nor the coarse index space
+    class HalfRefinedCore(amr.AmrCore):
+        def make_new_level_from_scratch(self, lev, time, ba, dm):
+            pass
+
+        def make_new_level_from_coarse(self, lev, time, ba, dm):
+            pass
+
+        def remake_level(self, lev, time, ba, dm):
+            pass
+
+        def clear_level(self, lev):
+            pass
+
+        def error_est(self, lev, tags, time, ngrow):
+            tags.set_val(amr.TagBox.SET, amr.Box([8, 0, 0], [15, 15, 15]))
+
+    real_box = amr.RealBox([-0.5, -0.5, -0.5], [0.5, 0.5, 0.5])
+    core = HalfRefinedCore(
+        real_box,
+        1,
+        amr.Vector_int([16, 16, 16]),
+        0,  # cartesian
+        amr.Vector_IntVect([amr.IntVect(2)]),
+        [0, 0, 0],
+    )
+    core.init_from_scratch(0.0)
+    assert core.finest_level == 1
+    gdb = core.get_par_gdb()
+
+    # matching two-level mesh plotfile, so the geometry can be recovered
+    mfs = []
+    for lev in range(2):
+        mf = amr.MultiFab(gdb.box_array(lev), gdb.dist_map(lev), 1, 0)
+        mf.set_val(np.pi)
+        mfs.append(mf)
+    amr.write_multi_level_plotfile(
+        plt_file_name,
+        mfs,
+        ["density"],
+        [core.geom(0), core.geom(1)],
+        1.0,
+        [200, 200],
+        [amr.IntVect(2)],
+    )
+
+    # multi-level pure-SoA particle container with a runtime component
+    pc = amr.ParticleContainer_pureSoA_3_0_polymorphic(gdb)
+    pc.arena = amr.The_Arena()
+    myt = amr.ParticleInitType_pureSoA_3_0()
+    myt.real_array_data = [0.0, 0.0, 0.0]  # x, y, z (overwritten by init_random)
+    myt.int_array_data = []
+    pc.init_random(n_part, 1, myt, False, real_box)
+    pc.add_real_comp("w", True)
+    for lvl in range(pc.finest_level + 1):
+        for pti in pc.iterator(level=lvl):
+            pti.soa().get_real_data(3).assign(1.2345)  # "w": after x,y,z
+    pc.redistribute()
+
+    # the particle file must exercise both levels
+    n_lev = [pc.number_of_particles_at_level(lvl) for lvl in range(2)]
+    assert n_lev[0] > 0 and n_lev[1] > 0
+    assert sum(n_lev) == n_part
+
+    pc.write_plotfile(
+        plt_file_name, "particles", amr.Vector_string(["w"]), amr.Vector_string([])
+    )
+    header = amr.ParticleHeader.read(plt_file_name, "particles")
+    assert header.finest_level == 1
+
+    pc_read = amr.read_particles(plt_file_name, "particles")
+    assert pc_read.finest_level == 0
+    assert pc_read.total_number_of_particles() == n_part
+
+    w_idx = pc_read.get_real_comp_index("w")
+    for pti in pc_read.iterator(level=0):
+        np.testing.assert_allclose(
+            pti.soa().get_real_data(w_idx).to_numpy(copy=False), 1.2345
+        )
 
     shutil.rmtree(plt_file_name)

--- a/tests/test_readparticles.py
+++ b/tests/test_readparticles.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+import shutil
+
+import numpy as np
+import pytest
+
+import amrex.space3d as amr
+
+
+def write_test_plotfile(filename, n_part):
+    """Write a single-level plotfile with a mesh and a pure-SoA particle
+    container, so it can be read back via ``amr.read_particles``.
+
+    Returns the names of the runtime real/int components that were added.
+    """
+    domain_box = amr.Box([0, 0, 0], [31, 31, 31])
+    real_box = amr.RealBox([-0.5, -0.5, -0.5], [0.5, 0.5, 0.5])
+    geom = amr.Geometry(domain_box, real_box, amr.CoordSys.cartesian, [0, 0, 0])
+
+    ba = amr.BoxArray(domain_box)
+    dm = amr.DistributionMapping(ba, 1)
+
+    # mesh data, so PlotFileData can recover the geometry on read
+    mf = amr.MultiFab(ba, dm, 1, 0)
+    mf.set_val(np.pi)
+    amr.write_single_level_plotfile(
+        filename, mf, amr.Vector_string(["density"]), geom, 1.0, 200
+    )
+
+    # pure-SoA particle container with runtime components
+    pc = amr.ParticleContainer_pureSoA_3_0_polymorphic(geom, dm, ba)
+    pc.arena = amr.The_Arena()
+    myt = amr.ParticleInitType_pureSoA_3_0()
+    myt.real_array_data = [0.0, 0.0, 0.0]  # x, y, z (overwritten by init_random)
+    myt.int_array_data = []
+    pc.init_random(n_part, 1, myt, False, real_box)
+
+    # add 1 runtime real + 2 runtime int components and fill them
+    pc.add_real_comp("w", True)
+    pc.add_int_comp("i1", True)
+    pc.add_int_comp("i2", True)
+    for lvl in range(pc.finest_level + 1):
+        for pti in pc.iterator(level=lvl):
+            soa = pti.soa()
+            soa.get_real_data(3).assign(1.2345)  # "w": after x,y,z (idx 0,1,2)
+            soa.get_int_data(0).assign(42)  # "i1"
+            soa.get_int_data(1).assign(33)  # "i2"
+    pc.redistribute()
+
+    real_names = ["w"]
+    int_names = ["i1", "i2"]
+    pc.write_plotfile(
+        filename,
+        "particles",
+        amr.Vector_string(real_names),
+        amr.Vector_string(int_names),
+    )
+    return real_names, int_names
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_read_particles_header():
+    """ParticleHeader discovers the on-disk layout without a matching container."""
+    plt_file_name = "plt_read_hdr"
+    n_part = 15
+    real_names, int_names = write_test_plotfile(plt_file_name, n_part)
+
+    header = amr.ParticleHeader.read(plt_file_name, "particles")
+    assert header.dim == 3
+    # pure SoA: the AMREX_SPACEDIM positions are implicit, so only the runtime
+    # real component "w" is counted here
+    assert header.num_real == len(real_names)
+    assert list(header.real_comp_names) == real_names
+    assert header.num_int == len(int_names)
+    assert list(header.int_comp_names) == int_names
+    assert header.num_particles == n_part
+
+    shutil.rmtree(plt_file_name)
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_read_particles_roundtrip():
+    """amr.read_particles reconstructs a container from a plotfile with no prior
+    knowledge of its compile-time layout."""
+    plt_file_name = "plt_read_rt"
+    n_part = 15
+    real_names, int_names = write_test_plotfile(plt_file_name, n_part)
+
+    pc = amr.read_particles(plt_file_name, "particles")
+
+    # the runtime layout was reconstructed from the file
+    for name in real_names:
+        assert pc.has_real_comp(name)
+    for name in int_names:
+        assert pc.has_int_comp(name)
+    assert pc.total_number_of_particles() == n_part
+
+    # and the runtime component values round-tripped
+    w_idx = pc.get_real_comp_index("w")
+    for lvl in range(pc.finest_level + 1):
+        for pti in pc.iterator(level=lvl):
+            soa = pti.soa()
+            np.testing.assert_allclose(
+                soa.get_real_data(w_idx).to_numpy(copy=False), 1.2345
+            )
+
+    shutil.rmtree(plt_file_name)


### PR DESCRIPTION
Add methods to read into a general polymorpic, all-runtime PC from plotfiles (output or checkpoint).
Related to https://github.com/AMReX-Codes/pyamrex/discussions/488

- [x] review draft
- [x] depends on https://github.com/AMReX-Codes/amrex/pull/5476
- [x] add a user-facing workflow page: ["How to read back plotfiles"](https://pyamrex--581.org.readthedocs.build/en/581/usage/workflows.html)