### PR TITLE
AMRCore et al.

### DIFF
--- a/docs/source/usage/api.rst
+++ b/docs/source/usage/api.rst
@@ -205,8 +205,9 @@ AmrCore
 Python subclasses implement the AMR callbacks with pyAMReX snake-case names:
 ``make_new_level_from_scratch``, ``make_new_level_from_coarse``,
 ``remake_level``, ``clear_level`` and ``error_est``.  The ``error_est``
-callback receives a ``TagBoxArray`` and marks cells for refinement with
-``tags.set_val(amr.TagBox.SET, ...)``.
+callback receives a mutable ``TagBoxArray`` for the level being tagged.  The
+tag array is a callback-scoped, non-owning view; mark cells for refinement with
+``tags.set_val(amr.TagBox.SET, ...)`` and do not store it for later use.
 
 A particle container can be connected to an ``AmrCore`` hierarchy through the
 particle metadata broker returned by ``core.get_par_gdb()``.

--- a/docs/source/usage/api.rst
+++ b/docs/source/usage/api.rst
@@ -202,11 +202,62 @@ Utility
 AmrCore
 -------
 
+Python subclasses implement the AMR callbacks with pyAMReX snake-case names:
+``make_new_level_from_scratch``, ``make_new_level_from_coarse``,
+``remake_level``, ``clear_level`` and ``error_est``.  The ``error_est``
+callback receives a ``TagBoxArray`` and marks cells for refinement with
+``tags.set_val(amr.TagBox.SET, ...)``.
+
+A particle container can be connected to an ``AmrCore`` hierarchy through the
+particle metadata broker returned by ``core.get_par_gdb()``.
+
+.. code-block:: python
+
+   class MyCore(amr.AmrCore):
+       def make_new_level_from_scratch(self, lev, time, ba, dm):
+           pass
+
+       def make_new_level_from_coarse(self, lev, time, ba, dm):
+           pass
+
+       def remake_level(self, lev, time, ba, dm):
+           pass
+
+       def clear_level(self, lev):
+           pass
+
+       def error_est(self, lev, tags, time, ngrow):
+           tags.set_val(amr.TagBox.SET)
+
+   core = MyCore(rb, 1, n_cell, 0, ref_ratios, is_periodic)
+   core.init_from_scratch(0.0)
+   particles = amr.ParticleContainer_2_1_3_1_default(core.get_par_gdb())
+
 .. autoclass:: amrex.space3d.AmrInfo
    :members:
    :undoc-members:
 
 .. autoclass:: amrex.space3d.AmrMesh
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.AmrCore
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.TagBox
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.TagBoxArray
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.ParGDBBase
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.AmrParGDB
    :members:
    :undoc-members:
 

--- a/src/AmrCore/AmrCore.cpp
+++ b/src/AmrCore/AmrCore.cpp
@@ -1,0 +1,134 @@
+/* Copyright 2024-2025 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_AmrCore.H>
+#include <AMReX_AmrMesh.H>
+#include <AMReX_Array.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_RealBox.H>
+#include <AMReX_TagBox.H>
+#include <AMReX_Vector.H>
+
+#ifdef AMREX_PARTICLES
+#   include <AMReX_AmrParGDB.H>
+#endif
+
+#include <sstream>
+
+
+namespace
+{
+    /** Trampoline class to allow Python subclasses of amrex::AmrCore.
+     *
+     * amrex::AmrCore declares five pure virtual member functions that a
+     * concrete class must implement. This trampoline forwards each of them to
+     * a Python override (if present). Codes such as ImpactX and WarpX subclass
+     * AmrCore in C++; this enables the same pattern from Python.
+     *
+     * See pybind11 docs: "Overriding virtual functions in Python".
+     *
+     * Note: pyAMReX uses the classic std::unique_ptr holder (not smart_holder),
+     * so this trampoline must NOT inherit py::trampoline_self_life_support. The
+     * AmrCore instance is owned by the Python subclass object; lifetime of the
+     * dependent AmrParGDB / ParticleContainer is handled via py::keep_alive.
+     */
+    struct PyAmrCore : public amrex::AmrCore
+    {
+        using amrex::AmrCore::AmrCore;  // inherit constructors
+
+        // We use the _NAME variants so Python subclasses override using
+        // snake_case method names, consistent with pyAMReX conventions.
+        void ErrorEst (
+            int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow
+        ) override
+        {
+            PYBIND11_OVERRIDE_PURE_NAME(
+                void, amrex::AmrCore, "error_est", ErrorEst,
+                lev, tags, time, ngrow);
+        }
+
+        void MakeNewLevelFromScratch (
+            int lev, amrex::Real time,
+            const amrex::BoxArray& ba, const amrex::DistributionMapping& dm
+        ) override
+        {
+            PYBIND11_OVERRIDE_PURE_NAME(
+                void, amrex::AmrCore, "make_new_level_from_scratch",
+                MakeNewLevelFromScratch, lev, time, ba, dm);
+        }
+
+        void MakeNewLevelFromCoarse (
+            int lev, amrex::Real time,
+            const amrex::BoxArray& ba, const amrex::DistributionMapping& dm
+        ) override
+        {
+            PYBIND11_OVERRIDE_PURE_NAME(
+                void, amrex::AmrCore, "make_new_level_from_coarse",
+                MakeNewLevelFromCoarse, lev, time, ba, dm);
+        }
+
+        void RemakeLevel (
+            int lev, amrex::Real time,
+            const amrex::BoxArray& ba, const amrex::DistributionMapping& dm
+        ) override
+        {
+            PYBIND11_OVERRIDE_PURE_NAME(
+                void, amrex::AmrCore, "remake_level", RemakeLevel,
+                lev, time, ba, dm);
+        }
+
+        void ClearLevel (int lev) override
+        {
+            PYBIND11_OVERRIDE_PURE_NAME(
+                void, amrex::AmrCore, "clear_level", ClearLevel, lev);
+        }
+    };
+}
+
+
+void init_AmrCore (py::module& m)
+{
+    using namespace amrex;
+
+    py::class_< AmrCore, AmrMesh, PyAmrCore >(m, "AmrCore")
+        .def("__repr__",
+            [](AmrCore const & amr_core) {
+                std::stringstream s;
+                s << amr_core.finestLevel();
+                return "<amrex.AmrCore with finest level '" + s.str() + "'>";
+            }
+        )
+
+        .def(py::init< >())
+        .def(py::init<
+                const RealBox&,
+                int,
+                const Vector<int>&,
+                int,
+                Vector<IntVect> const&,
+                Array<int, AMREX_SPACEDIM> const&
+             >(),
+             py::arg("rb"), py::arg("max_level_in"), py::arg("n_cell_in"),
+             py::arg("coord"), py::arg("ref_ratios"), py::arg("is_per"))
+        .def(py::init< Geometry const&, AmrInfo const& >(),
+             py::arg("level_0_geom"), py::arg("amr_info"))
+
+        .def("init_from_scratch", &AmrCore::InitFromScratch, py::arg("time"))
+        .def("regrid", &AmrCore::regrid,
+             py::arg("lbase"), py::arg("time"), py::arg("initial") = false)
+
+#ifdef AMREX_PARTICLES
+        // The AmrParGDB is owned by the AmrCore (unique_ptr m_gdb). We hand out
+        // a non-owning reference; keep the AmrCore alive while it is used.
+        .def("get_par_gdb", &AmrCore::GetParGDB,
+             py::return_value_policy::reference_internal)
+#endif
+    ;
+}

--- a/src/AmrCore/AmrCore.cpp
+++ b/src/AmrCore/AmrCore.cpp
@@ -52,7 +52,8 @@ namespace
         {
             PYBIND11_OVERRIDE_PURE_NAME(
                 void, amrex::AmrCore, "error_est", ErrorEst,
-                lev, tags, time, ngrow);
+                lev, py::cast(&tags, py::return_value_policy::reference),
+                time, ngrow);
         }
 
         void MakeNewLevelFromScratch (
@@ -119,6 +120,11 @@ Subclasses must implement ``make_new_level_from_scratch``,
 ``make_new_level_from_coarse``, ``remake_level``, ``clear_level`` and
 ``error_est``.  AMReX calls these Python overrides while creating or
 regridding levels.
+
+``error_est(lev, tags, time, ngrow)`` receives a mutable ``TagBoxArray``
+for the level being tagged.  Mark cells with
+``tags.set_val(TagBox.SET, ...)`` and keep the tag array only for the
+duration of the callback.
 )pbdoc");
 }
 

--- a/src/AmrCore/AmrCore.cpp
+++ b/src/AmrCore/AmrCore.cpp
@@ -110,7 +110,16 @@ void init_AmrCore_class (py::module& m)
     using namespace amrex;
 
     py_AmrCore = std::make_unique<
-        py::class_< AmrCore, AmrMesh, PyAmrCore > >(m, "AmrCore");
+        py::class_< AmrCore, AmrMesh, PyAmrCore > >(
+            m, "AmrCore",
+            R"pbdoc(
+Base class for Python AMR applications that manage an AMReX mesh hierarchy.
+
+Subclasses must implement ``make_new_level_from_scratch``,
+``make_new_level_from_coarse``, ``remake_level``, ``clear_level`` and
+``error_est``.  AMReX calls these Python overrides while creating or
+regridding levels.
+)pbdoc");
 }
 
 void init_AmrCore (py::module& /* m */)
@@ -126,7 +135,12 @@ void init_AmrCore (py::module& /* m */)
             }
         )
 
-        .def(py::init< >())
+        .def(py::init< >(),
+             R"pbdoc(
+Construct an empty AMR core.
+
+The mesh metadata is read from AMReX runtime parameters when available.
+)pbdoc")
         .def(py::init<
                 const RealBox&,
                 int,
@@ -136,19 +150,60 @@ void init_AmrCore (py::module& /* m */)
                 Array<int, AMREX_SPACEDIM> const&
              >(),
              py::arg("rb"), py::arg("max_level_in"), py::arg("n_cell_in"),
-             py::arg("coord"), py::arg("ref_ratios"), py::arg("is_per"))
-        .def(py::init< Geometry const&, AmrInfo const& >(),
-             py::arg("level_0_geom"), py::arg("amr_info"))
+             py::arg("coord"), py::arg("ref_ratios"), py::arg("is_per"),
+             R"pbdoc(
+Construct an AMR core from an explicit level-0 problem domain.
 
-        .def("init_from_scratch", &AmrCore::InitFromScratch, py::arg("time"))
+Parameters
+----------
+rb : RealBox
+    Physical problem domain for level 0.
+max_level_in : int
+    Maximum AMR level to create.  Use 0 for a single-level hierarchy.
+n_cell_in : Vector_int
+    Number of level-0 cells in each coordinate direction.
+coord : int
+    AMReX coordinate-system identifier.
+ref_ratios : Vector_IntVect
+    Refinement ratio for each coarse level.  Its length is normally
+    ``max_level_in``.
+is_per : Sequence[int]
+    Periodicity flags for each coordinate direction.
+)pbdoc")
+        .def(py::init< Geometry const&, AmrInfo const& >(),
+             py::arg("level_0_geom"), py::arg("amr_info"),
+             R"pbdoc(
+Construct an AMR core from a level-0 geometry and an ``AmrInfo`` object.
+)pbdoc")
+
+        .def("init_from_scratch", &AmrCore::InitFromScratch, py::arg("time"),
+             R"pbdoc(
+Create the AMR hierarchy from scratch at simulation time ``time``.
+
+This calls the Python overrides that allocate level data and, when
+``max_level`` is greater than 0, calls ``error_est`` to create refined grids.
+)pbdoc")
         .def("regrid", &AmrCore::regrid,
-             py::arg("lbase"), py::arg("time"), py::arg("initial") = false)
+             py::arg("lbase"), py::arg("time"), py::arg("initial") = false,
+             R"pbdoc(
+Rebuild levels finer than ``lbase`` at simulation time ``time``.
+
+``error_est`` is called to tag cells, followed by the level remake/create/clear
+callbacks as needed.
+)pbdoc")
 
 #ifdef AMREX_PARTICLES
         // The AmrParGDB is owned by the AmrCore (unique_ptr m_gdb). We hand out
         // a non-owning reference; keep the AmrCore alive while it is used.
         .def("get_par_gdb", &AmrCore::GetParGDB,
-             py::return_value_policy::reference_internal)
+             py::return_value_policy::reference_internal,
+             R"pbdoc(
+Return the particle geometry/database broker owned by this AMR core.
+
+The returned ``AmrParGDB`` can be passed to particle-container constructors or
+``define`` methods.  It is a non-owning view; the ``AmrCore`` is kept alive by
+the binding while the broker is used from Python.
+)pbdoc")
 #endif
     ;
 

--- a/src/AmrCore/AmrCore.cpp
+++ b/src/AmrCore/AmrCore.cpp
@@ -20,6 +20,7 @@
 #   include <AMReX_AmrParGDB.H>
 #endif
 
+#include <memory>
 #include <sstream>
 
 
@@ -90,14 +91,33 @@ namespace
                 void, amrex::AmrCore, "clear_level", ClearLevel, lev);
         }
     };
+
+    /** Class handle between declaration and method definition.
+     *
+     * The AmrCore type is declared first (init_AmrCore_class) so that types
+     * referencing it in member function signatures (AmrParGDB, the particle
+     * containers) render proper Python type names in their docstrings and
+     * type stubs. The member functions are added later (init_AmrCore), once
+     * the types AmrCore members reference (AmrParGDB) are registered, too.
+     */
+    std::unique_ptr< py::class_< amrex::AmrCore, amrex::AmrMesh, PyAmrCore > >
+        py_AmrCore;
 }
 
 
-void init_AmrCore (py::module& m)
+void init_AmrCore_class (py::module& m)
 {
     using namespace amrex;
 
-    py::class_< AmrCore, AmrMesh, PyAmrCore >(m, "AmrCore")
+    py_AmrCore = std::make_unique<
+        py::class_< AmrCore, AmrMesh, PyAmrCore > >(m, "AmrCore");
+}
+
+void init_AmrCore (py::module& /* m */)
+{
+    using namespace amrex;
+
+    (*py_AmrCore)
         .def("__repr__",
             [](AmrCore const & amr_core) {
                 std::stringstream s;
@@ -131,4 +151,7 @@ void init_AmrCore (py::module& m)
              py::return_value_policy::reference_internal)
 #endif
     ;
+
+    // release the class handle held since init_AmrCore_class
+    py_AmrCore.reset();
 }

--- a/src/AmrCore/AmrMesh.cpp
+++ b/src/AmrCore/AmrMesh.cpp
@@ -76,8 +76,10 @@ void init_AmrMesh(py::module &m)
 
         .def("geom",
              py::overload_cast< int >(&AmrMesh::Geom, py::const_),
-             py::return_value_policy::reference_internal, py::arg("lev"))
+             py::return_value_policy::reference_internal, py::arg("lev"),
+             "Return the Geometry stored for AMR level lev.")
         .def("set_geometry", &AmrMesh::SetGeometry,
-             py::arg("lev"), py::arg("geom_in"))
+             py::arg("lev"), py::arg("geom_in"),
+             "Replace the Geometry stored for AMR level lev.")
     ;
 }

--- a/src/AmrCore/AmrMesh.cpp
+++ b/src/AmrCore/AmrMesh.cpp
@@ -73,5 +73,11 @@ void init_AmrMesh(py::module &m)
         .def_property_readonly("finest_level", &AmrMesh::finestLevel)
         .def("ref_ratio", py::overload_cast< >(&AmrMesh::refRatio, py::const_))
         .def("ref_ratio", py::overload_cast< int >(&AmrMesh::refRatio, py::const_))
+
+        .def("geom",
+             py::overload_cast< int >(&AmrMesh::Geom, py::const_),
+             py::return_value_policy::reference_internal, py::arg("lev"))
+        .def("set_geometry", &AmrMesh::SetGeometry,
+             py::arg("lev"), py::arg("geom_in"))
     ;
 }

--- a/src/AmrCore/CMakeLists.txt
+++ b/src/AmrCore/CMakeLists.txt
@@ -3,5 +3,6 @@ foreach(D IN LISTS AMReX_SPACEDIM)
       PRIVATE
         AmrCore.cpp
         AmrMesh.cpp
+        TagBox.cpp
     )
 endforeach()

--- a/src/AmrCore/CMakeLists.txt
+++ b/src/AmrCore/CMakeLists.txt
@@ -1,6 +1,7 @@
 foreach(D IN LISTS AMReX_SPACEDIM)
     target_sources(pyAMReX_${D}d
       PRIVATE
+        AmrCore.cpp
         AmrMesh.cpp
     )
 endforeach()

--- a/src/AmrCore/TagBox.cpp
+++ b/src/AmrCore/TagBox.cpp
@@ -29,7 +29,14 @@ void init_TagBox (py::module& m)
 {
     using namespace amrex;
 
-    py::class_< TagBox > py_TagBox(m, "TagBox");
+    py::class_< TagBox > py_TagBox(
+        m, "TagBox",
+        R"pbdoc(
+Cell-tag storage used by ``AmrCore.error_est``.
+
+Use ``TagBox.SET`` to request refinement, ``TagBox.CLEAR`` to remove a tag and
+``TagBox.BUF`` for AMReX-generated buffered tags.
+)pbdoc");
 
     py::native_enum< TagBox::TagVal >(py_TagBox, "TagVal", "enum.IntEnum")
         .value("CLEAR", TagBox::TagVal::CLEAR)
@@ -45,7 +52,14 @@ void init_TagBox (py::module& m)
         }
     );
 
-    py::class_< TagBoxArray, FabArrayBase >(m, "TagBoxArray")
+    py::class_< TagBoxArray, FabArrayBase >(
+        m, "TagBoxArray",
+        R"pbdoc(
+Distributed array of ``TagBox`` objects used during AMR error estimation.
+
+Python ``AmrCore.error_est`` overrides receive a ``TagBoxArray`` and mark cells
+with ``set_val(TagBox.SET, ...)``.
+)pbdoc")
         .def("__repr__",
             [](TagBoxArray const& tags) {
                 std::stringstream s;
@@ -55,58 +69,77 @@ void init_TagBox (py::module& m)
         )
 
         .def(py::init< BoxArray const&, DistributionMapping const&, int >(),
-             py::arg("ba"), py::arg("dm"), py::arg("ngrow") = 0)
+             py::arg("ba"), py::arg("dm"), py::arg("ngrow") = 0,
+             "Construct tag storage on ba/dm with an isotropic grow width.")
         .def(py::init< BoxArray const&, DistributionMapping const&, IntVect const& >(),
-             py::arg("ba"), py::arg("dm"), py::arg("ngrow"))
+             py::arg("ba"), py::arg("dm"), py::arg("ngrow"),
+             "Construct tag storage on ba/dm with per-direction grow widths.")
 
-        .def("clear", &TagBoxArray::clear)
-        .def("ok", &TagBoxArray::ok)
+        .def("clear", &TagBoxArray::clear,
+             "Release all tag data and metadata.")
+        .def("ok", &TagBoxArray::ok,
+             "Return True if the tag array is internally consistent.")
         .def("__len__", &TagBoxArray::size)
-        .def_property_readonly("size", &TagBoxArray::size)
-        .def_property_readonly("local_size", &TagBoxArray::local_size)
-        .def_property_readonly("n_grow_vect", &TagBoxArray::nGrowVect)
+        .def_property_readonly("size", &TagBoxArray::size,
+             "Number of boxes in the global tag layout.")
+        .def_property_readonly("local_size", &TagBoxArray::local_size,
+             "Number of tag boxes owned by this MPI rank.")
+        .def_property_readonly("n_grow_vect", &TagBoxArray::nGrowVect,
+             "Grow width of the tag storage in each coordinate direction.")
         .def_property_readonly("box_array",
              [](TagBoxArray const& tags) { return tags.boxArray(); },
-             py::return_value_policy::reference_internal)
+             py::return_value_policy::reference_internal,
+             "BoxArray defining the valid regions for this tag array.")
         .def_property_readonly("dist_map",
              [](TagBoxArray const& tags) { return tags.DistributionMap(); },
-             py::return_value_policy::reference_internal)
+             py::return_value_policy::reference_internal,
+             "DistributionMapping defining ownership of this tag array.")
 
         .def("set_val",
              [](TagBoxArray& tags, TagBox::TagVal val) {
                  tags.setVal(tag_value(val));
              },
-             py::arg("val"))
+             py::arg("val"),
+             "Set all valid and grow cells in the tag array to val.")
         .def("set_val",
              [](TagBoxArray& tags, TagBox::TagVal val, int nghost) {
                  tags.setVal(tag_value(val), nghost);
              },
-             py::arg("val"), py::arg("nghost"))
+             py::arg("val"), py::arg("nghost"),
+             "Set all valid cells plus nghost grow cells to val.")
         .def("set_val",
              [](TagBoxArray& tags, TagBox::TagVal val, IntVect const& nghost) {
                  tags.setVal(tag_value(val), nghost);
              },
-             py::arg("val"), py::arg("nghost"))
+             py::arg("val"), py::arg("nghost"),
+             "Set all valid cells plus per-direction grow cells to val.")
         .def("set_val",
              [](TagBoxArray& tags, TagBox::TagVal val, Box const& region, int nghost) {
                  tags.setVal(tag_value(val), region, nghost);
              },
-             py::arg("val"), py::arg("region"), py::arg("nghost") = 0)
+             py::arg("val"), py::arg("region"), py::arg("nghost") = 0,
+             "Set cells intersecting region, optionally grown by nghost, to val.")
         .def("set_val",
              [](TagBoxArray& tags, TagBox::TagVal val, Box const& region, IntVect const& nghost) {
                  tags.setVal(tag_value(val), region, nghost);
              },
-             py::arg("val"), py::arg("region"), py::arg("nghost"))
+             py::arg("val"), py::arg("region"), py::arg("nghost"),
+             "Set cells intersecting region with per-direction grow widths to val.")
         .def("set_val",
              [](TagBoxArray& tags, BoxArray const& ba, TagBox::TagVal val) {
                  tags.setVal(ba, val);
              },
-             py::arg("ba"), py::arg("val"))
+             py::arg("ba"), py::arg("val"),
+             "Set cells covered by ba to val.")
 
-        .def("buffer", &TagBoxArray::buffer, py::arg("nbuf"))
+        .def("buffer", &TagBoxArray::buffer, py::arg("nbuf"),
+             "Grow every SET tag by nbuf cells using AMReX tag-buffer rules.")
         .def("map_periodic_remove_duplicates",
-             &TagBoxArray::mapPeriodicRemoveDuplicates, py::arg("geom"))
-        .def("coarsen", &TagBoxArray::coarsen, py::arg("ratio"))
-        .def("has_tags", &TagBoxArray::hasTags, py::arg("box"))
+             &TagBoxArray::mapPeriodicRemoveDuplicates, py::arg("geom"),
+             "Map tags through periodic boundaries described by geom and remove duplicates.")
+        .def("coarsen", &TagBoxArray::coarsen, py::arg("ratio"),
+             "Coarsen tags in place by ratio.")
+        .def("has_tags", &TagBoxArray::hasTags, py::arg("box"),
+             "Return True if box contains any SET or BUF tags.")
     ;
 }

--- a/src/AmrCore/TagBox.cpp
+++ b/src/AmrCore/TagBox.cpp
@@ -1,0 +1,112 @@
+/* Copyright 2024-2025 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_Box.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_FabArrayBase.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_TagBox.H>
+
+#include <sstream>
+
+
+namespace
+{
+    amrex::TagBox::TagType tag_value (amrex::TagBox::TagVal val)
+    {
+        return static_cast<amrex::TagBox::TagType>(val);
+    }
+}
+
+
+void init_TagBox (py::module& m)
+{
+    using namespace amrex;
+
+    py::class_< TagBox > py_TagBox(m, "TagBox");
+
+    py::native_enum< TagBox::TagVal >(py_TagBox, "TagVal", "enum.IntEnum")
+        .value("CLEAR", TagBox::TagVal::CLEAR)
+        .value("BUF", TagBox::TagVal::BUF)
+        .value("SET", TagBox::TagVal::SET)
+        .export_values()
+        .finalize()
+    ;
+
+    py_TagBox.def("__repr__",
+        [](TagBox const&) {
+            return "<amrex.TagBox>";
+        }
+    );
+
+    py::class_< TagBoxArray, FabArrayBase >(m, "TagBoxArray")
+        .def("__repr__",
+            [](TagBoxArray const& tags) {
+                std::stringstream s;
+                s << tags.size();
+                return "<amrex.TagBoxArray of size '" + s.str() + "'>";
+            }
+        )
+
+        .def(py::init< BoxArray const&, DistributionMapping const&, int >(),
+             py::arg("ba"), py::arg("dm"), py::arg("ngrow") = 0)
+        .def(py::init< BoxArray const&, DistributionMapping const&, IntVect const& >(),
+             py::arg("ba"), py::arg("dm"), py::arg("ngrow"))
+
+        .def("clear", &TagBoxArray::clear)
+        .def("ok", &TagBoxArray::ok)
+        .def("__len__", &TagBoxArray::size)
+        .def_property_readonly("size", &TagBoxArray::size)
+        .def_property_readonly("local_size", &TagBoxArray::local_size)
+        .def_property_readonly("n_grow_vect", &TagBoxArray::nGrowVect)
+        .def_property_readonly("box_array",
+             [](TagBoxArray const& tags) { return tags.boxArray(); },
+             py::return_value_policy::reference_internal)
+        .def_property_readonly("dist_map",
+             [](TagBoxArray const& tags) { return tags.DistributionMap(); },
+             py::return_value_policy::reference_internal)
+
+        .def("set_val",
+             [](TagBoxArray& tags, TagBox::TagVal val) {
+                 tags.setVal(tag_value(val));
+             },
+             py::arg("val"))
+        .def("set_val",
+             [](TagBoxArray& tags, TagBox::TagVal val, int nghost) {
+                 tags.setVal(tag_value(val), nghost);
+             },
+             py::arg("val"), py::arg("nghost"))
+        .def("set_val",
+             [](TagBoxArray& tags, TagBox::TagVal val, IntVect const& nghost) {
+                 tags.setVal(tag_value(val), nghost);
+             },
+             py::arg("val"), py::arg("nghost"))
+        .def("set_val",
+             [](TagBoxArray& tags, TagBox::TagVal val, Box const& region, int nghost) {
+                 tags.setVal(tag_value(val), region, nghost);
+             },
+             py::arg("val"), py::arg("region"), py::arg("nghost") = 0)
+        .def("set_val",
+             [](TagBoxArray& tags, TagBox::TagVal val, Box const& region, IntVect const& nghost) {
+                 tags.setVal(tag_value(val), region, nghost);
+             },
+             py::arg("val"), py::arg("region"), py::arg("nghost"))
+        .def("set_val",
+             [](TagBoxArray& tags, BoxArray const& ba, TagBox::TagVal val) {
+                 tags.setVal(ba, val);
+             },
+             py::arg("ba"), py::arg("val"))
+
+        .def("buffer", &TagBoxArray::buffer, py::arg("nbuf"))
+        .def("map_periodic_remove_duplicates",
+             &TagBoxArray::mapPeriodicRemoveDuplicates, py::arg("geom"))
+        .def("coarsen", &TagBoxArray::coarsen, py::arg("ratio"))
+        .def("has_tags", &TagBoxArray::hasTags, py::arg("box"))
+    ;
+}

--- a/src/AmrCore/TagBox.cpp
+++ b/src/AmrCore/TagBox.cpp
@@ -57,8 +57,9 @@ Use ``TagBox.SET`` to request refinement, ``TagBox.CLEAR`` to remove a tag and
         R"pbdoc(
 Distributed array of ``TagBox`` objects used during AMR error estimation.
 
-Python ``AmrCore.error_est`` overrides receive a ``TagBoxArray`` and mark cells
-with ``set_val(TagBox.SET, ...)``.
+Python ``AmrCore.error_est`` overrides receive a mutable ``TagBoxArray`` and
+mark cells with ``set_val(TagBox.SET, ...)``.  Callback arguments are
+non-owning views and should not be stored after the override returns.
 )pbdoc")
         .def("__repr__",
             [](TagBoxArray const& tags) {

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
         MFInfo.cpp
         MultiFab.cpp
         ParallelDescriptor.cpp
+        ParGDB.cpp
         ParmParse.cpp
         Periodicity.cpp
         PlotFileUtil.cpp

--- a/src/Base/ParGDB.cpp
+++ b/src/Base/ParGDB.cpp
@@ -24,47 +24,71 @@ void init_ParGDB (py::module& m)
     // Abstract base: the Geometry/DistributionMapping/BoxArray broker handed to
     // a ParticleContainer. No Python constructor (it is pure virtual); concrete
     // instances come from AmrParGDB or are built C++-side.
-    py::class_< ParGDBBase >(m, "ParGDBBase")
+    py::class_< ParGDBBase >(
+        m, "ParGDBBase",
+        R"pbdoc(
+Abstract broker for particle geometry, box arrays and distribution maps.
+
+Particle containers use a ``ParGDBBase`` to query mesh metadata for each AMR
+level.  Python users usually obtain a concrete ``AmrParGDB`` from
+``AmrCore.get_par_gdb()``.
+)pbdoc")
         .def("particle_geom",
              py::overload_cast< int >(&ParGDBBase::ParticleGeom, py::const_),
-             py::return_value_policy::reference_internal, py::arg("level"))
+             py::return_value_policy::reference_internal, py::arg("level"),
+             "Return particle Geometry for AMR level.")
         .def("geom",
              py::overload_cast< int >(&ParGDBBase::Geom, py::const_),
-             py::return_value_policy::reference_internal, py::arg("level"))
+             py::return_value_policy::reference_internal, py::arg("level"),
+             "Return mesh Geometry for AMR level.")
         .def("particle_dist_map",
              py::overload_cast< int >(&ParGDBBase::ParticleDistributionMap, py::const_),
-             py::return_value_policy::reference_internal, py::arg("level"))
+             py::return_value_policy::reference_internal, py::arg("level"),
+             "Return particle DistributionMapping for AMR level.")
         .def("dist_map",
              py::overload_cast< int >(&ParGDBBase::DistributionMap, py::const_),
-             py::return_value_policy::reference_internal, py::arg("level"))
+             py::return_value_policy::reference_internal, py::arg("level"),
+             "Return mesh DistributionMapping for AMR level.")
         .def("particle_box_array",
              py::overload_cast< int >(&ParGDBBase::ParticleBoxArray, py::const_),
-             py::return_value_policy::reference_internal, py::arg("level"))
+             py::return_value_policy::reference_internal, py::arg("level"),
+             "Return particle BoxArray for AMR level.")
         .def("box_array",
              py::overload_cast< int >(&ParGDBBase::boxArray, py::const_),
-             py::return_value_policy::reference_internal, py::arg("level"))
+             py::return_value_policy::reference_internal, py::arg("level"),
+             "Return mesh BoxArray for AMR level.")
 
         .def("set_particle_box_array", &ParGDBBase::SetParticleBoxArray,
-             py::arg("level"), py::arg("new_ba"))
+             py::arg("level"), py::arg("new_ba"),
+             "Replace the particle BoxArray for AMR level.")
         .def("set_particle_dist_map", &ParGDBBase::SetParticleDistributionMap,
-             py::arg("level"), py::arg("new_dm"))
+             py::arg("level"), py::arg("new_dm"),
+             "Replace the particle DistributionMapping for AMR level.")
         .def("set_particle_geometry", &ParGDBBase::SetParticleGeometry,
-             py::arg("level"), py::arg("new_geom"))
+             py::arg("level"), py::arg("new_geom"),
+             "Replace the particle Geometry for AMR level.")
 
-        .def("level_defined", &ParGDBBase::LevelDefined, py::arg("level"))
-        .def("finest_level", &ParGDBBase::finestLevel)
-        .def("max_level", &ParGDBBase::maxLevel)
+        .def("level_defined", &ParGDBBase::LevelDefined, py::arg("level"),
+             "Return True if AMR level has valid mesh metadata.")
+        .def("finest_level", &ParGDBBase::finestLevel,
+             "Return the finest currently defined AMR level.")
+        .def("max_level", &ParGDBBase::maxLevel,
+             "Return the maximum AMR level supported by this broker.")
         .def("ref_ratio",
              py::overload_cast< int >(&ParGDBBase::refRatio, py::const_),
-             py::arg("level"))
+             py::arg("level"),
+             "Return the refinement ratio from level to level + 1.")
     ;
 
 #ifdef AMREX_PARTICLES
     // Concrete ParGDB owned by an AmrCore. Mirrors AmrCore::GetParGDB().
-    py::class_< AmrParGDB, ParGDBBase >(m, "AmrParGDB")
+    py::class_< AmrParGDB, ParGDBBase >(
+        m, "AmrParGDB",
+        "Concrete particle metadata broker backed by an AmrCore.")
         .def(py::init< AmrCore* >(), py::arg("amr_core"),
              // keep the AmrCore (arg 1 to the ctor) alive while the GDB lives
-             py::keep_alive<1, 2>())
+             py::keep_alive<1, 2>(),
+             "Construct a particle metadata broker backed by amr_core.")
     ;
 #endif
 }

--- a/src/Base/ParGDB.cpp
+++ b/src/Base/ParGDB.cpp
@@ -1,0 +1,70 @@
+/* Copyright 2024-2025 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_ParGDB.H>
+
+#ifdef AMREX_PARTICLES
+#   include <AMReX_AmrCore.H>
+#   include <AMReX_AmrParGDB.H>
+#endif
+
+
+void init_ParGDB (py::module& m)
+{
+    using namespace amrex;
+
+    // Abstract base: the Geometry/DistributionMapping/BoxArray broker handed to
+    // a ParticleContainer. No Python constructor (it is pure virtual); concrete
+    // instances come from AmrParGDB or are built C++-side.
+    py::class_< ParGDBBase >(m, "ParGDBBase")
+        .def("particle_geom",
+             py::overload_cast< int >(&ParGDBBase::ParticleGeom, py::const_),
+             py::return_value_policy::reference_internal, py::arg("level"))
+        .def("geom",
+             py::overload_cast< int >(&ParGDBBase::Geom, py::const_),
+             py::return_value_policy::reference_internal, py::arg("level"))
+        .def("particle_dist_map",
+             py::overload_cast< int >(&ParGDBBase::ParticleDistributionMap, py::const_),
+             py::return_value_policy::reference_internal, py::arg("level"))
+        .def("dist_map",
+             py::overload_cast< int >(&ParGDBBase::DistributionMap, py::const_),
+             py::return_value_policy::reference_internal, py::arg("level"))
+        .def("particle_box_array",
+             py::overload_cast< int >(&ParGDBBase::ParticleBoxArray, py::const_),
+             py::return_value_policy::reference_internal, py::arg("level"))
+        .def("box_array",
+             py::overload_cast< int >(&ParGDBBase::boxArray, py::const_),
+             py::return_value_policy::reference_internal, py::arg("level"))
+
+        .def("set_particle_box_array", &ParGDBBase::SetParticleBoxArray,
+             py::arg("level"), py::arg("new_ba"))
+        .def("set_particle_dist_map", &ParGDBBase::SetParticleDistributionMap,
+             py::arg("level"), py::arg("new_dm"))
+        .def("set_particle_geometry", &ParGDBBase::SetParticleGeometry,
+             py::arg("level"), py::arg("new_geom"))
+
+        .def("level_defined", &ParGDBBase::LevelDefined, py::arg("level"))
+        .def("finest_level", &ParGDBBase::finestLevel)
+        .def("max_level", &ParGDBBase::maxLevel)
+        .def("ref_ratio",
+             py::overload_cast< int >(&ParGDBBase::refRatio, py::const_),
+             py::arg("level"))
+    ;
+
+#ifdef AMREX_PARTICLES
+    // Concrete ParGDB owned by an AmrCore. Mirrors AmrCore::GetParGDB().
+    py::class_< AmrParGDB, ParGDBBase >(m, "AmrParGDB")
+        .def(py::init< AmrCore* >(), py::arg("amr_core"),
+             // keep the AmrCore (arg 1 to the ctor) alive while the GDB lives
+             py::keep_alive<1, 2>())
+    ;
+#endif
+}

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -195,7 +195,8 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         .def(py::init<const Geometry&, const DistributionMapping&, const BoxArray&>())
         // construct from a ParGDBBase broker, e.g. AmrCore::GetParGDB();
         // keep the ParGDB (and its owner) alive while the container lives
-        .def(py::init<ParGDBBase*>(), py::arg("gdb"), py::keep_alive<1, 2>())
+        .def(py::init<ParGDBBase*>(), py::arg("gdb"), py::keep_alive<1, 2>(),
+             "Construct from a particle metadata broker such as AmrCore.get_par_gdb().")
         .def(py::init<const Vector<Geometry>&,
                       const Vector<DistributionMapping>&,
                       const Vector<BoxArray>&,
@@ -208,7 +209,8 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
     py_pc
         .def("define",
             py::overload_cast<ParGDBBase*>(&ParticleContainerType::Define),
-            py::arg("gdb"), py::keep_alive<1, 2>())
+            py::arg("gdb"), py::keep_alive<1, 2>(),
+            "Define this container from a particle metadata broker.")
 
         .def("make_alike", &ParticleContainerType::template make_alike<Allocator>)
 
@@ -479,7 +481,13 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
                 return pc.DefineAndReturnParticleTile(lev, grid, tile);
             },
             py::return_value_policy::reference_internal,
-            py::arg("lev"), py::arg("grid"), py::arg("tile"))
+            py::arg("lev"), py::arg("grid"), py::arg("tile"),
+            R"pbdoc(
+Define, if necessary, and return the particle tile at ``(lev, grid, tile)``.
+
+This is useful when particles are inserted in place into a known AMR tile.
+The returned tile is owned by the particle container.
+)pbdoc")
         // .def("ParticlesAt", py::overload_cast<int,int,int>(&ParticleContainerType::ParticlesAt),
         //     py::return_value_policy::reference_internal)
         // .def("ParticlesAt", py::overload_cast<int,int,int>(&ParticleContainerType::ParticlesAt,py::const_))

--- a/src/Particle/ParticleContainer.H
+++ b/src/Particle/ParticleContainer.H
@@ -15,6 +15,7 @@
 #include <AMReX_BoxArray.H>
 #include <AMReX_GpuAllocators.H>
 #include <AMReX_IntVect.H>
+#include <AMReX_ParGDB.H>
 #include <AMReX_ParIter.H>
 #include <AMReX_Particle.H>
 #include <AMReX_Particles.H>
@@ -192,6 +193,9 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
     auto py_pc = py::class_<ParticleContainerType>(m, particle_container_type.c_str())
         .def(py::init())
         .def(py::init<const Geometry&, const DistributionMapping&, const BoxArray&>())
+        // construct from a ParGDBBase broker, e.g. AmrCore::GetParGDB();
+        // keep the ParGDB (and its owner) alive while the container lives
+        .def(py::init<ParGDBBase*>(), py::arg("gdb"), py::keep_alive<1, 2>())
         .def(py::init<const Vector<Geometry>&,
                       const Vector<DistributionMapping>&,
                       const Vector<BoxArray>&,
@@ -202,6 +206,10 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
                       const Vector<IntVect>&>())
     ;
     py_pc
+        .def("define",
+            py::overload_cast<ParGDBBase*>(&ParticleContainerType::Define),
+            py::arg("gdb"), py::keep_alive<1, 2>())
+
         .def("make_alike", &ParticleContainerType::template make_alike<Allocator>)
 
         .def_property("arena",
@@ -463,6 +471,15 @@ void make_ParticleContainer_and_Iterators (py::module &m, std::string allocstr)
         // void WritePlotFilePost ();
         //.def("get_particles", py::overload_cast<>(&ParticleContainerType::GetParticles), py::return_value_policy::reference_internal)
         .def("get_particles", py::overload_cast<int>(&ParticleContainerType::GetParticles), py::return_value_policy::reference_internal, py::arg("level"))
+        // define (if needed) and return the particle tile at (level, grid, tile);
+        // used to add particles in-place into a known tile, e.g. ImpactX AddNParticles
+        .def("define_and_return_particle_tile",
+            [](ParticleContainerType& pc, int lev, int grid, int tile)
+                -> ParticleTileType& {
+                return pc.DefineAndReturnParticleTile(lev, grid, tile);
+            },
+            py::return_value_policy::reference_internal,
+            py::arg("lev"), py::arg("grid"), py::arg("tile"))
         // .def("ParticlesAt", py::overload_cast<int,int,int>(&ParticleContainerType::ParticlesAt),
         //     py::return_value_policy::reference_internal)
         // .def("ParticlesAt", py::overload_cast<int,int,int>(&ParticleContainerType::ParticlesAt,py::const_))

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -47,6 +47,7 @@ void init_PlotFileUtil(py::module &);
 void init_PODVector(py::module &);
 void init_RealVect(py::module &);
 void init_SmallMatrix(py::module &);
+void init_TagBox(py::module &);
 void init_Utility(py::module &);
 void init_Vector(py::module &);
 void init_Version(py::module &);
@@ -71,8 +72,10 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
 
             .. autosummary::
                :toctree: _generate
+               AmrCore
                AmrInfo
                AmrMesh
+               AmrParGDB
                Arena
                ArrayOfStructs
                Box
@@ -88,6 +91,7 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
                MFItInfo
                MultiFab
                ParallelDescriptor
+               ParGDBBase
                Particle
                ParmParse
                ParticleTile
@@ -97,6 +101,8 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
                PODVector
                SmallMatrix
                StructOfArrays
+               TagBox
+               TagBoxArray
                Utility
                Vector
                VisMF
@@ -135,6 +141,7 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     // note: the AmrCore class is declared before ParGDB and the particle
     // containers (they reference it in member signatures), while its member
     // functions are added after ParGDB (get_par_gdb returns an AmrParGDB)
+    init_TagBox(m);
     init_AmrMesh(m);
     init_AmrCore_class(m);      // after AmrMesh (its pybind base)
     init_ParGDB(m);             // after the AmrCore class declaration

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -16,6 +16,7 @@
 void init_Algorithm(py::module&);
 void init_AMReX(py::module&);
 void init_AmrCore(py::module &);
+void init_AmrCore_class(py::module &);
 void init_AmrMesh(py::module &);
 void init_Arena(py::module&);
 void init_Array4(py::module&);
@@ -131,10 +132,14 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     init_ParallelDescriptor(m);
     init_PODVector(m);
 
-    init_ParticleContainer(m);
+    // note: the AmrCore class is declared before ParGDB and the particle
+    // containers (they reference it in member signatures), while its member
+    // functions are added after ParGDB (get_par_gdb returns an AmrParGDB)
     init_AmrMesh(m);
-    init_AmrCore(m);   // after AmrMesh (its pybind base)
-    init_ParGDB(m);    // after AmrCore (AmrParGDB references it)
+    init_AmrCore_class(m);      // after AmrMesh (its pybind base)
+    init_ParGDB(m);             // after the AmrCore class declaration
+    init_ParticleContainer(m);  // after ParGDB (constructible from it)
+    init_AmrCore(m);            // after ParGDB (AmrParGDB in signatures)
 
 #ifdef AMREX_USE_MPI
     init_MPMD(m);

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -15,6 +15,7 @@
 // forward declarations of exposed classes
 void init_Algorithm(py::module&);
 void init_AMReX(py::module&);
+void init_AmrCore(py::module &);
 void init_AmrMesh(py::module &);
 void init_Arena(py::module&);
 void init_Array4(py::module&);
@@ -37,6 +38,7 @@ void init_MPMD(py::module &);
 #endif
 void init_MultiFab(py::module &, py::class_< amrex::MFIter >&);
 void init_ParallelDescriptor(py::module &);
+void init_ParGDB(py::module &);
 void init_ParmParse(py::module &);
 void init_ParticleContainer(py::module &);
 void init_Periodicity(py::module &);
@@ -131,6 +133,8 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
 
     init_ParticleContainer(m);
     init_AmrMesh(m);
+    init_AmrCore(m);   // after AmrMesh (its pybind base)
+    init_ParGDB(m);    // after AmrCore (AmrParGDB references it)
 
 #ifdef AMREX_USE_MPI
     init_MPMD(m);

--- a/tests/test_amrcore.py
+++ b/tests/test_amrcore.py
@@ -6,7 +6,7 @@ import pytest
 import amrex.space3d as amr
 
 
-def _make_core(record=None):
+def _make_core(record=None, max_level=0):
     """An AmrCore subclass that records calls to its overridden virtuals.
 
     Built as a single-level (``max_level = 0``), non-periodic, Cartesian core.
@@ -28,12 +28,15 @@ def _make_core(record=None):
             record.setdefault("clear", []).append(lev)
 
         def error_est(self, lev, tags, time, ngrow):
-            record.setdefault("error_est", []).append(lev)
+            record.setdefault("error_est", []).append(
+                (lev, isinstance(tags, amr.TagBoxArray), tags.size)
+            )
+            tags.set_val(amr.TagBox.SET)
 
     rb = amr.RealBox(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
     n_cell = amr.Vector_int([16, 16, 16])
-    ref_ratios = amr.Vector_IntVect([])  # max_level=0 -> no refinement ratios
-    core = RecordingCore(rb, 0, n_cell, 0, ref_ratios, [0, 0, 0])
+    ref_ratios = amr.Vector_IntVect([amr.IntVect(2) for _ in range(max_level)])
+    core = RecordingCore(rb, max_level, n_cell, 0, ref_ratios, [0, 0, 0])
     return core, record
 
 
@@ -42,6 +45,8 @@ def _make_core(record=None):
 # ---------------------------------------------------------------------------
 def test_amrcore_classes_are_bound():
     assert hasattr(amr, "AmrCore")
+    assert hasattr(amr, "TagBox")
+    assert hasattr(amr, "TagBoxArray")
     assert hasattr(amr, "ParGDBBase")
     assert hasattr(amr, "AmrParGDB")
     # AmrCore derives from AmrMesh in C++ and in the bindings
@@ -74,6 +79,19 @@ def test_amrcore_trampoline_clear_level():
     core.init_from_scratch(0.0)
     core.clear_level(0)
     assert record.get("clear") == [0]
+
+
+def test_amrcore_trampoline_error_est_tags_refined_level():
+    core, record = _make_core(max_level=1)
+    core.init_from_scratch(0.0)
+
+    assert record.get("error_est")
+    lev, got_tag_box_array, n_boxes = record["error_est"][0]
+    assert lev == 0
+    assert got_tag_box_array
+    assert n_boxes >= 1
+    assert [call[0] for call in record["scratch"]] == [0, 1]
+    assert core.finest_level == 1
 
 
 def test_amrcore_missing_pure_virtual_raises():

--- a/tests/test_amrcore.py
+++ b/tests/test_amrcore.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+import amrex.space3d as amr
+
+
+def _make_core(record=None):
+    """An AmrCore subclass that records calls to its overridden virtuals.
+
+    Built as a single-level (``max_level = 0``), non-periodic, Cartesian core.
+    """
+    if record is None:
+        record = {}
+
+    class RecordingCore(amr.AmrCore):
+        def make_new_level_from_scratch(self, lev, time, ba, dm):
+            record.setdefault("scratch", []).append((lev, ba.size))
+
+        def make_new_level_from_coarse(self, lev, time, ba, dm):
+            record.setdefault("coarse", []).append(lev)
+
+        def remake_level(self, lev, time, ba, dm):
+            record.setdefault("remake", []).append(lev)
+
+        def clear_level(self, lev):
+            record.setdefault("clear", []).append(lev)
+
+        def error_est(self, lev, tags, time, ngrow):
+            record.setdefault("error_est", []).append(lev)
+
+    rb = amr.RealBox(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+    n_cell = amr.Vector_int([16, 16, 16])
+    ref_ratios = amr.Vector_IntVect([])  # max_level=0 -> no refinement ratios
+    core = RecordingCore(rb, 0, n_cell, 0, ref_ratios, [0, 0, 0])
+    return core, record
+
+
+# ---------------------------------------------------------------------------
+# AmrCore binding & trampoline
+# ---------------------------------------------------------------------------
+def test_amrcore_classes_are_bound():
+    assert hasattr(amr, "AmrCore")
+    assert hasattr(amr, "ParGDBBase")
+    assert hasattr(amr, "AmrParGDB")
+    # AmrCore derives from AmrMesh in C++ and in the bindings
+    assert issubclass(amr.AmrCore, amr.AmrMesh)
+    assert issubclass(amr.AmrParGDB, amr.ParGDBBase)
+
+
+def test_amrcore_construct():
+    core, _ = _make_core()
+    assert core.max_level == 0
+    # finest_level is -1 until init_from_scratch defines level 0
+    assert core.finest_level == -1
+
+
+def test_amrcore_trampoline_make_new_level_from_scratch():
+    core, record = _make_core()
+    core.init_from_scratch(0.0)
+
+    # the Python override must have been called exactly once, for level 0
+    assert "scratch" in record
+    assert len(record["scratch"]) == 1
+    lev, n_boxes = record["scratch"][0]
+    assert lev == 0
+    assert n_boxes >= 1
+    assert core.finest_level == 0
+
+
+def test_amrcore_trampoline_clear_level():
+    core, record = _make_core()
+    core.init_from_scratch(0.0)
+    core.clear_level(0)
+    assert record.get("clear") == [0]
+
+
+def test_amrcore_missing_pure_virtual_raises():
+    # A subclass that does NOT override make_new_level_from_scratch must raise
+    # when AMReX tries to call that pure virtual during init_from_scratch.
+    class IncompleteCore(amr.AmrCore):
+        def make_new_level_from_coarse(self, *args):
+            pass
+
+        def remake_level(self, *args):
+            pass
+
+        def clear_level(self, lev):
+            pass
+
+        def error_est(self, *args):
+            pass
+
+    rb = amr.RealBox(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+    core = IncompleteCore(
+        rb, 0, amr.Vector_int([16, 16, 16]), 0, amr.Vector_IntVect([]), [0, 0, 0]
+    )
+    with pytest.raises(RuntimeError):
+        core.init_from_scratch(0.0)
+
+
+# ---------------------------------------------------------------------------
+# AmrMesh geom / set_geometry accessors (added alongside AmrCore)
+# ---------------------------------------------------------------------------
+def test_amrmesh_geom_accessor():
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+    geom = core.geom(0)
+    assert np.allclose(geom.ProbLo(), [0.0, 0.0, 0.0])
+    assert np.allclose(geom.ProbHi(), [1.0, 1.0, 1.0])
+
+
+def test_amrmesh_set_geometry():
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+    new_geom = amr.Geometry(
+        core.geom(0).domain,
+        amr.RealBox(-2.0, -2.0, -2.0, 2.0, 2.0, 2.0),
+        0,
+        [0, 0, 0],
+    )
+    core.set_geometry(0, new_geom)
+    assert np.allclose(core.geom(0).ProbHi(), [2.0, 2.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# ParGDB / AmrParGDB
+# ---------------------------------------------------------------------------
+def test_get_par_gdb():
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+    gdb = core.get_par_gdb()
+    assert isinstance(gdb, amr.AmrParGDB)
+    assert isinstance(gdb, amr.ParGDBBase)
+    assert gdb.max_level() == 0
+    assert gdb.finest_level() == 0
+    assert gdb.level_defined(0)
+    # geometry queried through the GDB matches the AmrCore's level-0 geometry
+    assert np.allclose(gdb.geom(0).ProbHi(), [1.0, 1.0, 1.0])
+
+
+def test_amrpargdb_construct_from_core():
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+    gdb = amr.AmrParGDB(core)
+    assert gdb.max_level() == 0
+    assert gdb.finest_level() == 0
+
+
+def test_get_par_gdb_keeps_core_alive(assert_keeps_python_alive):
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+    gdb = assert_keeps_python_alive(core, lambda: core.get_par_gdb())
+    assert gdb.finest_level() == 0
+
+
+# ---------------------------------------------------------------------------
+# ParticleContainer construction from a ParGDB + in-place tile definition
+# ---------------------------------------------------------------------------
+def test_particle_container_from_gdb():
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+    gdb = core.get_par_gdb()
+
+    pc = amr.ParticleContainer_2_1_3_1_default(gdb)
+    assert pc.finest_level == 0
+    assert pc.total_number_of_particles() == 0
+
+
+def test_define_and_return_particle_tile():
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+    gdb = core.get_par_gdb()
+    pc = amr.ParticleContainer_2_1_3_1_default(gdb)
+
+    tile = pc.define_and_return_particle_tile(0, 0, 0)
+    assert tile.num_particles == 0
+    tile.resize(5)
+    assert tile.size == 5
+
+
+@pytest.mark.skipif(
+    not hasattr(amr, "ParticleContainer_pureSoA_11_0_polymorphic"),
+    reason="ImpactX pure-SoA particle container not built",
+)
+def test_pure_soa_container_from_gdb_add_particles():
+    """End-to-end: AmrCore -> ParGDB -> pure-SoA PC -> in-place particle add.
+
+    This mirrors the ImpactX construction path
+    ``ImpactXParticleContainer(amr_core->GetParGDB())`` followed by
+    ``AddNParticles``.
+    """
+    core, _ = _make_core()
+    core.init_from_scratch(0.0)
+
+    pc = amr.ParticleContainer_pureSoA_11_0_polymorphic(core.get_par_gdb())
+    pc.arena = amr.The_Arena()  # PolymorphicArenaAllocator needs an arena
+    names = [f"r{i}" for i in range(11)]
+    pc.set_soa_compile_time_names(names, [])
+
+    npart = 100
+    tile = pc.define_and_return_particle_tile(0, 0, 0)
+    tile.resize(npart)
+    soa = tile.get_struct_of_arrays()
+
+    # write the first real component and the particle ids
+    x = np.arange(npart, dtype=np.float64)
+    np.array(soa.get_real_data(0), copy=False)[:] = x
+
+    idcpu = np.array(soa.get_idcpu_data(), copy=False)
+    amr.pack_ids(idcpu, np.arange(1, npart + 1, dtype=np.int64))
+    amr.pack_cpus(idcpu, np.zeros(npart, dtype=np.int32))
+
+    assert pc.number_of_particles_at_level(0) == npart
+    assert pc.total_number_of_particles() == npart
+
+    # read back via the iterator and confirm the written data round-trips
+    read = []
+    for pti in pc.iterator(level=0):
+        read.append(np.array(pti.soa().get_real_data(0), copy=False).copy())
+    read = np.concatenate(read)
+    assert read.size == npart
+    assert np.allclose(np.sort(read), x)

--- a/tests/test_amrcore.py
+++ b/tests/test_amrcore.py
@@ -7,9 +7,10 @@ import amrex.space3d as amr
 
 
 def _make_core(record=None, max_level=0):
-    """An AmrCore subclass that records calls to its overridden virtuals.
+    """Return an AmrCore subclass that records virtual-callback calls.
 
-    Built as a single-level (``max_level = 0``), non-periodic, Cartesian core.
+    The core uses a non-periodic Cartesian domain and the requested
+    ``max_level``.
     """
     if record is None:
         record = {}


### PR DESCRIPTION
Reintroduce `AMRCore` with trampolines for [virtual members](https://pybind11.readthedocs.io/en/stable/advanced/classes.html#overriding-virtual-functions-in-python). Also add `AMRMesh` and GDB classes.

Useful for all-pyAMReX build applications (e.g., [tutorials](https://github.com/AMReX-Codes/amrex-tutorials) or [ImpactX as pyAMReX app](https://github.com/ax3l/impactx/tree/topic-all-pyamrex-base-classes).)

- [x] finish self-review
- [x] ensure doc strings, args and sphinx docs are complete & user-friendly