### PR TITLE
Boundary: BCType, BCRec, FillDomainBoundary, PhysBCFunct

### DIFF
--- a/docs/source/usage/api.rst
+++ b/docs/source/usage/api.rst
@@ -135,6 +135,83 @@ Vectors
    :members:
    :undoc-members:
 
+Boundary Conditions
+"""""""""""""""""""
+
+Boundary records describe the mathematical boundary types used for each
+MultiFab component and coordinate direction. A common cell-centered fill
+sequence is to fill interior or periodic ghost cells first and then fill
+physical-domain ghost cells:
+
+.. code-block:: python
+
+   sd = amr.Config.spacedim
+   bc = amr.Vector_BCRec([
+       amr.BCRec(
+           lo=[amr.BCType.foextrap] * sd,
+           hi=[amr.BCType.foextrap] * sd,
+       )
+   ])
+
+   mf.fill_boundary()
+   amr.fill_domain_boundary(mf, geom, bc)
+
+``fill_domain_boundary`` handles extrapolation and reflection boundary
+types. For external Dirichlet values, ``BCType.ext_dir`` or
+``BCType.ext_dir_cc``, fill the relevant ghost cells from application
+code. ``PhysBCFunctUser`` provides a Python callback hook with the same
+component-range convention as AMReX FillPatch routines:
+
+.. code-block:: python
+
+   def fill_ext_dir(mf, dcomp, ncomp, nghost, time, bccomp):
+       # Fill external Dirichlet ghost cells for mf components
+       # [dcomp, dcomp + ncomp).
+       pass
+
+   physbc = amr.PhysBCFunctUser(fill_ext_dir)
+   physbc(mf, 0, 1, mf.n_grow_vect, 0.0, 0)
+
+In physical boundary functors, ``dcomp`` is the first destination
+component in the ``MultiFab`` and ``bccomp`` is the first matching entry
+in the ``Vector_BCRec``.
+
+.. autoclass:: amrex.space3d.BCType
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.PhysBCType
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.BCRec
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.Vector_BCRec
+   :members:
+   :undoc-members:
+
+.. autofunction:: amrex.space3d.setBC
+
+.. autofunction:: amrex.space3d.fill_domain_boundary
+
+.. autoclass:: amrex.space3d.PhysBCFunctNoOp
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.CpuBndryFuncFab
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.PhysBCFunct_CpuBndryFuncFab
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.PhysBCFunctUser
+   :members:
+   :undoc-members:
+
 Data Containers
 """""""""""""""
 

--- a/src/Boundary/BCRec.cpp
+++ b/src/Boundary/BCRec.cpp
@@ -21,8 +21,16 @@ void init_BCRec(py::module& m)
 {
     using namespace amrex;
 
+    // Expose AMReX boundary enums with the same names used in C++ docs.
     py::native_enum<BCType::mathematicalBndryTypes>(m, "BCType", "enum.IntEnum",
-            "Mathematical boundary condition types")
+            R"pbdoc(Mathematical boundary condition types stored in BCRec.
+
+Common values are BCType.int_dir for interior cells, BCType.foextrap
+for first-order extrapolation, BCType.reflect_even and
+BCType.reflect_odd for reflective boundaries, and BCType.ext_dir or
+BCType.ext_dir_cc for external Dirichlet values supplied by the
+application.
+)pbdoc")
         .value("bogus", BCType::bogus)
         .value("reflect_odd", BCType::reflect_odd)
         .value("int_dir", BCType::int_dir)
@@ -40,7 +48,11 @@ void init_BCRec(py::module& m)
     ;
 
     py::native_enum<PhysBCType::physicalBndryTypes>(m, "PhysBCType", "enum.IntEnum",
-            "Physical boundary condition types")
+            R"pbdoc(Physical boundary condition categories.
+
+Application code maps these physical categories to mathematical
+BCType values for each field component and coordinate direction.
+)pbdoc")
         .value("interior", PhysBCType::interior)
         .value("inflow", PhysBCType::inflow)
         .value("outflow", PhysBCType::outflow)
@@ -51,72 +63,112 @@ void init_BCRec(py::module& m)
         .finalize()
     ;
 
+    // BCRec stores low/high mathematical boundary types for one component.
     py::class_<BCRec>(m, "BCRec",
-            "Boundary Condition Records. Necessary information and "
-            "functions for computing boundary conditions.")
+            R"pbdoc(Boundary condition record for one field component.
+
+A BCRec stores one mathematical boundary type on the low and high side
+of each coordinate direction. Pass lists of length Config.spacedim for
+lo and hi, usually using BCType enum values.
+)pbdoc")
         .def("__repr__",
              [](BCRec const & bcr) {
+                 auto append_values = [](std::stringstream& s, int const* values) {
+                     char const* separator = "";
+                     for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                         s << separator << values[dir];
+                         separator = ",";
+                     }
+                 };
+
                  std::stringstream s;
                  s << "<amrex.BCRec (";
-                 for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                     s << bcr.lo(dir);
-                     s << (dir < AMREX_SPACEDIM-1 ? "," : ") (");
-                 }
-                 for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                     s << bcr.hi(dir);
-                     s << (dir < AMREX_SPACEDIM-1 ? "," : ")>");
-                 }
+                 append_values(s, bcr.lo());
+                 s << ") (";
+                 append_values(s, bcr.hi());
+                 s << ")>";
                  return s.str();
              }
         )
 
+        // Constructors document AMReX's component and direction conventions.
         .def(py::init<>(),
-             "The default constructor, which does NOT set valid boundary types.")
+             R"pbdoc(Create a BCRec initialized to BCType.bogus on every face.
+
+Set all low and high entries before using this record in a fill
+operation.
+)pbdoc")
         .def(py::init([](std::array<int, AMREX_SPACEDIM> const & lo,
                          std::array<int, AMREX_SPACEDIM> const & hi) {
                  return BCRec(lo.data(), hi.data());
              }),
              py::arg("lo"), py::arg("hi"),
-             "The constructor, taking the boundary condition types on the "
-             "low and high side of the domain, per direction.")
+             R"pbdoc(Create a BCRec from low-side and high-side boundary types.
+
+Args:
+    lo: Sequence of Config.spacedim BCType or integer values for the
+        low side of each coordinate direction.
+    hi: Sequence of Config.spacedim BCType or integer values for the
+        high side of each coordinate direction.
+)pbdoc")
         .def(py::init<Box const &, Box const &, BCRec const &>(),
              py::arg("bx"), py::arg("domain"), py::arg("bc_domain"),
-             "Yet another constructor. Inherits bndry types from bc_domain "
-             "when bx lies on edge of domain otherwise gets interior Dirichlet.")
+             R"pbdoc(Create the BCRec for a sub-box from a domain BCRec.
 
+For each face, the returned record inherits bc_domain when bx touches
+the physical domain boundary and uses BCType.int_dir otherwise.
+
+Args:
+    bx: Box to classify.
+    domain: Physical domain box.
+    bc_domain: Boundary record for the full domain.
+)pbdoc")
+
+        // Mutators set one coordinate direction at a time, matching BCRec.
         .def("set_lo", &BCRec::setLo,
-             py::arg("dir"), py::arg("bc_val"),
-             "Explicitly set lo bndry value.")
-        .def("set_hi", &BCRec::setHi,
-             py::arg("dir"), py::arg("bc_val"),
-             "Explicitly set hi bndry value.")
+             py::arg("dir"), py::arg("bc_type"),
+             R"pbdoc(Set the low-side boundary type in one direction.
 
+Args:
+    dir: Coordinate direction, from 0 to Config.spacedim - 1.
+    bc_type: BCType or integer boundary value.
+)pbdoc")
+        .def("set_hi", &BCRec::setHi,
+             py::arg("dir"), py::arg("bc_type"),
+             R"pbdoc(Set the high-side boundary type in one direction.
+
+Args:
+    dir: Coordinate direction, from 0 to Config.spacedim - 1.
+    bc_type: BCType or integer boundary value.
+)pbdoc")
+
+        // List accessors make boundary records easy to inspect from Python.
         .def("lo",
              [](BCRec const & bcr) {
                  return std::vector<int>(bcr.lo(), bcr.lo() + AMREX_SPACEDIM);
              },
-             "Return low-end boundary data.")
+             "Return low-side boundary types as a list.")
         .def("lo", py::overload_cast<int>(&BCRec::lo, py::const_),
              py::arg("dir"),
-             "Return low-end boundary data in direction dir.")
+             "Return the low-side boundary type in one direction.")
         .def("hi",
              [](BCRec const & bcr) {
                  return std::vector<int>(bcr.hi(), bcr.hi() + AMREX_SPACEDIM);
              },
-             "Return high-end boundary data.")
+             "Return high-side boundary types as a list.")
         .def("hi", py::overload_cast<int>(&BCRec::hi, py::const_),
              py::arg("dir"),
-             "Return high-end boundary data in direction dir.")
+             "Return the high-side boundary type in one direction.")
         .def("vect",
              [](BCRec const & bcr) {
                  return std::vector<int>(bcr.vect(), bcr.vect() + 2*AMREX_SPACEDIM);
              },
-             "Return bndry values.")
+             "Return all boundary types as low-side entries followed by high-side entries.")
         .def("data",
              [](BCRec const & bcr) {
                  return std::vector<int>(bcr.data(), bcr.data() + 2*AMREX_SPACEDIM);
              },
-             "Return bndry values.")
+             "Return all boundary types as low-side entries followed by high-side entries.")
 
         .def(py::self == py::self)
         .def(py::self != py::self)
@@ -124,15 +176,24 @@ void init_BCRec(py::module& m)
 
     make_Vector<BCRec>(m, "BCRec");
 
+    // Return Python-owned records instead of exposing output parameters.
     m.def("setBC",
           [](Box const & bx, Box const & domain, BCRec const & bc_dom) {
               BCRec bcr;
               setBC(bx, domain, bc_dom, bcr);
               return bcr;
           },
-          py::arg("bx"), py::arg("domain"), py::arg("bc_dom"),
-          "Function for setting a BC. Inherits bndry types from bc_dom "
-          "when bx lies on edge of domain otherwise gets interior Dirichlet.");
+          py::arg("bx"), py::arg("domain"), py::arg("bc_domain"),
+          R"pbdoc(Return the BCRec for a box from a domain BCRec.
+
+For each face, the returned record inherits bc_domain when bx touches
+the physical domain boundary and uses BCType.int_dir otherwise.
+
+Args:
+    bx: Box to classify.
+    domain: Physical domain box.
+    bc_domain: Boundary record for the full domain.
+)pbdoc");
     m.def("setBC",
           [](Box const & bx, Box const & domain,
              int src_comp, int dest_comp, int ncomp,
@@ -143,6 +204,20 @@ void init_BCRec(py::module& m)
           },
           py::arg("bx"), py::arg("domain"),
           py::arg("src_comp"), py::arg("dest_comp"), py::arg("ncomp"),
-          py::arg("bc_dom"),
-          "Function for setting array of BCs.");
+          py::arg("bc_domain"),
+          R"pbdoc(Return component boundary records for a box.
+
+The returned Vector_BCRec has size dest_comp + ncomp. Components in
+the interval [dest_comp, dest_comp + ncomp) are populated from
+bc_domain[src_comp:src_comp + ncomp]. Earlier destination entries are
+left at their default BCType.bogus values.
+
+Args:
+    bx: Box to classify.
+    domain: Physical domain box.
+    src_comp: First component to read from bc_domain.
+    dest_comp: First component to write in the returned Vector_BCRec.
+    ncomp: Number of component records to populate.
+    bc_domain: Domain boundary records for source components.
+)pbdoc");
 }

--- a/src/Boundary/BCRec.cpp
+++ b/src/Boundary/BCRec.cpp
@@ -1,0 +1,148 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include "Base/Vector.H"
+
+#include <AMReX_BCRec.H>
+#include <AMReX_BC_TYPES.H>
+#include <AMReX_Box.H>
+#include <AMReX_Vector.H>
+
+#include <array>
+#include <sstream>
+#include <vector>
+
+
+void init_BCRec(py::module& m)
+{
+    using namespace amrex;
+
+    py::native_enum<BCType::mathematicalBndryTypes>(m, "BCType", "enum.IntEnum",
+            "Mathematical boundary condition types")
+        .value("bogus", BCType::bogus)
+        .value("reflect_odd", BCType::reflect_odd)
+        .value("int_dir", BCType::int_dir)
+        .value("reflect_even", BCType::reflect_even)
+        .value("foextrap", BCType::foextrap)
+        .value("ext_dir", BCType::ext_dir)
+        .value("hoextrap", BCType::hoextrap)
+        .value("hoextrapcc", BCType::hoextrapcc)
+        .value("ext_dir_cc", BCType::ext_dir_cc)
+        .value("direction_dependent", BCType::direction_dependent)
+        .value("user_1", BCType::user_1)
+        .value("user_2", BCType::user_2)
+        .value("user_3", BCType::user_3)
+        .finalize()
+    ;
+
+    py::native_enum<PhysBCType::physicalBndryTypes>(m, "PhysBCType", "enum.IntEnum",
+            "Physical boundary condition types")
+        .value("interior", PhysBCType::interior)
+        .value("inflow", PhysBCType::inflow)
+        .value("outflow", PhysBCType::outflow)
+        .value("symmetry", PhysBCType::symmetry)
+        .value("slipwall", PhysBCType::slipwall)
+        .value("noslipwall", PhysBCType::noslipwall)
+        .value("inflowoutflow", PhysBCType::inflowoutflow)
+        .finalize()
+    ;
+
+    py::class_<BCRec>(m, "BCRec",
+            "Boundary Condition Records. Necessary information and "
+            "functions for computing boundary conditions.")
+        .def("__repr__",
+             [](BCRec const & bcr) {
+                 std::stringstream s;
+                 s << "<amrex.BCRec (";
+                 for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                     s << bcr.lo(dir);
+                     s << (dir < AMREX_SPACEDIM-1 ? "," : ") (");
+                 }
+                 for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                     s << bcr.hi(dir);
+                     s << (dir < AMREX_SPACEDIM-1 ? "," : ")>");
+                 }
+                 return s.str();
+             }
+        )
+
+        .def(py::init<>(),
+             "The default constructor, which does NOT set valid boundary types.")
+        .def(py::init([](std::array<int, AMREX_SPACEDIM> const & lo,
+                         std::array<int, AMREX_SPACEDIM> const & hi) {
+                 return BCRec(lo.data(), hi.data());
+             }),
+             py::arg("lo"), py::arg("hi"),
+             "The constructor, taking the boundary condition types on the "
+             "low and high side of the domain, per direction.")
+        .def(py::init<Box const &, Box const &, BCRec const &>(),
+             py::arg("bx"), py::arg("domain"), py::arg("bc_domain"),
+             "Yet another constructor. Inherits bndry types from bc_domain "
+             "when bx lies on edge of domain otherwise gets interior Dirichlet.")
+
+        .def("set_lo", &BCRec::setLo,
+             py::arg("dir"), py::arg("bc_val"),
+             "Explicitly set lo bndry value.")
+        .def("set_hi", &BCRec::setHi,
+             py::arg("dir"), py::arg("bc_val"),
+             "Explicitly set hi bndry value.")
+
+        .def("lo",
+             [](BCRec const & bcr) {
+                 return std::vector<int>(bcr.lo(), bcr.lo() + AMREX_SPACEDIM);
+             },
+             "Return low-end boundary data.")
+        .def("lo", py::overload_cast<int>(&BCRec::lo, py::const_),
+             py::arg("dir"),
+             "Return low-end boundary data in direction dir.")
+        .def("hi",
+             [](BCRec const & bcr) {
+                 return std::vector<int>(bcr.hi(), bcr.hi() + AMREX_SPACEDIM);
+             },
+             "Return high-end boundary data.")
+        .def("hi", py::overload_cast<int>(&BCRec::hi, py::const_),
+             py::arg("dir"),
+             "Return high-end boundary data in direction dir.")
+        .def("vect",
+             [](BCRec const & bcr) {
+                 return std::vector<int>(bcr.vect(), bcr.vect() + 2*AMREX_SPACEDIM);
+             },
+             "Return bndry values.")
+        .def("data",
+             [](BCRec const & bcr) {
+                 return std::vector<int>(bcr.data(), bcr.data() + 2*AMREX_SPACEDIM);
+             },
+             "Return bndry values.")
+
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+    ;
+
+    make_Vector<BCRec>(m, "BCRec");
+
+    m.def("setBC",
+          [](Box const & bx, Box const & domain, BCRec const & bc_dom) {
+              BCRec bcr;
+              setBC(bx, domain, bc_dom, bcr);
+              return bcr;
+          },
+          py::arg("bx"), py::arg("domain"), py::arg("bc_dom"),
+          "Function for setting a BC. Inherits bndry types from bc_dom "
+          "when bx lies on edge of domain otherwise gets interior Dirichlet.");
+    m.def("setBC",
+          [](Box const & bx, Box const & domain,
+             int src_comp, int dest_comp, int ncomp,
+             Vector<BCRec> const & bc_dom) {
+              Vector<BCRec> bcr(dest_comp + ncomp);
+              setBC(bx, domain, src_comp, dest_comp, ncomp, bc_dom, bcr);
+              return bcr;
+          },
+          py::arg("bx"), py::arg("domain"),
+          py::arg("src_comp"), py::arg("dest_comp"), py::arg("ncomp"),
+          py::arg("bc_dom"),
+          "Function for setting array of BCs.");
+}

--- a/src/Boundary/BCUtil.cpp
+++ b/src/Boundary/BCUtil.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_BCRec.H>
+#include <AMReX_BCUtil.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_Vector.H>
+
+
+void init_BCUtil(py::module& m)
+{
+    using namespace amrex;
+
+    m.def("fill_domain_boundary",
+          &FillDomainBoundary,
+          py::arg("phi"), py::arg("geom"), py::arg("bc"),
+          "Fill cell-centered data outside the physical domain "
+          "(excluding periodic boundaries). It only fills "
+          "BCType.foextrap, BCType.hoextrap, BCType.hoextrapcc, "
+          "BCType.reflect_even, and BCType.reflect_odd. It does not fill "
+          "BCType.ext_dir and BCType.ext_dir_cc (i.e., external "
+          "Dirichlet). For BCType.ext_dir and BCType.ext_dir_cc, fill the "
+          "ghost cells from Python, e.g., via a PhysBCFunctUser callback."
+    );
+}

--- a/src/Boundary/BCUtil.cpp
+++ b/src/Boundary/BCUtil.cpp
@@ -19,12 +19,23 @@ void init_BCUtil(py::module& m)
     m.def("fill_domain_boundary",
           &FillDomainBoundary,
           py::arg("phi"), py::arg("geom"), py::arg("bc"),
-          "Fill cell-centered data outside the physical domain "
-          "(excluding periodic boundaries). It only fills "
-          "BCType.foextrap, BCType.hoextrap, BCType.hoextrapcc, "
-          "BCType.reflect_even, and BCType.reflect_odd. It does not fill "
-          "BCType.ext_dir and BCType.ext_dir_cc (i.e., external "
-          "Dirichlet). For BCType.ext_dir and BCType.ext_dir_cc, fill the "
-          "ghost cells from Python, e.g., via a PhysBCFunctUser callback."
+          R"pbdoc(Fill cell-centered physical-domain ghost cells.
+
+This fills non-periodic ghost cells outside the physical domain for
+BCType.foextrap, BCType.hoextrap, BCType.hoextrapcc,
+BCType.reflect_even, and BCType.reflect_odd. It intentionally leaves
+BCType.ext_dir and BCType.ext_dir_cc unchanged; fill those values from
+application code, for example with PhysBCFunctUser.
+
+Args:
+    phi: MultiFab to modify in place. All components are processed.
+    geom: Geometry defining the physical domain and periodic directions.
+    bc: Vector_BCRec with one record per component in phi.
+
+Notes:
+    This function fills physical-domain ghost cells only. For multi-box
+    MultiFabs, call phi.fill_boundary() separately when interior or
+    periodic ghost cells also need to be valid.
+)pbdoc"
     );
 }

--- a/src/Boundary/CMakeLists.txt
+++ b/src/Boundary/CMakeLists.txt
@@ -1,0 +1,8 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    target_sources(pyAMReX_${D}d
+      PRIVATE
+        BCRec.cpp
+        BCUtil.cpp
+        PhysBCFunct.cpp
+    )
+endforeach()

--- a/src/Boundary/PhysBCFunct.H
+++ b/src/Boundary/PhysBCFunct.H
@@ -1,0 +1,49 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#pragma once
+
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_REAL.H>
+
+#include <functional>
+#include <utility>
+
+
+namespace pyAMReX
+{
+    /** A physical boundary condition functor calling back into Python.
+     *
+     * This fulfills the same interface as amrex::PhysBCFunct<F> at the
+     * MultiFab level and can thus be passed to, e.g., the FillPatch
+     * functions. The user-provided callable receives
+     * (mf, dcomp, ncomp, nghost, time, bccomp) and is expected to fill
+     * the ghost cells of mf that lie outside the physical domain,
+     * e.g., for external Dirichlet (BCType.ext_dir) boundaries.
+     *
+     * Note: the callback runs on the host. When called from C++, the
+     * pybind11 functional caster acquires the GIL automatically.
+     */
+    struct PhysBCFunctUser
+    {
+        using UserFillFunc =
+            std::function<void(amrex::MultiFab&, int, int,
+                               amrex::IntVect const&, amrex::Real, int)>;
+
+        PhysBCFunctUser () = default;
+
+        explicit PhysBCFunctUser (UserFillFunc f) : m_f(std::move(f)) {}
+
+        void operator() (amrex::MultiFab& mf, int dcomp, int ncomp,
+                         amrex::IntVect const& nghost, amrex::Real time,
+                         int bccomp)
+        {
+            if (m_f) { m_f(mf, dcomp, ncomp, nghost, time, bccomp); }
+        }
+
+        UserFillFunc m_f;
+    };
+}

--- a/src/Boundary/PhysBCFunct.H
+++ b/src/Boundary/PhysBCFunct.H
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <AMReX_Gpu.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_REAL.H>
@@ -22,9 +23,11 @@ namespace pyAMReX
      * functions. The user-provided callable receives
      * (mf, dcomp, ncomp, nghost, time, bccomp) and is expected to fill
      * the ghost cells of mf that lie outside the physical domain,
-     * e.g., for external Dirichlet (BCType.ext_dir) boundaries.
+     * e.g., for external Dirichlet (BCType.ext_dir or
+     * BCType.ext_dir_cc) boundaries.
      *
-     * Note: the callback runs on the host. When called from C++, the
+     * Note: the callback runs on the host. Pending AMReX GPU stream
+     * work is synchronized before invoking it. When called from C++, the
      * pybind11 functional caster acquires the GIL automatically.
      */
     struct PhysBCFunctUser
@@ -41,7 +44,12 @@ namespace pyAMReX
                          amrex::IntVect const& nghost, amrex::Real time,
                          int bccomp)
         {
-            if (m_f) { m_f(mf, dcomp, ncomp, nghost, time, bccomp); }
+            if (m_f) {
+                // AMReX FillPatch work can be asynchronous; Python callbacks
+                // run on the host and may read or mutate host-visible data.
+                amrex::Gpu::streamSynchronize();
+                m_f(mf, dcomp, ncomp, nghost, time, bccomp);
+            }
         }
 
         UserFillFunc m_f;

--- a/src/Boundary/PhysBCFunct.cpp
+++ b/src/Boundary/PhysBCFunct.cpp
@@ -20,55 +20,134 @@ void init_PhysBCFunct(py::module& m)
     using namespace amrex;
 
     py::class_<PhysBCFunctNoOp>(m, "PhysBCFunctNoOp",
-            "A physical boundary condition functor that does nothing. "
-            "Use this if there is nothing to fill outside the physical "
-            "domain, e.g., for fully periodic domains.")
-        .def(py::init<>())
+            R"pbdoc(Physical boundary condition functor that does nothing.
+
+Use this with FillPatch-style calls when physical-domain ghost cells do
+not need additional work, for example in fully periodic domains or when
+the caller has already filled them.
+)pbdoc")
+        .def(py::init<>(),
+             "Create a no-op physical boundary functor.")
         .def("__call__", &PhysBCFunctNoOp::operator(),
              py::arg("mf"), py::arg("dcomp"), py::arg("ncomp"),
-             py::arg("nghost"), py::arg("time"), py::arg("bccomp"))
+             py::arg("nghost"), py::arg("time"), py::arg("bccomp"),
+             R"pbdoc(Apply the no-op boundary fill.
+
+The arguments match the PhysBCFunct call interface and are accepted for
+interchangeability with other physical boundary functors.
+
+Args:
+    mf: MultiFab passed by reference.
+    dcomp: First destination component.
+    ncomp: Number of destination components.
+    nghost: Number of ghost cells to consider in each direction.
+    time: Simulation time associated with the fill.
+    bccomp: First boundary-condition component.
+)pbdoc")
     ;
 
     py::class_<CpuBndryFuncFab>(m, "CpuBndryFuncFab",
-            "A boundary function functor for cell-centered data on the "
-            "host (CPU). Without a user function, it fills "
-            "BCType.foextrap, BCType.hoextrap, BCType.reflect_even and "
-            "BCType.reflect_odd boundaries; BCType.ext_dir (external "
-            "Dirichlet) values are left untouched. Use PhysBCFunctUser "
-            "to fill external Dirichlet boundaries from Python.")
-        .def(py::init<>())
+            R"pbdoc(Host boundary-fill helper for PhysBCFunct_CpuBndryFuncFab.
+
+The default-constructed helper fills extrapolation and reflection
+boundaries handled by AMReX, including BCType.foextrap,
+BCType.hoextrap, BCType.hoextrapcc, BCType.reflect_even, and
+BCType.reflect_odd. It leaves BCType.ext_dir and BCType.ext_dir_cc
+unchanged; fill external Dirichlet values separately, for example with
+PhysBCFunctUser.
+)pbdoc")
+        .def(py::init<>(),
+             "Create the default host boundary-fill helper.")
     ;
 
     py::class_<PhysBCFunct<CpuBndryFuncFab>>(m, "PhysBCFunct_CpuBndryFuncFab",
-            "A physical boundary condition functor for cell-centered data, "
-            "as amrex::PhysBCFunct<CpuBndryFuncFab> in C++. Fills domain "
-            "boundary ghost cells based on boundary condition records.")
-        .def(py::init<>())
+            R"pbdoc(Physical boundary condition functor using CpuBndryFuncFab.
+
+This wraps amrex::PhysBCFunct<CpuBndryFuncFab>. It applies the
+boundary types stored in a Vector_BCRec over the physical-domain ghost
+cells selected by a Geometry.
+)pbdoc")
+        .def(py::init<>(),
+             R"pbdoc(Create an undefined physical boundary functor.
+
+Call define() before invoking this object.
+)pbdoc")
         .def(py::init<Geometry const &, Vector<BCRec> const &,
                       CpuBndryFuncFab const &>(),
-             py::arg("geom"), py::arg("bcr"), py::arg("f"))
+             py::arg("geom"), py::arg("bc"), py::arg("bndry_func"),
+             R"pbdoc(Create a physical boundary functor.
+
+Args:
+    geom: Geometry defining the physical domain and periodic directions.
+    bc: Vector_BCRec with one record per component.
+    bndry_func: Boundary-fill helper, usually CpuBndryFuncFab().
+)pbdoc")
         .def("define",
              py::overload_cast<Geometry const &, Vector<BCRec> const &,
                                CpuBndryFuncFab const &>(
                  &PhysBCFunct<CpuBndryFuncFab>::define),
-             py::arg("geom"), py::arg("bcr"), py::arg("f"))
+             py::arg("geom"), py::arg("bc"), py::arg("bndry_func"),
+             R"pbdoc(Reset the geometry, component BC records, and boundary helper.
+
+Args:
+    geom: Geometry defining the physical domain and periodic directions.
+    bc: Vector_BCRec with one record per component.
+    bndry_func: Boundary-fill helper, usually CpuBndryFuncFab().
+)pbdoc")
         .def("__call__", &PhysBCFunct<CpuBndryFuncFab>::operator(),
-             py::arg("mf"), py::arg("icomp"), py::arg("ncomp"),
-             py::arg("nghost"), py::arg("time"), py::arg("bccomp"))
+             py::arg("mf"), py::arg("dcomp"), py::arg("ncomp"),
+             py::arg("nghost"), py::arg("time"), py::arg("bccomp"),
+             R"pbdoc(Fill physical-domain ghost cells for a component range.
+
+Args:
+    mf: MultiFab to modify in place.
+    dcomp: First destination component in mf.
+    ncomp: Number of components to fill.
+    nghost: Number of ghost cells to consider in each direction.
+    time: Simulation time associated with the fill.
+    bccomp: First component in the stored Vector_BCRec that corresponds
+        to dcomp.
+)pbdoc")
     ;
 
     py::class_<pyAMReX::PhysBCFunctUser>(m, "PhysBCFunctUser",
-            "A physical boundary condition functor calling back into "
-            "Python. The user-provided callable receives "
-            "(mf, dcomp, ncomp, nghost, time, bccomp) and is expected to "
-            "fill the ghost cells of mf that lie outside the physical "
-            "domain, e.g., for external Dirichlet (BCType.ext_dir) "
-            "boundaries. The callback runs on the host.")
-        .def(py::init<>())
+            R"pbdoc(Physical boundary condition functor implemented in Python.
+
+The callback receives (mf, dcomp, ncomp, nghost, time, bccomp). It
+should fill the ghost cells of mf that lie outside the physical domain
+for the requested component range. This is the intended hook for
+application-supplied external Dirichlet values such as BCType.ext_dir
+and BCType.ext_dir_cc.
+
+The callback runs on the host after pending AMReX GPU stream work is
+synchronized. When called from C++, pybind11 acquires the Python GIL
+before invoking the callback.
+)pbdoc")
+        .def(py::init<>(),
+             R"pbdoc(Create a user boundary functor with no callback.
+
+Calling an empty PhysBCFunctUser is a no-op.
+)pbdoc")
         .def(py::init<pyAMReX::PhysBCFunctUser::UserFillFunc>(),
-             py::arg("f"))
+             py::arg("callback"),
+             R"pbdoc(Create a user boundary functor from a Python callback.
+
+Args:
+    callback: Callable with signature
+        callback(mf, dcomp, ncomp, nghost, time, bccomp).
+)pbdoc")
         .def("__call__", &pyAMReX::PhysBCFunctUser::operator(),
              py::arg("mf"), py::arg("dcomp"), py::arg("ncomp"),
-             py::arg("nghost"), py::arg("time"), py::arg("bccomp"))
+             py::arg("nghost"), py::arg("time"), py::arg("bccomp"),
+             R"pbdoc(Invoke the Python physical-boundary callback.
+
+Args:
+    mf: MultiFab to modify in place.
+    dcomp: First destination component in mf.
+    ncomp: Number of components the callback should fill.
+    nghost: Number of ghost cells to consider in each direction.
+    time: Simulation time associated with the fill.
+    bccomp: First boundary-condition component corresponding to dcomp.
+)pbdoc")
     ;
 }

--- a/src/Boundary/PhysBCFunct.cpp
+++ b/src/Boundary/PhysBCFunct.cpp
@@ -1,0 +1,74 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include "Boundary/PhysBCFunct.H"
+
+#include <AMReX_BCRec.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_PhysBCFunct.H>
+#include <AMReX_Vector.H>
+
+
+void init_PhysBCFunct(py::module& m)
+{
+    using namespace amrex;
+
+    py::class_<PhysBCFunctNoOp>(m, "PhysBCFunctNoOp",
+            "A physical boundary condition functor that does nothing. "
+            "Use this if there is nothing to fill outside the physical "
+            "domain, e.g., for fully periodic domains.")
+        .def(py::init<>())
+        .def("__call__", &PhysBCFunctNoOp::operator(),
+             py::arg("mf"), py::arg("dcomp"), py::arg("ncomp"),
+             py::arg("nghost"), py::arg("time"), py::arg("bccomp"))
+    ;
+
+    py::class_<CpuBndryFuncFab>(m, "CpuBndryFuncFab",
+            "A boundary function functor for cell-centered data on the "
+            "host (CPU). Without a user function, it fills "
+            "BCType.foextrap, BCType.hoextrap, BCType.reflect_even and "
+            "BCType.reflect_odd boundaries; BCType.ext_dir (external "
+            "Dirichlet) values are left untouched. Use PhysBCFunctUser "
+            "to fill external Dirichlet boundaries from Python.")
+        .def(py::init<>())
+    ;
+
+    py::class_<PhysBCFunct<CpuBndryFuncFab>>(m, "PhysBCFunct_CpuBndryFuncFab",
+            "A physical boundary condition functor for cell-centered data, "
+            "as amrex::PhysBCFunct<CpuBndryFuncFab> in C++. Fills domain "
+            "boundary ghost cells based on boundary condition records.")
+        .def(py::init<>())
+        .def(py::init<Geometry const &, Vector<BCRec> const &,
+                      CpuBndryFuncFab const &>(),
+             py::arg("geom"), py::arg("bcr"), py::arg("f"))
+        .def("define",
+             py::overload_cast<Geometry const &, Vector<BCRec> const &,
+                               CpuBndryFuncFab const &>(
+                 &PhysBCFunct<CpuBndryFuncFab>::define),
+             py::arg("geom"), py::arg("bcr"), py::arg("f"))
+        .def("__call__", &PhysBCFunct<CpuBndryFuncFab>::operator(),
+             py::arg("mf"), py::arg("icomp"), py::arg("ncomp"),
+             py::arg("nghost"), py::arg("time"), py::arg("bccomp"))
+    ;
+
+    py::class_<pyAMReX::PhysBCFunctUser>(m, "PhysBCFunctUser",
+            "A physical boundary condition functor calling back into "
+            "Python. The user-provided callable receives "
+            "(mf, dcomp, ncomp, nghost, time, bccomp) and is expected to "
+            "fill the ghost cells of mf that lie outside the physical "
+            "domain, e.g., for external Dirichlet (BCType.ext_dir) "
+            "boundaries. The callback runs on the host.")
+        .def(py::init<>())
+        .def(py::init<pyAMReX::PhysBCFunctUser::UserFillFunc>(),
+             py::arg("f"))
+        .def("__call__", &pyAMReX::PhysBCFunctUser::operator(),
+             py::arg("mf"), py::arg("dcomp"), py::arg("ncomp"),
+             py::arg("nghost"), py::arg("time"), py::arg("bccomp"))
+    ;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 #add_subdirectory(Amr)
 add_subdirectory(AmrCore)
 add_subdirectory(Base)
-#add_subdirectory(Boundary)
+add_subdirectory(Boundary)
 add_subdirectory(EB)
 #add_subdirectory(Extern)
 #add_subdirectory(LinearSolvers)

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -21,6 +21,8 @@ void init_AmrMesh(py::module &);
 void init_Arena(py::module&);
 void init_Array4(py::module&);
 void init_BaseFab(py::module&);
+void init_BCRec(py::module&);
+void init_BCUtil(py::module&);
 void init_Box(py::module &);
 void init_RealBox(py::module &);
 void init_BoxArray(py::module &);
@@ -43,6 +45,7 @@ void init_ParGDB(py::module &);
 void init_ParmParse(py::module &);
 void init_ParticleContainer(py::module &);
 void init_Periodicity(py::module &);
+void init_PhysBCFunct(py::module &);
 void init_PlotFileUtil(py::module &);
 void init_PODVector(py::module &);
 void init_RealVect(py::module &);
@@ -129,12 +132,15 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     init_Geometry(m);
     init_DistributionMapping(m);
     init_BaseFab(m);
+    init_BCRec(m);  // after Box and Vector
     init_FArrayBox(m);
     py::class_< amrex::MFIter > py_MFIter(m, "MFIter", py::dynamic_attr());
     init_FabArray(m);
     init_MFInfo(m);
     init_iMultiFab(m);
     init_MultiFab(m, py_MFIter);
+    init_BCUtil(m);       // after MultiFab, Geometry and BCRec
+    init_PhysBCFunct(m);  // after MultiFab, Geometry and BCRec
     init_ParallelDescriptor(m);
     init_PODVector(m);
 

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -84,6 +84,9 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
                Box
                RealBox
                BoxArray
+               BCRec
+               BCType
+               CpuBndryFuncFab
                Dim3
                FArrayBox
                iMultiFab
@@ -100,6 +103,10 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
                ParticleTile
                ParticleContainer
                Periodicity
+               PhysBCFunctNoOp
+               PhysBCFunct_CpuBndryFuncFab
+               PhysBCFunctUser
+               PhysBCType
                PlotFileUtil
                PODVector
                SmallMatrix
@@ -108,6 +115,9 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
                TagBoxArray
                Utility
                Vector
+               Vector_BCRec
+               fill_domain_boundary
+               setBC
                VisMF
     )pbdoc";
 

--- a/tests/test_bcrec.py
+++ b/tests/test_bcrec.py
@@ -119,6 +119,29 @@ def test_set_bc_vector(std_box):
         assert bcr[n].hi() == [amr.BCType.int_dir] * sd
 
 
+def test_set_bc_vector_with_offsets(std_box):
+    sd = amr.Config.spacedim
+    bc_domain = amr.Vector_BCRec(
+        [
+            amr.BCRec(lo=[amr.BCType.foextrap] * sd, hi=[amr.BCType.ext_dir] * sd),
+            amr.BCRec(lo=[amr.BCType.hoextrap] * sd, hi=[amr.BCType.reflect_even] * sd),
+            amr.BCRec(
+                lo=[amr.BCType.reflect_odd] * sd, hi=[amr.BCType.ext_dir_cc] * sd
+            ),
+        ]
+    )
+    lo_box = amr.Box(std_box.small_end, amr.IntVect(7))
+    bcr = amr.setBC(lo_box, std_box, 1, 1, 2, bc_domain)
+
+    assert bcr.size() == 3
+    assert bcr[0].lo() == [amr.BCType.bogus] * sd
+    assert bcr[0].hi() == [amr.BCType.bogus] * sd
+    assert bcr[1].lo() == [amr.BCType.hoextrap] * sd
+    assert bcr[1].hi() == [amr.BCType.int_dir] * sd
+    assert bcr[2].lo() == [amr.BCType.reflect_odd] * sd
+    assert bcr[2].hi() == [amr.BCType.int_dir] * sd
+
+
 def test_vector_bcrec():
     sd = amr.Config.spacedim
     bcr = amr.BCRec(lo=[amr.BCType.int_dir] * sd, hi=[amr.BCType.foextrap] * sd)

--- a/tests/test_bcrec.py
+++ b/tests/test_bcrec.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+
+import amrex.space3d as amr
+
+
+def test_bctype_values():
+    # values are fixed in AMReX_BC_TYPES.H
+    assert int(amr.BCType.bogus) == -666
+    assert int(amr.BCType.reflect_odd) == -1
+    assert int(amr.BCType.int_dir) == 0
+    assert int(amr.BCType.reflect_even) == 1
+    assert int(amr.BCType.foextrap) == 2
+    assert int(amr.BCType.ext_dir) == 3
+    assert int(amr.BCType.hoextrap) == 4
+    assert int(amr.BCType.hoextrapcc) == 5
+    assert int(amr.BCType.ext_dir_cc) == 6
+    assert int(amr.BCType.direction_dependent) == 7
+
+
+def test_physbctype_values():
+    assert int(amr.PhysBCType.interior) == 0
+    assert int(amr.PhysBCType.inflow) == 1
+    assert int(amr.PhysBCType.outflow) == 2
+    assert int(amr.PhysBCType.symmetry) == 3
+    assert int(amr.PhysBCType.slipwall) == 4
+    assert int(amr.PhysBCType.noslipwall) == 5
+    assert int(amr.PhysBCType.inflowoutflow) == 6
+
+
+def test_bcrec_default():
+    bcr = amr.BCRec()
+    sd = amr.Config.spacedim
+    assert bcr.lo() == [amr.BCType.bogus] * sd
+    assert bcr.hi() == [amr.BCType.bogus] * sd
+
+
+def test_bcrec_lo_hi():
+    sd = amr.Config.spacedim
+    bcr = amr.BCRec(
+        lo=[amr.BCType.int_dir] * sd,
+        hi=[amr.BCType.foextrap] * sd,
+    )
+    assert bcr.lo() == [amr.BCType.int_dir] * sd
+    assert bcr.hi() == [amr.BCType.foextrap] * sd
+    for d in range(sd):
+        assert bcr.lo(d) == amr.BCType.int_dir
+        assert bcr.hi(d) == amr.BCType.foextrap
+    assert bcr.vect() == [amr.BCType.int_dir] * sd + [amr.BCType.foextrap] * sd
+    assert bcr.data() == bcr.vect()
+
+
+def test_bcrec_set():
+    sd = amr.Config.spacedim
+    bcr = amr.BCRec()
+    for d in range(sd):
+        bcr.set_lo(d, amr.BCType.reflect_even)
+        bcr.set_hi(d, amr.BCType.ext_dir)
+    assert bcr.lo() == [amr.BCType.reflect_even] * sd
+    assert bcr.hi() == [amr.BCType.ext_dir] * sd
+
+
+def test_bcrec_equality():
+    sd = amr.Config.spacedim
+    a = amr.BCRec(lo=[amr.BCType.int_dir] * sd, hi=[amr.BCType.int_dir] * sd)
+    b = amr.BCRec(lo=[amr.BCType.int_dir] * sd, hi=[amr.BCType.int_dir] * sd)
+    c = amr.BCRec(lo=[amr.BCType.foextrap] * sd, hi=[amr.BCType.int_dir] * sd)
+    assert a == b
+    assert a != c
+
+
+def test_bcrec_from_box(std_box):
+    """BCRec(bx, domain, bc_domain): inherits domain bndry types on the
+    domain edge, interior Dirichlet elsewhere"""
+    sd = amr.Config.spacedim
+    bc_domain = amr.BCRec(
+        lo=[amr.BCType.foextrap] * sd,
+        hi=[amr.BCType.ext_dir] * sd,
+    )
+
+    # box at the low end of the domain
+    lo_box = amr.Box(std_box.small_end, amr.IntVect(7))
+    bcr = amr.BCRec(lo_box, std_box, bc_domain)
+    assert bcr.lo() == [amr.BCType.foextrap] * sd
+    assert bcr.hi() == [amr.BCType.int_dir] * sd
+
+    # box in the interior of the domain
+    in_box = amr.Box(amr.IntVect(8), amr.IntVect(15))
+    bcr = amr.BCRec(in_box, std_box, bc_domain)
+    assert bcr.lo() == [amr.BCType.int_dir] * sd
+    assert bcr.hi() == [amr.BCType.int_dir] * sd
+
+
+def test_set_bc(std_box):
+    sd = amr.Config.spacedim
+    bc_domain = amr.BCRec(
+        lo=[amr.BCType.foextrap] * sd,
+        hi=[amr.BCType.ext_dir] * sd,
+    )
+    lo_box = amr.Box(std_box.small_end, amr.IntVect(7))
+    bcr = amr.setBC(lo_box, std_box, bc_domain)
+    assert bcr.lo() == [amr.BCType.foextrap] * sd
+    assert bcr.hi() == [amr.BCType.int_dir] * sd
+
+
+def test_set_bc_vector(std_box):
+    sd = amr.Config.spacedim
+    ncomp = 3
+    bc_domain = amr.Vector_BCRec(
+        [
+            amr.BCRec(lo=[amr.BCType.foextrap] * sd, hi=[amr.BCType.ext_dir] * sd)
+            for _ in range(ncomp)
+        ]
+    )
+    lo_box = amr.Box(std_box.small_end, amr.IntVect(7))
+    bcr = amr.setBC(lo_box, std_box, 0, 0, ncomp, bc_domain)
+    assert bcr.size() == ncomp
+    for n in range(ncomp):
+        assert bcr[n].lo() == [amr.BCType.foextrap] * sd
+        assert bcr[n].hi() == [amr.BCType.int_dir] * sd
+
+
+def test_vector_bcrec():
+    sd = amr.Config.spacedim
+    bcr = amr.BCRec(lo=[amr.BCType.int_dir] * sd, hi=[amr.BCType.foextrap] * sd)
+    v = amr.Vector_BCRec([bcr, bcr])
+    assert v.size() == 2
+    assert v[0] == bcr
+    v[1] = amr.BCRec(lo=[amr.BCType.ext_dir] * sd, hi=[amr.BCType.ext_dir] * sd)
+    assert v[1] != bcr

--- a/tests/test_fill_domain_boundary.py
+++ b/tests/test_fill_domain_boundary.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import amrex.space3d as amr
+
+
+def make_geometry(box):
+    """Non-periodic Cartesian unit-box Geometry"""
+    sd = amr.Config.spacedim
+    real_box = amr.RealBox([0.0] * sd, [1.0] * sd)
+    coord = 0  # Cartesian
+    is_per = [0] * sd
+    return amr.Geometry(box, real_box, coord, is_per)
+
+
+def valid_slices(arr_shape, n_grow_vect):
+    """Slices into the valid (non-ghost) region of a 4-axis (x,y,z,n)
+    Array4 view, for any AMREX_SPACEDIM"""
+    sd = amr.Config.spacedim
+    ng = [n_grow_vect[d] if d < sd else 0 for d in range(3)] + [0]
+    return tuple(slice(g, s - g) for g, s in zip(ng, arr_shape))
+
+
+def test_fill_domain_boundary_foextrap(std_box):
+    """foextrap of a constant field fills all ghost cells with the constant"""
+    sd = amr.Config.spacedim
+    geom = make_geometry(std_box)
+    ba = amr.BoxArray(std_box)
+    ba.max_size(32)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 1)
+
+    sentinel = -42.0
+    inner = 7.0
+
+    # fill everything (incl. ghost cells) with the sentinel, then the
+    # valid cells with a constant
+    mf.set_val(sentinel)
+    for mfi in mf:
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        arr[valid_slices(arr.shape, mf.n_grow_vect)] = inner
+
+    # first fill interior box-box ghost cells: domain corner ghosts
+    # extrapolate from them (same order as the C++ tutorials)
+    mf.fill_boundary()
+
+    bc = amr.Vector_BCRec(
+        [amr.BCRec(lo=[amr.BCType.foextrap] * sd, hi=[amr.BCType.foextrap] * sd)]
+    )
+    amr.fill_domain_boundary(mf, geom, bc)
+
+    # first-order extrapolation of a constant is the constant, everywhere
+    # (domain face, edge and corner ghost cells alike)
+    for mfi in mf:
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        assert np.all(arr == inner)
+
+
+def test_fill_domain_boundary_linear(std_box):
+    """foextrap continues a linear-in-x field flat at the x faces"""
+    sd = amr.Config.spacedim
+    geom = make_geometry(std_box)
+    ba = amr.BoxArray(std_box)  # single box
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 1)
+    mf.set_val(0.0)
+
+    for mfi in mf:
+        bx = mfi.validbox()
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        vs = valid_slices(arr.shape, mf.n_grow_vect)
+        # f(i,j,k) = i (cell index in x)
+        i = np.arange(bx.small_end[0], bx.big_end[0] + 1)
+        arr[vs] = i[(slice(None),) + (np.newaxis,) * 3]
+
+    bc = amr.Vector_BCRec(
+        [amr.BCRec(lo=[amr.BCType.foextrap] * sd, hi=[amr.BCType.foextrap] * sd)]
+    )
+    amr.fill_domain_boundary(mf, geom, bc)
+
+    for mfi in mf:
+        bx = mfi.validbox()
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        vs = valid_slices(arr.shape, mf.n_grow_vect)
+        # x-lo face ghosts equal the first valid cell (flat extrapolation)
+        lo_ghost = arr[(slice(0, 1),) + vs[1:]]
+        assert np.all(lo_ghost == bx.small_end[0])
+        # x-hi face ghosts equal the last valid cell
+        hi_ghost = arr[(slice(-1, None),) + vs[1:]]
+        assert np.all(hi_ghost == bx.big_end[0])
+
+
+def test_physbcfunct_noop(std_box):
+    """PhysBCFunctNoOp leaves ghost cells untouched"""
+    geom = make_geometry(std_box)  # noqa: F841
+    ba = amr.BoxArray(std_box)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 1)
+
+    sentinel = -42.0
+    mf.set_val(sentinel)
+
+    physbc = amr.PhysBCFunctNoOp()
+    physbc(mf, 0, 1, mf.n_grow_vect, 0.0, 0)
+
+    for mfi in mf:
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        assert np.all(arr == sentinel)
+
+
+def test_physbcfunct_cpu(std_box):
+    """PhysBCFunct_CpuBndryFuncFab fills domain ghost cells like
+    fill_domain_boundary"""
+    sd = amr.Config.spacedim
+    geom = make_geometry(std_box)
+    ba = amr.BoxArray(std_box)  # single box: all ghosts are domain ghosts
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 1)
+
+    sentinel = -42.0
+    inner = 7.0
+    mf.set_val(sentinel)
+    for mfi in mf:
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        arr[valid_slices(arr.shape, mf.n_grow_vect)] = inner
+
+    bc = amr.Vector_BCRec(
+        [amr.BCRec(lo=[amr.BCType.foextrap] * sd, hi=[amr.BCType.foextrap] * sd)]
+    )
+    bndry_func = amr.CpuBndryFuncFab()
+    physbc = amr.PhysBCFunct_CpuBndryFuncFab(geom, bc, bndry_func)
+    physbc(mf, 0, 1, mf.n_grow_vect, 0.0, 0)
+
+    for mfi in mf:
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        assert np.all(arr == inner)
+
+
+def test_physbcfunct_user(std_box):
+    """PhysBCFunctUser calls back into Python with reference semantics"""
+    geom = make_geometry(std_box)  # noqa: F841
+    ba = amr.BoxArray(std_box)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 1)
+    mf.set_val(0.0)
+
+    called = {}
+
+    def fill(mf_arg, dcomp, ncomp, nghost, time, bccomp):
+        called["args"] = (dcomp, ncomp, nghost, time, bccomp)
+        # mutate through the callback argument: reference semantics
+        mf_arg.set_val(99.0)
+
+    physbc = amr.PhysBCFunctUser(fill)
+    physbc(mf, 0, 1, mf.n_grow_vect, 1.5, 0)
+
+    assert called["args"][0] == 0
+    assert called["args"][1] == 1
+    assert called["args"][3] == 1.5
+    assert np.isclose(mf.max(0), 99.0)
+    assert np.isclose(mf.min(0), 99.0)

--- a/tests/test_fill_domain_boundary.py
+++ b/tests/test_fill_domain_boundary.py
@@ -93,7 +93,6 @@ def test_fill_domain_boundary_linear(std_box):
 
 def test_physbcfunct_noop(std_box):
     """PhysBCFunctNoOp leaves ghost cells untouched"""
-    geom = make_geometry(std_box)  # noqa: F841
     ba = amr.BoxArray(std_box)
     dm = amr.DistributionMapping(ba)
     mf = amr.MultiFab(ba, dm, 1, 1)
@@ -137,12 +136,42 @@ def test_physbcfunct_cpu(std_box):
         assert np.all(arr == inner)
 
 
-def test_physbcfunct_user(std_box):
-    """PhysBCFunctUser calls back into Python with reference semantics"""
-    geom = make_geometry(std_box)  # noqa: F841
+def test_physbcfunct_cpu_with_offsets(std_box):
+    sd = amr.Config.spacedim
+    geom = make_geometry(std_box)
     ba = amr.BoxArray(std_box)
     dm = amr.DistributionMapping(ba)
-    mf = amr.MultiFab(ba, dm, 1, 1)
+    mf = amr.MultiFab(ba, dm, 2, 1)
+
+    sentinel = -42.0
+    inner = 7.0
+    mf.set_val(sentinel)
+    for mfi in mf:
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        vs = valid_slices(arr.shape, mf.n_grow_vect)
+        arr[vs[:-1] + (slice(1, 2),)] = inner
+
+    bc = amr.Vector_BCRec(
+        [
+            amr.BCRec(lo=[amr.BCType.ext_dir] * sd, hi=[amr.BCType.ext_dir] * sd),
+            amr.BCRec(lo=[amr.BCType.foextrap] * sd, hi=[amr.BCType.foextrap] * sd),
+        ]
+    )
+    bndry_func = amr.CpuBndryFuncFab()
+    physbc = amr.PhysBCFunct_CpuBndryFuncFab(geom, bc, bndry_func)
+    physbc(mf, 1, 1, mf.n_grow_vect, 0.0, 1)
+
+    for mfi in mf:
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        assert np.all(arr[..., 0] == sentinel)
+        assert np.all(arr[..., 1] == inner)
+
+
+def test_physbcfunct_user(std_box):
+    """PhysBCFunctUser calls back into Python with reference semantics"""
+    ba = amr.BoxArray(std_box)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 2, 1)
     mf.set_val(0.0)
 
     called = {}
@@ -150,13 +179,16 @@ def test_physbcfunct_user(std_box):
     def fill(mf_arg, dcomp, ncomp, nghost, time, bccomp):
         called["args"] = (dcomp, ncomp, nghost, time, bccomp)
         # mutate through the callback argument: reference semantics
-        mf_arg.set_val(99.0)
+        mf_arg.set_val(99.0, dcomp, ncomp)
 
     physbc = amr.PhysBCFunctUser(fill)
-    physbc(mf, 0, 1, mf.n_grow_vect, 1.5, 0)
+    physbc(mf, 1, 1, mf.n_grow_vect, 1.5, 2)
 
-    assert called["args"][0] == 0
+    assert called["args"][0] == 1
     assert called["args"][1] == 1
     assert called["args"][3] == 1.5
-    assert np.isclose(mf.max(0), 99.0)
-    assert np.isclose(mf.min(0), 99.0)
+    assert called["args"][4] == 2
+    assert np.isclose(mf.max(0), 0.0)
+    assert np.isclose(mf.min(0), 0.0)
+    assert np.isclose(mf.max(1), 99.0)
+    assert np.isclose(mf.min(1), 99.0)


### PR DESCRIPTION
Add the Boundary module with bindings for:
- BCType and PhysBCType enums (AMReX_BC_TYPES.H)
- BCRec and Vector<BCRec>, incl. the setBC helper functions
- fill_domain_boundary (AMReX_BCUtil.H)
- PhysBCFunctNoOp, CpuBndryFuncFab, PhysBCFunct<CpuBndryFuncFab> ("PhysBCFunct_CpuBndryFuncFab")
- PhysBCFunctUser: a physical boundary condition functor calling back into Python at the MultiFab level, e.g., for external Dirichlet (BCType.ext_dir) fills

checklist:
- [x] rebase after #582
- [x] ensure doc strings, args and sphinx docs are complete & user-friendly