### PR TITLE
MultiFabUtil & IO, AmrCore app support, ParmParse & ParallelDescriptor

### DIFF
--- a/docs/source/usage/api.rst
+++ b/docs/source/usage/api.rst
@@ -251,6 +251,31 @@ Data Containers
    :members:
    :undoc-members:
 
+MultiFab Operations
+"""""""""""""""""""
+
+Averaging operations between AMR levels and between data centerings.
+Functions that take one ``MultiFab`` per coordinate direction expect a list
+of exactly ``AMREX_SPACEDIM`` entries and raise ``ValueError`` otherwise.
+
+.. autofunction:: amrex.space3d.average_down
+
+.. autofunction:: amrex.space3d.average_down_faces
+
+.. autofunction:: amrex.space3d.average_down_edges
+
+.. autofunction:: amrex.space3d.average_down_nodal
+
+.. autofunction:: amrex.space3d.average_node_to_cellcenter
+
+.. autofunction:: amrex.space3d.average_edge_to_cellcenter
+
+.. autofunction:: amrex.space3d.average_face_to_cellcenter
+
+.. autofunction:: amrex.space3d.average_cellcenter_to_face
+
+.. autofunction:: amrex.space3d.sum_fine_to_coarse
+
 Small Matrices and Vectors
 """"""""""""""""""""""""""
 
@@ -278,6 +303,27 @@ Utility
 .. autoclass:: amrex.space3d.PlotFileData
    :members:
    :undoc-members:
+
+Plotfile paths and directories, e.g. to write a multi-level plotfile
+incrementally:
+
+.. autofunction:: amrex.space3d.level_path
+
+.. autofunction:: amrex.space3d.multifab_header_path
+
+.. autofunction:: amrex.space3d.level_full_path
+
+.. autofunction:: amrex.space3d.multifab_file_full_prefix
+
+.. autofunction:: amrex.space3d.pre_build_director_hierarchy
+
+.. autofunction:: amrex.space3d.util_create_directory
+
+.. autofunction:: amrex.space3d.util_create_clean_directory
+
+.. autofunction:: amrex.space3d.util_create_directory_destructive
+
+.. autofunction:: amrex.space3d.file_exists
 
 
 .. _usage-api-amrcore:
@@ -342,6 +388,56 @@ particle metadata broker returned by ``core.get_par_gdb()``.
    :undoc-members:
 
 .. autoclass:: amrex.space3d.AmrParGDB
+   :members:
+   :undoc-members:
+
+Interpolaters
+"""""""""""""
+
+Interpolaters map data from coarse to fine levels. They cannot (yet) be
+implemented in Python, since their per-FAB ``interp`` methods are called in
+performance-critical inner loops. Use the global instances below, which are
+the same objects as their C++ counterparts:
+
+``pc_interp``, ``node_bilinear_interp``, ``cell_bilinear_interp``,
+``cell_cons_interp``, ``lincc_interp``, ``protected_interp``,
+``quartic_interp``, ``quadratic_interp``, ``cell_quartic_interp``,
+``face_linear_interp``, ``face_divfree_interp``, ``face_cons_linear_interp``
+and the ``MFInterpolater`` variants ``mf_pc_interp``,
+``mf_cell_cons_interp``, ``mf_lincc_interp``,
+``mf_linear_slope_minmax_interp``, ``mf_cell_bilinear_interp`` and
+``mf_node_bilinear_interp``.
+
+.. autoclass:: amrex.space3d.InterpBase
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.Interpolater
+   :members:
+   :undoc-members:
+
+.. autoclass:: amrex.space3d.MFInterpolater
+   :members:
+   :undoc-members:
+
+FillPatch
+"""""""""
+
+Fill a ``MultiFab``, including its ghost cells, from same-level and/or
+coarse-level data. ``mapper`` accepts any ``Interpolater`` or
+``MFInterpolater``; ``physbcf`` accepts ``PhysBCFunctNoOp``,
+``PhysBCFunct_CpuBndryFuncFab`` or a Python ``PhysBCFunctUser``.
+
+.. autofunction:: amrex.space3d.fill_patch_single_level
+
+.. autofunction:: amrex.space3d.fill_patch_two_levels
+
+.. autofunction:: amrex.space3d.interp_from_coarse_level
+
+Flux Registers
+""""""""""""""
+
+.. autoclass:: amrex.space3d.FluxRegister
    :members:
    :undoc-members:
 

--- a/src/AmrCore/AmrCore.cpp
+++ b/src/AmrCore/AmrCore.cpp
@@ -20,6 +20,7 @@
 #   include <AMReX_AmrParGDB.H>
 #endif
 
+#include <functional>
 #include <memory>
 #include <sstream>
 
@@ -50,6 +51,8 @@ namespace
             int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow
         ) override
         {
+            // pass the (non-copyable) TagBoxArray by reference, so that
+            // tags set in Python propagate back to AMReX
             PYBIND11_OVERRIDE_PURE_NAME(
                 void, amrex::AmrCore, "error_est", ErrorEst,
                 lev, py::cast(&tags, py::return_value_policy::reference),

--- a/src/AmrCore/AmrMesh.cpp
+++ b/src/AmrCore/AmrMesh.cpp
@@ -81,5 +81,49 @@ void init_AmrMesh(py::module &m)
         .def("set_geometry", &AmrMesh::SetGeometry,
              py::arg("lev"), py::arg("geom_in"),
              "Replace the Geometry stored for AMR level lev.")
+
+        .def("box_array",
+             py::overload_cast< int >(&AmrMesh::boxArray, py::const_),
+             py::return_value_policy::reference_internal, py::arg("lev"),
+             "Return the BoxArray of level lev.")
+        .def("dist_map",
+             py::overload_cast< int >(&AmrMesh::DistributionMap, py::const_),
+             py::return_value_policy::reference_internal, py::arg("lev"),
+             "Return the DistributionMapping of level lev.")
+        .def("set_box_array", &AmrMesh::SetBoxArray,
+             py::arg("lev"), py::arg("ba_in"))
+        .def("set_dist_map", &AmrMesh::SetDistributionMap,
+             py::arg("lev"), py::arg("dm_in"))
+        .def("clear_box_array", &AmrMesh::ClearBoxArray, py::arg("lev"))
+        .def("clear_dist_map", &AmrMesh::ClearDistributionMap,
+             py::arg("lev"))
+
+        .def("blocking_factor",
+             [](AmrMesh const & amr_mesh, int lev)
+             { return amr_mesh.blockingFactor(lev); },
+             py::arg("lev"),
+             "Return the blocking factor at level lev.")
+        .def("max_grid_size",
+             [](AmrMesh const & amr_mesh, int lev)
+             { return amr_mesh.maxGridSize(lev); },
+             py::arg("lev"),
+             "Return the largest allowed grid size at level lev.")
+        .def("n_error_buf",
+             [](AmrMesh const & amr_mesh, int lev)
+             { return amr_mesh.nErrorBuf(lev); },
+             py::arg("lev"),
+             "Return the number of cells by which the tagged region is "
+             "buffered at level lev.")
+        .def("max_ref_ratio",
+             [](AmrMesh const & amr_mesh, int lev)
+             { return amr_mesh.MaxRefRatio(lev); },
+             py::arg("lev"),
+             "Return the maximum over the components of ref_ratio(lev).")
+
+        .def("count_cells", &AmrMesh::CountCells, py::arg("lev"),
+             "Return the number of cells at level lev.")
+        .def("level_defined", &AmrMesh::LevelDefined, py::arg("lev"),
+             "Return whether BoxArray and DistributionMapping are defined "
+             "at level lev.")
     ;
 }

--- a/src/AmrCore/AmrMesh.cpp
+++ b/src/AmrCore/AmrMesh.cpp
@@ -71,6 +71,10 @@ void init_AmrMesh(py::module &m)
         .def_property_readonly("verbose", &AmrMesh::Verbose)
         .def_property_readonly("max_level", &AmrMesh::maxLevel)
         .def_property_readonly("finest_level", &AmrMesh::finestLevel)
+        .def("set_finest_level", &AmrMesh::SetFinestLevel,
+             py::arg("new_finest_level"),
+             "Update the recorded finest level index (without "
+             "reallocating), e.g., when restarting from a checkpoint.")
         .def("ref_ratio", py::overload_cast< >(&AmrMesh::refRatio, py::const_))
         .def("ref_ratio", py::overload_cast< int >(&AmrMesh::refRatio, py::const_))
 

--- a/src/AmrCore/CMakeLists.txt
+++ b/src/AmrCore/CMakeLists.txt
@@ -3,6 +3,9 @@ foreach(D IN LISTS AMReX_SPACEDIM)
       PRIVATE
         AmrCore.cpp
         AmrMesh.cpp
+        FillPatchUtil.cpp
+        FluxRegister.cpp
+        Interpolater.cpp
         TagBox.cpp
     )
 endforeach()

--- a/src/AmrCore/FillPatchUtil.cpp
+++ b/src/AmrCore/FillPatchUtil.cpp
@@ -1,0 +1,150 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include "Boundary/PhysBCFunct.H"
+
+#include <AMReX_BCRec.H>
+#include <AMReX_FillPatchUtil.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_Interpolater.H>
+#include <AMReX_InterpBase.H>
+#include <AMReX_MFInterpolater.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_PhysBCFunct.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+
+#include <string>
+#include <vector>
+
+
+namespace
+{
+    using namespace amrex;
+
+    /** Dispatch on the dynamic type of an InterpBase* mapper.
+     *
+     * The FillPatch functions are templated on the interpolater type:
+     * accept any bound InterpBase in Python and dispatch to the matching
+     * instantiation.
+     */
+    template< typename F >
+    void dispatch_mapper (InterpBase* mapper, F&& f)
+    {
+        if (auto* interp = dynamic_cast<Interpolater*>(mapper)) {
+            f(interp);
+        } else if (auto* mf_interp = dynamic_cast<MFInterpolater*>(mapper)) {
+            f(mf_interp);
+        } else {
+            throw py::value_error(
+                "mapper must be an Interpolater or MFInterpolater");
+        }
+    }
+
+    template< typename BC >
+    void register_fill_patch (py::module& m)
+    {
+        m.def("fill_patch_single_level",
+              [](MultiFab & mf, Real time,
+                 std::vector<MultiFab*> const & smf,
+                 std::vector<Real> const & stime,
+                 int scomp, int dcomp, int ncomp,
+                 Geometry const & geom, BC & physbcf, int bcfcomp)
+              {
+                  FillPatchSingleLevel(
+                      mf, time,
+                      Vector<MultiFab*>(smf.begin(), smf.end()),
+                      Vector<Real>(stime.begin(), stime.end()),
+                      scomp, dcomp, ncomp, geom, physbcf, bcfcomp);
+              },
+              py::arg("mf"), py::arg("time"),
+              py::arg("smf"), py::arg("stime"),
+              py::arg("scomp"), py::arg("dcomp"), py::arg("ncomp"),
+              py::arg("geom"), py::arg("physbcf"), py::arg("bcfcomp"),
+              "Fill mf (incl. ghost cells) with data on the same level: "
+              "valid data from (time-interpolated) smf/stime source data, "
+              "ghost cells from intra-level and periodic copies plus the "
+              "physical boundary functor physbcf.");
+
+        m.def("fill_patch_two_levels",
+              [](MultiFab & mf, Real time,
+                 std::vector<MultiFab*> const & cmf,
+                 std::vector<Real> const & ct,
+                 std::vector<MultiFab*> const & fmf,
+                 std::vector<Real> const & ft,
+                 int scomp, int dcomp, int ncomp,
+                 Geometry const & cgeom, Geometry const & fgeom,
+                 BC & cbc, int cbccomp, BC & fbc, int fbccomp,
+                 IntVect const & ratio, InterpBase* mapper,
+                 Vector<BCRec> const & bcs, int bcscomp)
+              {
+                  dispatch_mapper(mapper, [&](auto* interp) {
+                      FillPatchTwoLevels(
+                          mf, time,
+                          Vector<MultiFab*>(cmf.begin(), cmf.end()),
+                          Vector<Real>(ct.begin(), ct.end()),
+                          Vector<MultiFab*>(fmf.begin(), fmf.end()),
+                          Vector<Real>(ft.begin(), ft.end()),
+                          scomp, dcomp, ncomp, cgeom, fgeom,
+                          cbc, cbccomp, fbc, fbccomp, ratio, interp,
+                          bcs, bcscomp);
+                  });
+              },
+              py::arg("mf"), py::arg("time"),
+              py::arg("cmf"), py::arg("ct"), py::arg("fmf"), py::arg("ft"),
+              py::arg("scomp"), py::arg("dcomp"), py::arg("ncomp"),
+              py::arg("cgeom"), py::arg("fgeom"),
+              py::arg("cbc"), py::arg("cbccomp"),
+              py::arg("fbc"), py::arg("fbccomp"),
+              py::arg("ratio"), py::arg("mapper"),
+              py::arg("bcs"), py::arg("bcscomp"),
+              "Fill mf (incl. ghost cells) with data from the fine level "
+              "it lives on (fmf/ft) where possible, and spatially "
+              "interpolated (mapper, with bcs boundary conditions) from "
+              "the coarse level (cmf/ct) elsewhere. Includes time "
+              "interpolation of the source data.");
+
+        m.def("interp_from_coarse_level",
+              [](MultiFab & mf, Real time, MultiFab const & cmf,
+                 int scomp, int dcomp, int ncomp,
+                 Geometry const & cgeom, Geometry const & fgeom,
+                 BC & cbc, int cbccomp, BC & fbc, int fbccomp,
+                 IntVect const & ratio, InterpBase* mapper,
+                 Vector<BCRec> const & bcs, int bcscomp)
+              {
+                  dispatch_mapper(mapper, [&](auto* interp) {
+                      InterpFromCoarseLevel(
+                          mf, time, cmf, scomp, dcomp, ncomp, cgeom, fgeom,
+                          cbc, cbccomp, fbc, fbccomp, ratio, interp,
+                          bcs, bcscomp);
+                  });
+              },
+              py::arg("mf"), py::arg("time"), py::arg("cmf"),
+              py::arg("scomp"), py::arg("dcomp"), py::arg("ncomp"),
+              py::arg("cgeom"), py::arg("fgeom"),
+              py::arg("cbc"), py::arg("cbccomp"),
+              py::arg("fbc"), py::arg("fbccomp"),
+              py::arg("ratio"), py::arg("mapper"),
+              py::arg("bcs"), py::arg("bcscomp"),
+              "Fill mf (incl. ghost cells) entirely by spatial "
+              "interpolation (mapper, with bcs boundary conditions) from "
+              "the coarse level data cmf. This comes into play, e.g., "
+              "when a new level of refinement appears.");
+    }
+}
+
+
+void init_FillPatchUtil(py::module& m)
+{
+    using namespace amrex;
+
+    // overloads for each bound physical boundary condition functor type
+    register_fill_patch< PhysBCFunctNoOp >(m);
+    register_fill_patch< PhysBCFunct<CpuBndryFuncFab> >(m);
+    register_fill_patch< pyAMReX::PhysBCFunctUser >(m);
+}

--- a/src/AmrCore/FluxRegister.cpp
+++ b/src/AmrCore/FluxRegister.cpp
@@ -1,0 +1,123 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_FluxRegister.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+
+#include <sstream>
+
+
+void init_FluxRegister(py::module& m)
+{
+    using namespace amrex;
+
+    py::class_<FluxRegister> py_flux_register(m, "FluxRegister",
+        "Stores and manipulates fluxes at coarse-fine interfaces, for "
+        "conservative flux corrections (refluxing) of cell-centered data "
+        "in AMR simulations.");
+
+    py::native_enum<FluxRegister::FrOp>(py_flux_register, "FrOp",
+            "enum.IntEnum",
+            "Whether to copy or add fluxes into the register")
+        .value("COPY", FluxRegister::COPY)
+        .value("ADD", FluxRegister::ADD)
+        .finalize()
+    ;
+
+    py_flux_register
+        .def("__repr__",
+             [](FluxRegister const & fr) {
+                 std::stringstream s;
+                 s << fr.nComp();
+                 return "<amrex.FluxRegister with '" + s.str() +
+                        "' components>";
+             }
+        )
+
+        .def(py::init<>())
+        .def(py::init<BoxArray const &, DistributionMapping const &,
+                      IntVect const &, int, int>(),
+             py::arg("fine_boxes"), py::arg("dm"), py::arg("ref_ratio"),
+             py::arg("fine_lev"), py::arg("nvar"))
+
+        .def_property_readonly("fine_level", &FluxRegister::fineLevel,
+             "Returns the level number of the fine level.")
+        .def_property_readonly("crse_level", &FluxRegister::crseLevel,
+             "Returns the level number of the coarse level "
+             "(fine_level - 1).")
+        .def_property_readonly("n_comp", &FluxRegister::nComp,
+             "Returns the number of components.")
+        .def_property_readonly("ref_ratio", &FluxRegister::refRatio,
+             "Returns the refinement ratio.")
+
+        .def("set_val", &FluxRegister::setVal, py::arg("val"),
+             "Set all registers to val.")
+
+        .def("sum_reg", &FluxRegister::SumReg, py::arg("comp"),
+             "Returns the sum over all registers of component comp.")
+
+        .def("crse_init",
+             py::overload_cast<MultiFab const &, int, int, int, int, Real,
+                               FluxRegister::FrOp>(&FluxRegister::CrseInit),
+             py::arg("mflx"), py::arg("dir"), py::arg("srccomp"),
+             py::arg("destcomp"), py::arg("numcomp"),
+             py::arg("mult") = -1.0,
+             py::arg_v("op", FluxRegister::COPY, "FrOp.COPY"),
+             "Initialize flux correction with coarse data (area already "
+             "applied).")
+        .def("crse_init",
+             py::overload_cast<MultiFab const &, MultiFab const &, int, int,
+                               int, int, Real, FluxRegister::FrOp>(
+                 &FluxRegister::CrseInit),
+             py::arg("mflx"), py::arg("area"), py::arg("dir"),
+             py::arg("srccomp"), py::arg("destcomp"), py::arg("numcomp"),
+             py::arg("mult") = -1.0,
+             py::arg_v("op", FluxRegister::COPY, "FrOp.COPY"),
+             "Initialize flux correction with coarse data and explicit "
+             "face areas.")
+
+        .def("fine_add",
+             py::overload_cast<MultiFab const &, int, int, int, int, Real>(
+                 &FluxRegister::FineAdd),
+             py::arg("mflx"), py::arg("dir"), py::arg("srccomp"),
+             py::arg("destcomp"), py::arg("numcomp"), py::arg("mult"),
+             "Increment flux correction with fine data (area already "
+             "applied).")
+        .def("fine_add",
+             py::overload_cast<MultiFab const &, MultiFab const &, int, int,
+                               int, int, Real>(&FluxRegister::FineAdd),
+             py::arg("mflx"), py::arg("area"), py::arg("dir"),
+             py::arg("srccomp"), py::arg("destcomp"), py::arg("numcomp"),
+             py::arg("mult"),
+             "Increment flux correction with fine data and explicit face "
+             "areas.")
+
+        .def("reflux",
+             py::overload_cast<MultiFab &, Real, int, int, int,
+                               Geometry const &>(&FluxRegister::Reflux),
+             py::arg("mf"), py::arg("scale"), py::arg("scomp"),
+             py::arg("dcomp"), py::arg("nc"), py::arg("crse_geom"),
+             "Apply the flux correction to the coarse MultiFab mf "
+             "(constant-volume version).")
+        .def("reflux",
+             py::overload_cast<MultiFab &, MultiFab const &, Real, int, int,
+                               int, Geometry const &>(&FluxRegister::Reflux),
+             py::arg("mf"), py::arg("volume"), py::arg("scale"),
+             py::arg("scomp"), py::arg("dcomp"), py::arg("nc"),
+             py::arg("crse_geom"),
+             "Apply the flux correction to the coarse MultiFab mf, with "
+             "explicit cell volumes.")
+
+        .def("clear_internal_borders",
+             &FluxRegister::ClearInternalBorders, py::arg("crse_geom"),
+             "Set internal borders to zero.")
+    ;
+}

--- a/src/AmrCore/Interpolater.cpp
+++ b/src/AmrCore/Interpolater.cpp
@@ -1,0 +1,122 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_Interpolater.H>
+#include <AMReX_InterpBase.H>
+#include <AMReX_MFInterpolater.H>
+
+
+void init_Interpolater(py::module& m)
+{
+    using namespace amrex;
+
+    // abstract base classes: no Python constructors. Custom interpolaters
+    // cannot (yet) be implemented in Python: the per-FAB interp() methods
+    // are called in performance-critical inner loops.
+    py::class_<InterpBase>(m, "InterpBase");
+    py::class_<Interpolater, InterpBase>(m, "Interpolater",
+        "Virtual base class for grid interpolaters, mapping data from "
+        "coarse to fine levels.");
+    py::class_<MFInterpolater, InterpBase>(m, "MFInterpolater",
+        "Virtual base class for MultiFab-level grid interpolaters, "
+        "mapping data from coarse to fine levels.");
+
+    // concrete Interpolater types
+    py::class_<PCInterp, Interpolater>(m, "PCInterp",
+        "Piecewise constant interpolation on cell-centered data.");
+    py::class_<NodeBilinear, Interpolater>(m, "NodeBilinear",
+        "Bilinear interpolation on node-centered data.");
+    py::class_<CellBilinear, Interpolater>(m, "CellBilinear",
+        "Bilinear interpolation on cell-centered data.");
+    py::class_<CellConservativeLinear, Interpolater>(
+        m, "CellConservativeLinear",
+        "Linear conservative interpolation on cell-centered data, i.e, "
+        "conservative interpolation with a limiting scheme that "
+        "preserves the value of any linear combination of the fab "
+        "components.");
+    py::class_<CellConservativeProtected, CellConservativeLinear>(
+        m, "CellConservativeProtected",
+        "Lin. cons. interp. on cc data with protection against under- or "
+        "overshoots.");
+    py::class_<CellConservativeQuartic, Interpolater>(
+        m, "CellConservativeQuartic",
+        "Quartic interpolation on cell-centered data, i.e, conservative "
+        "quartic interpolation with a limiting scheme that preserves the "
+        "value of any linear combination of the fab components.");
+    py::class_<CellQuadratic, Interpolater>(m, "CellQuadratic",
+        "Quadratic interpolation on cell-centered data.");
+    py::class_<CellQuartic, Interpolater>(m, "CellQuartic",
+        "Quartic interpolation on cell-centered data.");
+    py::class_<FaceDivFree, Interpolater>(m, "FaceDivFree",
+        "Divergence-preserving interpolation on face-centered data.");
+    py::class_<FaceLinear, Interpolater>(m, "FaceLinear",
+        "Piecewise constant tangential interpolation / linear normal "
+        "interpolation of face data.");
+    py::class_<FaceConservativeLinear, Interpolater>(
+        m, "FaceConservativeLinear",
+        "Bilinear tangential interpolation / linear normal interpolation "
+        "of face data.");
+
+    // concrete MFInterpolater types
+    py::class_<MFPCInterp, MFInterpolater>(m, "MFPCInterp",
+        "Piecewise constant interpolation on cell-centered data.");
+    py::class_<MFCellConsLinInterp, MFInterpolater>(
+        m, "MFCellConsLinInterp",
+        "Linear conservative interpolation on cell centered data.");
+    py::class_<MFCellConsLinMinmaxLimitInterp, MFInterpolater>(
+        m, "MFCellConsLinMinmaxLimitInterp",
+        "Linear conservative interpolation on cell centered data with "
+        "the minmax limiter.");
+    py::class_<MFCellBilinear, MFInterpolater>(m, "MFCellBilinear",
+        "Bilinear interpolation on cell-centered data.");
+    py::class_<MFNodeBilinear, MFInterpolater>(m, "MFNodeBilinear",
+        "Bilinear interpolation on node-centered data.");
+
+    // global singleton instances (defined in AMReX); handed out as
+    // non-owning references
+    m.attr("pc_interp") = py::cast(&pc_interp,
+                                   py::return_value_policy::reference);
+    m.attr("node_bilinear_interp") =
+        py::cast(&node_bilinear_interp, py::return_value_policy::reference);
+    m.attr("face_divfree_interp") =
+        py::cast(&face_divfree_interp, py::return_value_policy::reference);
+    m.attr("face_linear_interp") =
+        py::cast(&face_linear_interp, py::return_value_policy::reference);
+    m.attr("face_cons_linear_interp") =
+        py::cast(&face_cons_linear_interp,
+                 py::return_value_policy::reference);
+    m.attr("lincc_interp") = py::cast(&lincc_interp,
+                                      py::return_value_policy::reference);
+    m.attr("cell_cons_interp") =
+        py::cast(&cell_cons_interp, py::return_value_policy::reference);
+    m.attr("cell_bilinear_interp") =
+        py::cast(&cell_bilinear_interp, py::return_value_policy::reference);
+    m.attr("protected_interp") =
+        py::cast(&protected_interp, py::return_value_policy::reference);
+    m.attr("quartic_interp") =
+        py::cast(&quartic_interp, py::return_value_policy::reference);
+    m.attr("quadratic_interp") =
+        py::cast(&quadratic_interp, py::return_value_policy::reference);
+    m.attr("cell_quartic_interp") =
+        py::cast(&cell_quartic_interp, py::return_value_policy::reference);
+
+    m.attr("mf_pc_interp") =
+        py::cast(&mf_pc_interp, py::return_value_policy::reference);
+    m.attr("mf_cell_cons_interp") =
+        py::cast(&mf_cell_cons_interp, py::return_value_policy::reference);
+    m.attr("mf_lincc_interp") =
+        py::cast(&mf_lincc_interp, py::return_value_policy::reference);
+    m.attr("mf_linear_slope_minmax_interp") =
+        py::cast(&mf_linear_slope_minmax_interp,
+                 py::return_value_policy::reference);
+    m.attr("mf_cell_bilinear_interp") =
+        py::cast(&mf_cell_bilinear_interp,
+                 py::return_value_policy::reference);
+    m.attr("mf_node_bilinear_interp") =
+        py::cast(&mf_node_bilinear_interp,
+                 py::return_value_policy::reference);
+}

--- a/src/AmrCore/TagBox.cpp
+++ b/src/AmrCore/TagBox.cpp
@@ -105,7 +105,9 @@ non-owning views and should not be stored after the override returns.
              py::arg("mfi"),
              // do not copy via brace init list
              py::return_value_policy::move,
-             "Return the Array4 (of char) of the tags in the box of mfi.")
+             "Return the Array4 (of char) of the tags in the box of mfi. "
+             "Viewed as an array, the dtype is a 1-byte integer whose "
+             "signedness follows the platform's plain char (int8 or uint8).")
         .def("const_array",
              [](TagBoxArray const& tags, MFIter const& mfi) {
                  return tags.const_array(mfi);
@@ -113,7 +115,10 @@ non-owning views and should not be stored after the override returns.
              py::arg("mfi"),
              // do not copy via brace init list
              py::return_value_policy::move,
-             "Return the read-only Array4 (of char) of the tags in the box of mfi.")
+             "Return the read-only Array4 (of char) of the tags in the box "
+             "of mfi. Viewed as an array, the dtype is a 1-byte integer "
+             "whose signedness follows the platform's plain char (int8 or "
+             "uint8).")
 
         .def("set_val",
              [](TagBoxArray& tags, TagBox::TagVal val) {

--- a/src/AmrCore/TagBox.cpp
+++ b/src/AmrCore/TagBox.cpp
@@ -5,12 +5,14 @@
  */
 #include "pyAMReX.H"
 
+#include <AMReX_Array4.H>
 #include <AMReX_Box.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_FabArrayBase.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_IntVect.H>
+#include <AMReX_MFIter.H>
 #include <AMReX_TagBox.H>
 
 #include <sstream>
@@ -95,6 +97,23 @@ non-owning views and should not be stored after the override returns.
              [](TagBoxArray const& tags) { return tags.DistributionMap(); },
              py::return_value_policy::reference_internal,
              "DistributionMapping defining ownership of this tag array.")
+
+        .def("array",
+             [](TagBoxArray& tags, MFIter const& mfi) {
+                 return tags.array(mfi);
+             },
+             py::arg("mfi"),
+             // do not copy via brace init list
+             py::return_value_policy::move,
+             "Return the Array4 (of char) of the tags in the box of mfi.")
+        .def("const_array",
+             [](TagBoxArray const& tags, MFIter const& mfi) {
+                 return tags.const_array(mfi);
+             },
+             py::arg("mfi"),
+             // do not copy via brace init list
+             py::return_value_policy::move,
+             "Return the read-only Array4 (of char) of the tags in the box of mfi.")
 
         .def("set_val",
              [](TagBoxArray& tags, TagBox::TagVal val) {

--- a/src/Base/Array4_int.cpp
+++ b/src/Base/Array4_int.cpp
@@ -14,6 +14,7 @@ void init_Array4_int(py::module &m)
 {
     using namespace pyAMReX;
 
+    make_Array4< char >(m, "char");
     make_Array4< short >(m, "short");
     make_Array4< int >(m, "int");
     make_Array4< long >(m, "long");

--- a/src/Base/Array4_int_const.cpp
+++ b/src/Base/Array4_int_const.cpp
@@ -14,6 +14,7 @@ void init_Array4_int_const(py::module &m)
 {
     using namespace pyAMReX;
 
+    make_Array4< char const >(m, "char_const");
     make_Array4< short const >(m, "short_const");
     make_Array4< int const >(m, "int_const");
     make_Array4< long const >(m, "long_const");

--- a/src/Base/BoxArray.cpp
+++ b/src/Base/BoxArray.cpp
@@ -47,6 +47,9 @@ void init_BoxArray(py::module &m) {
         //BoxArray (const BoxArray& rhs, const BATransformer& trans);
         //BoxArray (BoxList&& bl, IntVect const& max_grid_size);
 
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+
         .def_property_readonly("size", &BoxArray::size)
         .def_property_readonly("capacity", &BoxArray::capacity)
         .def_property_readonly("empty", &BoxArray::empty)

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
         SmallMatrix.cpp
         MFInfo.cpp
         MultiFab.cpp
+        MultiFabUtil.cpp
         ParallelDescriptor.cpp
         ParGDB.cpp
         ParmParse.cpp

--- a/src/Base/MultiFabUtil.cpp
+++ b/src/Base/MultiFabUtil.cpp
@@ -5,6 +5,7 @@
  */
 #include "pyAMReX.H"
 
+#include <AMReX_Array.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_MultiFab.H>
@@ -124,6 +125,25 @@ void init_MultiFabUtil (py::module& m)
           py::arg("ratio"), py::arg("ngcrse") = 0,
           "Average fine face-based MultiFabs (one per direction) onto "
           "crse face-based MultiFabs.");
+    m.def("average_down_faces",
+          [](std::vector<MultiFab*> const & fine,
+             std::vector<MultiFab*> const & crse,
+             IntVect const & ratio, Geometry const & crse_geom)
+          {
+              check_num_dirs("fine", fine.size());
+              check_num_dirs("crse", crse.size());
+              Array<MultiFab const*, AMREX_SPACEDIM> c_fine;
+              Array<MultiFab*, AMREX_SPACEDIM> v_crse;
+              for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                  c_fine[d] = fine[d];
+                  v_crse[d] = crse[d];
+              }
+              average_down_faces(c_fine, v_crse, ratio, crse_geom);
+          },
+          py::arg("fine"), py::arg("crse"),
+          py::arg("ratio"), py::arg("crse_geom"),
+          "Average fine face-based MultiFabs (one per direction) onto "
+          "crse face-based MultiFabs, taking periodicity into account.");
     m.def("average_down_faces",
           [](FabArray<FArrayBox> const & fine, FabArray<FArrayBox> & crse,
              IntVect const & ratio, int ngcrse)

--- a/src/Base/MultiFabUtil.cpp
+++ b/src/Base/MultiFabUtil.cpp
@@ -201,7 +201,11 @@ void init_MultiFabUtil (py::module& m)
     m.def("average_node_to_cellcenter",
           [](MultiFab & cc, int dcomp, MultiFab const & nd,
              int scomp, int ncomp, int ngrow)
-          { average_node_to_cellcenter(cc, dcomp, nd, scomp, ncomp, ngrow); },
+          {
+              check_num_comp("cc", cc.nComp(), dcomp + ncomp);
+              check_num_comp("nd", nd.nComp(), scomp + ncomp);
+              average_node_to_cellcenter(cc, dcomp, nd, scomp, ncomp, ngrow);
+          },
           py::arg("cc"), py::arg("dcomp"),
           py::arg("nd"), py::arg("scomp"), py::arg("ncomp"),
           py::arg("ngrow") = 0,

--- a/src/Base/MultiFabUtil.cpp
+++ b/src/Base/MultiFabUtil.cpp
@@ -1,0 +1,247 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_Vector.H>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+
+namespace
+{
+    /** Convert a (Python list grown) std::vector of pointers to an
+     *  amrex::Vector of const pointers. */
+    template< class T >
+    amrex::Vector< T const* >
+    to_const_vector (std::vector< T* > const & in)
+    {
+        amrex::Vector< T const* > out;
+        out.reserve(in.size());
+        for (auto const * ptr : in) { out.push_back(ptr); }
+        return out;
+    }
+
+    template< class T >
+    amrex::Vector< T* >
+    to_vector (std::vector< T* > const & in)
+    {
+        return amrex::Vector< T* >(in.begin(), in.end());
+    }
+
+    /** Throw a ValueError if a per-direction MultiFab list has the wrong
+     *  number of entries. */
+    void check_num_dirs (std::string const & name, std::size_t size)
+    {
+        if (size != AMREX_SPACEDIM) {
+            throw py::value_error(
+                name + " must have exactly AMREX_SPACEDIM=" +
+                std::to_string(AMREX_SPACEDIM) + " entries (one per "
+                "direction), got " + std::to_string(size));
+        }
+    }
+
+    /** Throw a ValueError if a MultiFab has too few components. */
+    void check_num_comp (std::string const & name, int ncomp, int needed)
+    {
+        if (ncomp < needed) {
+            throw py::value_error(
+                name + " needs at least " + std::to_string(needed) +
+                " components, got " + std::to_string(ncomp));
+        }
+    }
+}
+
+
+void init_MultiFabUtil (py::module& m)
+{
+    using namespace amrex;
+
+    constexpr auto doc_average_down =
+        "Average fine MultiFab onto crse MultiFab. Both MultiFabs are "
+        "assumed to be cell-centered. This routine DOES NOT assume that "
+        "the crse BoxArray is a coarsened version of the fine BoxArray. "
+        "Includes volume weighting for curvilinear coordinates.";
+    m.def("average_down",
+          [](MultiFab const & S_fine, MultiFab & S_crse,
+             Geometry const & fgeom, Geometry const & cgeom,
+             int scomp, int ncomp, IntVect const & ratio)
+          { average_down(S_fine, S_crse, fgeom, cgeom, scomp, ncomp, ratio); },
+          py::arg("S_fine"), py::arg("S_crse"),
+          py::arg("fgeom"), py::arg("cgeom"),
+          py::arg("scomp"), py::arg("ncomp"), py::arg("ratio"),
+          doc_average_down);
+    m.def("average_down",
+          [](MultiFab const & S_fine, MultiFab & S_crse,
+             Geometry const & fgeom, Geometry const & cgeom,
+             int scomp, int ncomp, int ratio)
+          { average_down(S_fine, S_crse, fgeom, cgeom, scomp, ncomp, ratio); },
+          py::arg("S_fine"), py::arg("S_crse"),
+          py::arg("fgeom"), py::arg("cgeom"),
+          py::arg("scomp"), py::arg("ncomp"), py::arg("ratio"),
+          doc_average_down);
+
+    constexpr auto doc_average_down_no_geom =
+        "Average fine MultiFab onto crse MultiFab without volume "
+        "weighting. This routine DOES NOT assume that the crse BoxArray "
+        "is a coarsened version of the fine BoxArray. Works for both "
+        "cell-centered and nodal MultiFabs.";
+    m.def("average_down",
+          [](FabArray<FArrayBox> const & S_fine, FabArray<FArrayBox> & S_crse,
+             int scomp, int ncomp, IntVect const & ratio)
+          { average_down(S_fine, S_crse, scomp, ncomp, ratio); },
+          py::arg("S_fine"), py::arg("S_crse"),
+          py::arg("scomp"), py::arg("ncomp"), py::arg("ratio"),
+          doc_average_down_no_geom);
+    m.def("average_down",
+          [](FabArray<FArrayBox> const & S_fine, FabArray<FArrayBox> & S_crse,
+             int scomp, int ncomp, int ratio)
+          { average_down(S_fine, S_crse, scomp, ncomp, ratio); },
+          py::arg("S_fine"), py::arg("S_crse"),
+          py::arg("scomp"), py::arg("ncomp"), py::arg("ratio"),
+          doc_average_down_no_geom);
+
+    m.def("average_down_faces",
+          [](std::vector<MultiFab*> const & fine,
+             std::vector<MultiFab*> const & crse,
+             IntVect const & ratio, int ngcrse)
+          {
+              check_num_dirs("fine", fine.size());
+              check_num_dirs("crse", crse.size());
+              auto const c_fine = to_const_vector(fine);
+              auto v_crse = to_vector(crse);
+              average_down_faces(c_fine, v_crse, ratio, ngcrse);
+          },
+          py::arg("fine"), py::arg("crse"),
+          py::arg("ratio"), py::arg("ngcrse") = 0,
+          "Average fine face-based MultiFabs (one per direction) onto "
+          "crse face-based MultiFabs.");
+    m.def("average_down_faces",
+          [](FabArray<FArrayBox> const & fine, FabArray<FArrayBox> & crse,
+             IntVect const & ratio, int ngcrse)
+          { average_down_faces(fine, crse, ratio, ngcrse); },
+          py::arg("fine"), py::arg("crse"),
+          py::arg("ratio"), py::arg("ngcrse") = 0,
+          "Average down for one face direction. It uses the IndexType of "
+          "the MultiFabs to determine the direction. It is expected that "
+          "one direction is nodal and the rest are cell-centered.");
+    m.def("average_down_faces",
+          [](FabArray<FArrayBox> const & fine, FabArray<FArrayBox> & crse,
+             IntVect const & ratio, Geometry const & crse_geom)
+          { average_down_faces(fine, crse, ratio, crse_geom); },
+          py::arg("fine"), py::arg("crse"),
+          py::arg("ratio"), py::arg("crse_geom"),
+          "Average down for one face direction, taking periodicity into "
+          "account.");
+
+    m.def("average_down_edges",
+          [](std::vector<MultiFab*> const & fine,
+             std::vector<MultiFab*> const & crse,
+             IntVect const & ratio, int ngcrse)
+          {
+              check_num_dirs("fine", fine.size());
+              check_num_dirs("crse", crse.size());
+              auto const c_fine = to_const_vector(fine);
+              auto v_crse = to_vector(crse);
+              average_down_edges(c_fine, v_crse, ratio, ngcrse);
+          },
+          py::arg("fine"), py::arg("crse"),
+          py::arg("ratio"), py::arg("ngcrse") = 0,
+          "Average fine edge-based MultiFabs (one per direction) onto "
+          "crse edge-based MultiFabs.");
+    m.def("average_down_edges",
+          [](MultiFab const & fine, MultiFab & crse,
+             IntVect const & ratio, int ngcrse)
+          { average_down_edges(fine, crse, ratio, ngcrse); },
+          py::arg("fine"), py::arg("crse"),
+          py::arg("ratio"), py::arg("ngcrse") = 0,
+          "Average down for one edge direction. It uses the IndexType of "
+          "the MultiFabs to determine the direction. It is expected that "
+          "one direction is cell-centered and the rest are nodal.");
+
+    m.def("average_down_nodal",
+          [](FabArray<FArrayBox> const & fine, FabArray<FArrayBox> & crse,
+             IntVect const & ratio, int ngcrse, bool mfiter_is_definitely_safe)
+          { average_down_nodal(fine, crse, ratio, ngcrse,
+                               mfiter_is_definitely_safe); },
+          py::arg("fine"), py::arg("crse"),
+          py::arg("ratio"), py::arg("ngcrse") = 0,
+          py::arg("mfiter_is_definitely_safe") = false,
+          "Average fine node-based MultiFab onto crse node-centered "
+          "MultiFab.");
+
+    m.def("average_node_to_cellcenter",
+          [](MultiFab & cc, int dcomp, MultiFab const & nd,
+             int scomp, int ncomp, int ngrow)
+          { average_node_to_cellcenter(cc, dcomp, nd, scomp, ncomp, ngrow); },
+          py::arg("cc"), py::arg("dcomp"),
+          py::arg("nd"), py::arg("scomp"), py::arg("ncomp"),
+          py::arg("ngrow") = 0,
+          "Average nodal-based MultiFab onto cell-centered MultiFab.");
+
+    m.def("average_edge_to_cellcenter",
+          [](MultiFab & cc, int dcomp,
+             std::vector<MultiFab*> const & edge, int ngrow)
+          {
+              check_num_dirs("edge", edge.size());
+              check_num_comp("cc", cc.nComp(), dcomp + AMREX_SPACEDIM);
+              auto const c_edge = to_const_vector(edge);
+              average_edge_to_cellcenter(cc, dcomp, c_edge, ngrow);
+          },
+          py::arg("cc"), py::arg("dcomp"), py::arg("edge"),
+          py::arg("ngrow") = 0,
+          "Average edge-based MultiFabs (one per direction) onto a "
+          "cell-centered MultiFab.");
+
+    m.def("average_face_to_cellcenter",
+          [](MultiFab & cc, int dcomp,
+             std::vector<MultiFab*> const & fc, int ngrow)
+          {
+              check_num_dirs("fc", fc.size());
+              check_num_comp("cc", cc.nComp(), dcomp + AMREX_SPACEDIM);
+              auto const c_fc = to_const_vector(fc);
+              average_face_to_cellcenter(cc, dcomp, c_fc, ngrow);
+          },
+          py::arg("cc"), py::arg("dcomp"), py::arg("fc"),
+          py::arg("ngrow") = 0,
+          "Average face-based MultiFabs (one per direction) onto a "
+          "cell-centered MultiFab.");
+
+    m.def("average_cellcenter_to_face",
+          [](std::vector<MultiFab*> const & fc, MultiFab const & cc,
+             Geometry const & geom, int ncomp,
+             bool use_harmonic_averaging, int ngrow)
+          {
+              check_num_dirs("fc", fc.size());
+              check_num_comp("cc", cc.nComp(), ncomp);
+              if (cc.nGrowVect().min() < ngrow + 1) {
+                  throw py::value_error(
+                      "cc needs at least ngrow+1 ghost cells");
+              }
+              auto v_fc = to_vector(fc);
+              average_cellcenter_to_face(v_fc, cc, geom, ncomp,
+                                         use_harmonic_averaging, ngrow);
+          },
+          py::arg("fc"), py::arg("cc"), py::arg("geom"),
+          py::arg("ncomp") = 1,
+          py::arg("use_harmonic_averaging") = false,
+          py::arg("ngrow") = 0,
+          "Average a cell-centered MultiFab onto face-based MultiFabs "
+          "(one per direction) with geometric weighting.");
+
+    m.def("sum_fine_to_coarse",
+          &sum_fine_to_coarse,
+          py::arg("S_fine"), py::arg("S_crse"),
+          py::arg("scomp"), py::arg("ncomp"), py::arg("ratio"),
+          py::arg("cgeom"), py::arg("fgeom"),
+          "Add a coarsened version of the data contained in the S_fine "
+          "MultiFab to S_crse, including ghost cells.");
+}

--- a/src/Base/ParallelDescriptor.cpp
+++ b/src/Base/ParallelDescriptor.cpp
@@ -7,6 +7,8 @@
 
 #include <AMReX_ParallelDescriptor.H>
 
+#include <vector>
+
 
 void init_ParallelDescriptor(py::module &m)
 {
@@ -18,6 +20,50 @@ void init_ParallelDescriptor(py::module &m)
        .def("MyProc", py::overload_cast<>(&ParallelDescriptor::MyProc))
        .def("IOProcessor", py::overload_cast<>(&ParallelDescriptor::IOProcessor))
        .def("IOProcessorNumber", py::overload_cast<>(&ParallelDescriptor::IOProcessorNumber))
+
+       .def("Barrier", [](){ ParallelDescriptor::Barrier(); })
+
+       // note: in Python, the reduced values are returned (arguments
+       // are not modified in place)
+       .def("ReduceRealMin",
+            [](Real v){ ParallelDescriptor::ReduceRealMin(v); return v; })
+       .def("ReduceRealMin",
+            [](std::vector<Real> v){
+                ParallelDescriptor::ReduceRealMin(v.data(), int(v.size()));
+                return v;
+            })
+       .def("ReduceRealMax",
+            [](Real v){ ParallelDescriptor::ReduceRealMax(v); return v; })
+       .def("ReduceRealMax",
+            [](std::vector<Real> v){
+                ParallelDescriptor::ReduceRealMax(v.data(), int(v.size()));
+                return v;
+            })
+       .def("ReduceRealSum",
+            [](Real v){ ParallelDescriptor::ReduceRealSum(v); return v; })
+       .def("ReduceRealSum",
+            [](std::vector<Real> v){
+                ParallelDescriptor::ReduceRealSum(v.data(), int(v.size()));
+                return v;
+            })
+
+       .def("ReduceIntMin",
+            [](int v){ ParallelDescriptor::ReduceIntMin(v); return v; })
+       .def("ReduceIntMax",
+            [](int v){ ParallelDescriptor::ReduceIntMax(v); return v; })
+       .def("ReduceIntSum",
+            [](int v){ ParallelDescriptor::ReduceIntSum(v); return v; })
+
+       .def("ReduceLongMin",
+            [](Long v){ ParallelDescriptor::ReduceLongMin(v); return v; })
+       .def("ReduceLongMax",
+            [](Long v){ ParallelDescriptor::ReduceLongMax(v); return v; })
+       .def("ReduceLongSum",
+            [](Long v){ ParallelDescriptor::ReduceLongSum(v); return v; })
+
+       .def("ReduceBoolAnd",
+            [](bool v){ ParallelDescriptor::ReduceBoolAnd(v); return v; })
+       .def("ReduceBoolOr",
+            [](bool v){ ParallelDescriptor::ReduceBoolOr(v); return v; })
    ;
-    // ...
 }

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -9,11 +9,55 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_ParmParse.H>
 
+#include <algorithm>
+#include <cstddef>
 #include <functional>
 #include <iostream>
 #include <string>
 #include <string_view>
 #include <vector>
+
+
+namespace
+{
+    /** Read an array-valued ParmParse entry.
+     *
+     * amrex::ParmParse::getarr indexes its output by the absolute value
+     * index: it writes into ref[start_ix, start_ix+num_val) and leaves the
+     * leading entries default-constructed. Return only the requested slice.
+     *
+     * num_val == -1 requests all values after start_ix. Passing AMReX's
+     * "all values" sentinel straight through would ask for num_val values
+     * starting at start_ix, i.e. run past the end and abort.
+     */
+    template< typename T >
+    std::vector<T>
+    get_arr (amrex::ParmParse & pp, std::string const & name,
+             int start_ix, int num_val)
+    {
+        if (start_ix < 0) {
+            throw py::value_error("start_ix must be non-negative, got " +
+                                  std::to_string(start_ix));
+        }
+        if (num_val < -1) {
+            throw py::value_error("num_val must be -1 (all values after "
+                                  "start_ix) or non-negative, got " +
+                                  std::to_string(num_val));
+        }
+        if (num_val == -1) {
+            num_val = std::max(pp.countval(name.c_str()) - start_ix, 0);
+        }
+
+        std::vector<T> ref;
+        pp.getarr(name, ref, start_ix, num_val);
+
+        // drop the default-constructed [0, start_ix) entries
+        auto const skip = std::min(static_cast<std::size_t>(start_ix),
+                                   ref.size());
+        ref.erase(ref.begin(), ref.begin() + static_cast<std::ptrdiff_t>(skip));
+        return ref;
+    }
+}
 
 
 void init_ParmParse(py::module &m)
@@ -128,34 +172,28 @@ void init_ParmParse(py::module &m)
 
         .def("get_int_arr",
             [](ParmParse &pp, std::string name, int start_ix, int num_val) {
-                std::vector<int> ref;
-                if (num_val == -1) { num_val = pp.countval(name.c_str()); }
-                pp.getarr(name, ref, start_ix, num_val);
-                return ref;
+                return get_arr<int>(pp, name, start_ix, num_val);
             },
-            "parses an array of input values",
+            "parses an array of input values, starting at index start_ix; "
+            "num_val=-1 returns all values after start_ix",
             py::arg("name"), py::arg("start_ix")=0, py::arg("num_val")=-1
         )
 
         .def("get_real_arr",
             [](ParmParse &pp, std::string name, int start_ix, int num_val) {
-                std::vector<amrex::Real> ref;
-                if (num_val == -1) { num_val = pp.countval(name.c_str()); }
-                pp.getarr(name, ref, start_ix, num_val);
-                return ref;
+                return get_arr<amrex::Real>(pp, name, start_ix, num_val);
             },
-            "parses an array of input values",
+            "parses an array of input values, starting at index start_ix; "
+            "num_val=-1 returns all values after start_ix",
             py::arg("name"), py::arg("start_ix")=0, py::arg("num_val")=-1
         )
 
         .def("get_str_arr",
             [](ParmParse &pp, std::string name, int start_ix, int num_val) {
-                std::vector<std::string> ref;
-                if (num_val == -1) { num_val = pp.countval(name.c_str()); }
-                pp.getarr(name, ref, start_ix, num_val);
-                return ref;
+                return get_arr<std::string>(pp, name, start_ix, num_val);
             },
-            "parses an array of input values",
+            "parses an array of input values, starting at index start_ix; "
+            "num_val=-1 returns all values after start_ix",
             py::arg("name"), py::arg("start_ix")=0, py::arg("num_val")=-1
         )
 

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -90,9 +90,27 @@ void init_ParmParse(py::module &m)
             "parses input values", py::arg("name"), py::arg("ival")=0
         )
 
+        .def("query_bool",
+            [](ParmParse &pp, std::string name, int ival) {
+                bool ref = false;
+                bool exist = pp.query(name, ref, ival);
+                return std::make_tuple(exist,ref);
+            },
+            "queries input values", py::arg("name"), py::arg("ival")=0
+        )
+
         .def("query_int",
             [](ParmParse &pp, std::string name, int ival) {
-                int ref;
+                int ref = 0;
+                bool exist = pp.query(name, ref, ival);
+                return std::make_tuple(exist,ref);
+            },
+            "queries input values", py::arg("name"), py::arg("ival")=0
+        )
+
+        .def("query_real",
+            [](ParmParse &pp, std::string name, int ival) {
+                amrex::Real ref = 0.;
                 bool exist = pp.query(name, ref, ival);
                 return std::make_tuple(exist,ref);
             },
@@ -106,6 +124,74 @@ void init_ParmParse(py::module &m)
                 return std::make_tuple(exist,ref);
             },
             "queries input values", py::arg("name"), py::arg("ival")=0
+        )
+
+        .def("get_int_arr",
+            [](ParmParse &pp, std::string name, int start_ix, int num_val) {
+                std::vector<int> ref;
+                if (num_val == -1) { num_val = pp.countval(name.c_str()); }
+                pp.getarr(name, ref, start_ix, num_val);
+                return ref;
+            },
+            "parses an array of input values",
+            py::arg("name"), py::arg("start_ix")=0, py::arg("num_val")=-1
+        )
+
+        .def("get_real_arr",
+            [](ParmParse &pp, std::string name, int start_ix, int num_val) {
+                std::vector<amrex::Real> ref;
+                if (num_val == -1) { num_val = pp.countval(name.c_str()); }
+                pp.getarr(name, ref, start_ix, num_val);
+                return ref;
+            },
+            "parses an array of input values",
+            py::arg("name"), py::arg("start_ix")=0, py::arg("num_val")=-1
+        )
+
+        .def("get_str_arr",
+            [](ParmParse &pp, std::string name, int start_ix, int num_val) {
+                std::vector<std::string> ref;
+                if (num_val == -1) { num_val = pp.countval(name.c_str()); }
+                pp.getarr(name, ref, start_ix, num_val);
+                return ref;
+            },
+            "parses an array of input values",
+            py::arg("name"), py::arg("start_ix")=0, py::arg("num_val")=-1
+        )
+
+        .def("query_int_arr",
+            [](ParmParse &pp, std::string name) {
+                std::vector<int> ref;
+                bool exist = pp.queryarr(name, ref);
+                return std::make_tuple(exist,ref);
+            },
+            "queries an array of input values", py::arg("name")
+        )
+
+        .def("query_real_arr",
+            [](ParmParse &pp, std::string name) {
+                std::vector<amrex::Real> ref;
+                bool exist = pp.queryarr(name, ref);
+                return std::make_tuple(exist,ref);
+            },
+            "queries an array of input values", py::arg("name")
+        )
+
+        .def("query_str_arr",
+            [](ParmParse &pp, std::string name) {
+                std::vector<std::string> ref;
+                bool exist = pp.queryarr(name, ref);
+                return std::make_tuple(exist,ref);
+            },
+            "queries an array of input values", py::arg("name")
+        )
+
+        .def("countval",
+            [](ParmParse &pp, std::string name) {
+                return pp.countval(name.c_str());
+            },
+            "Returns the number of values associated with a parameter",
+            py::arg("name")
         )
 
         .def(
@@ -127,6 +213,11 @@ void init_ParmParse(py::module &m)
             "to_dict",
             [](ParmParse &pp) {
                 py::dict d;
+
+                // note: the table names below are fully qualified; use an
+                // unprefixed ParmParse for the value lookups, independent
+                // of the prefix of pp
+                ParmParse pp_root;
 
                 auto g_table = pp.table();
 
@@ -172,7 +263,7 @@ void init_ParmParse(py::module &m)
                                 [&](auto&& arg) {
                                     using T = std::remove_pointer_t<std::decay_t<decltype(arg)>>;
                                     T v;
-                                    pp.get(name, v);
+                                    pp_root.get(name, v);
                                     add_nested(v, name);
                                 },
                                 entry.m_typehint
@@ -183,7 +274,7 @@ void init_ParmParse(py::module &m)
                                     using T = std::remove_pointer_t<std::decay_t<decltype(arg)>>;
                                     if constexpr (!std::is_same_v<T, bool>) {
                                         std::vector<T> valarr;
-                                        pp.getarr(name, valarr);
+                                        pp_root.getarr(name, valarr);
                                         add_nested(valarr, name);
                                     }
                                 },

--- a/src/Base/PlotFileUtil.cpp
+++ b/src/Base/PlotFileUtil.cpp
@@ -4,8 +4,12 @@
  */
 #include "pyAMReX.H"
 
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_Print.H>
+#include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 
 #include <sstream>
@@ -64,6 +68,33 @@ void init_PlotFileUtil(py::module &m) {
         py::arg("ref_ratio"), py::arg("versionName") = "HyperCLaw-V1.1",
         py::arg("levelPrefix") = "Level_", py::arg("mfPrefix") = "Cell",
         py::arg_v("extra_dirs", std::vector<std::string>(), "list[str]"));
+
+  m.def("level_path", &amrex::LevelPath,
+        "return the path of the Level directory, e.g., Level_5",
+        py::arg("level"), py::arg("levelPrefix") = "Level_");
+  m.def("multifab_header_path", &amrex::MultiFabHeaderPath,
+        "return the path of the MultiFab to write to the header, "
+        "e.g., Level_5/Cell",
+        py::arg("level"), py::arg("levelPrefix") = "Level_",
+        py::arg("mfPrefix") = "Cell");
+  m.def("level_full_path", &amrex::LevelFullPath,
+        "return the full path of the Level directory, e.g., "
+        "plt00005/Level_5",
+        py::arg("level"), py::arg("plotfilename"),
+        py::arg("levelPrefix") = "Level_");
+  m.def("multifab_file_full_prefix", &amrex::MultiFabFileFullPrefix,
+        "return the full path MultiFab prefix, e.g., plt00005/Level_5/Cell",
+        py::arg("level"), py::arg("plotfilename"),
+        py::arg("levelPrefix") = "Level_", py::arg("mfPrefix") = "Cell");
+  m.def("pre_build_director_hierarchy", &amrex::PreBuildDirectorHierarchy,
+        "prebuild a hierarchy of directories. dirName is built first; if "
+        "dirName exists, it is renamed. Then dirName/Level_0 .. "
+        "dirName/Level_{nSubDirs-1} are built. If callBarrier is true, "
+        "ParallelDescriptor::Barrier() is called after all directories "
+        "are built; ParallelDescriptor::IOProcessor() creates the "
+        "directories",
+        py::arg("dirName"), py::arg("subDirPrefix"), py::arg("nSubDirs"),
+        py::arg("callBarrier"));
 
   py::class_<PlotFileData>(m, "PlotFileData")
       // explicitly provide constructor argument types

--- a/src/Base/Utility.cpp
+++ b/src/Base/Utility.cpp
@@ -17,4 +17,31 @@ void init_Utility(py::module& m)
           "Builds plotfile name",
           py::arg("root"), py::arg("num"), py::arg("mindigits")=5
     );
+
+    m.def("util_create_directory",
+          [](std::string const & path, bool verbose) {
+              return amrex::UtilCreateDirectory(path, 0755, verbose);
+          },
+          "Creates the specified directories. path may be either a full "
+          "pathname or a relative pathname. It will create all the "
+          "directories in the pathname, if they don't already exist.",
+          py::arg("path"), py::arg("verbose") = false
+    );
+    m.def("util_create_clean_directory",
+          &amrex::UtilCreateCleanDirectory,
+          "Create a new directory, renaming the old one if it exists",
+          py::arg("path"), py::arg("callbarrier") = true
+    );
+    m.def("util_create_directory_destructive",
+          &amrex::UtilCreateDirectoryDestructive,
+          "Create a new directory, removing the old one if it exists",
+          py::arg("path"), py::arg("callbarrier") = true
+    );
+    m.def("file_exists",
+          &amrex::FileExists,
+          "Check if a file already exists. Return true if the filename "
+          "is an existing file, directory, or link. For links, this "
+          "operates on the link and not what the link points to.",
+          py::arg("filename")
+    );
 }

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -33,7 +33,10 @@ void init_Dim3(py::module&);
 void init_DistributionMapping(py::module&);
 void init_FabArray(py::module &);
 void init_FArrayBox(py::module&);
+void init_FillPatchUtil(py::module&);
+void init_FluxRegister(py::module&);
 void init_Geometry(py::module&);
+void init_Interpolater(py::module&);
 void init_iMultiFab(py::module&);
 void init_IndexType(py::module &);
 void init_IntVect(py::module &);
@@ -155,9 +158,12 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     init_MFInfo(m);
     init_iMultiFab(m);
     init_MultiFab(m, py_MFIter);
-    init_MultiFabUtil(m); // after MultiFab, iMultiFab and Geometry
-    init_BCUtil(m);       // after MultiFab, Geometry and BCRec
-    init_PhysBCFunct(m);  // after MultiFab, Geometry and BCRec
+    init_MultiFabUtil(m);   // after MultiFab, iMultiFab and Geometry
+    init_BCUtil(m);         // after MultiFab, Geometry and BCRec
+    init_PhysBCFunct(m);    // after MultiFab, Geometry and BCRec
+    init_Interpolater(m);
+    init_FillPatchUtil(m);  // after PhysBCFunct, Interpolater and BCRec
+    init_FluxRegister(m);   // after MultiFab and Geometry
     init_ParallelDescriptor(m);
     init_PODVector(m);
 

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -42,6 +42,7 @@ void init_MFInfo(py::module &);
 void init_MPMD(py::module &);
 #endif
 void init_MultiFab(py::module &, py::class_< amrex::MFIter >&);
+void init_MultiFabUtil(py::module &);
 void init_ParallelDescriptor(py::module &);
 void init_ParGDB(py::module &);
 void init_ParmParse(py::module &);
@@ -154,6 +155,7 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     init_MFInfo(m);
     init_iMultiFab(m);
     init_MultiFab(m, py_MFIter);
+    init_MultiFabUtil(m); // after MultiFab, iMultiFab and Geometry
     init_BCUtil(m);       // after MultiFab, Geometry and BCRec
     init_PhysBCFunct(m);  // after MultiFab, Geometry and BCRec
     init_ParallelDescriptor(m);

--- a/tests/test_amrcore_fillpatch.py
+++ b/tests/test_amrcore_fillpatch.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import amrex.space3d as amr
+
+
+def valid_slices(arr_shape, n_grow_vect):
+    """Slices into the valid (non-ghost) region of a 4-axis (x,y,z,n)
+    Array4 view"""
+    sd = amr.Config.spacedim
+    ng = [n_grow_vect[d] if d < sd else 0 for d in range(3)] + [0]
+    return tuple(slice(g, s - g) for g, s in zip(ng, arr_shape))
+
+
+class GaussianCore(amr.AmrCore):
+    """A two-level AmrCore mirroring the structure of the
+    Advection_AmrCore tutorial: a Gaussian profile, tagged by threshold,
+    with FillPatch/InterpFromCoarseLevel-based level construction."""
+
+    def __init__(self, n_cell=32):
+        sd = amr.Config.spacedim
+        rb = amr.RealBox([0.0] * sd, [1.0] * sd)
+        max_level = 1
+        super().__init__(
+            rb,
+            max_level,
+            amr.Vector_int([n_cell] * sd),
+            0,  # Cartesian
+            amr.Vector_IntVect([amr.IntVect(2)] * max_level),
+            [1] * sd,  # fully periodic
+        )
+        self.phi = [None] * (max_level + 1)
+        self.bcs = amr.Vector_BCRec(
+            [
+                amr.BCRec(
+                    lo=[amr.BCType.int_dir] * sd,
+                    hi=[amr.BCType.int_dir] * sd,
+                )
+            ]
+        )
+        self.physbc = amr.PhysBCFunctNoOp()  # fully periodic
+        self.tag_threshold = 1.0e30  # nothing tagged until lowered
+        self.calls = []
+
+    def fill_gaussian(self, lev, mf):
+        """phi = 1 + exp(-(r - r_center)^2 / 0.01) at cell centers"""
+        sd = amr.Config.spacedim
+        geom_data = self.geom(lev).data()
+        dx = geom_data.CellSize()
+        for mfi in mf:
+            bx = mfi.validbox()
+            arr = mf.array(mfi).to_xp(copy=False, order="F")
+            vs = valid_slices(arr.shape, mf.n_grow_vect)
+            rsq = 0.0
+            for d in range(sd):
+                x = (np.arange(bx.small_end[d], bx.big_end[d] + 1) + 0.5) * dx[d]
+                rsq = rsq + ((x - 0.5) ** 2).reshape(
+                    [-1 if i == d else 1 for i in range(4)]
+                )
+            arr[vs] = 1.0 + np.exp(-rsq / 0.01)
+        mf.fill_boundary(self.geom(lev).periodicity())
+
+    # pure virtual overrides ------------------------------------------
+    def make_new_level_from_scratch(self, lev, time, ba, dm):
+        self.calls.append(("scratch", lev))
+        self.phi[lev] = amr.MultiFab(ba, dm, 1, 1)
+        self.fill_gaussian(lev, self.phi[lev])
+
+    def make_new_level_from_coarse(self, lev, time, ba, dm):
+        self.calls.append(("coarse", lev))
+        mf = amr.MultiFab(ba, dm, 1, 1)
+        amr.interp_from_coarse_level(
+            mf,
+            time,
+            self.phi[lev - 1],
+            0,
+            0,
+            1,
+            self.geom(lev - 1),
+            self.geom(lev),
+            self.physbc,
+            0,
+            self.physbc,
+            0,
+            self.ref_ratio(lev - 1),
+            amr.cell_cons_interp,
+            self.bcs,
+            0,
+        )
+        self.phi[lev] = mf
+
+    def remake_level(self, lev, time, ba, dm):
+        self.calls.append(("remake", lev))
+        mf = amr.MultiFab(ba, dm, 1, 1)
+        amr.fill_patch_two_levels(
+            mf,
+            time,
+            [self.phi[lev - 1]],
+            [time],
+            [self.phi[lev]],
+            [time],
+            0,
+            0,
+            1,
+            self.geom(lev - 1),
+            self.geom(lev),
+            self.physbc,
+            0,
+            self.physbc,
+            0,
+            self.ref_ratio(lev - 1),
+            amr.cell_cons_interp,
+            self.bcs,
+            0,
+        )
+        self.phi[lev] = mf
+
+    def clear_level(self, lev):
+        self.calls.append(("clear", lev))
+        self.phi[lev] = None
+
+    def error_est(self, lev, tags, time, ngrow):
+        self.calls.append(("error_est", lev))
+        phi = self.phi[lev]
+        for mfi in phi:
+            phi_arr = phi.array(mfi).to_xp(copy=False, order="F")
+            phi_valid = phi_arr[valid_slices(phi_arr.shape, phi.n_grow_vect)]
+            tag_arr = tags.array(mfi).to_xp(copy=False, order="F")
+            tag_valid = tag_arr[valid_slices(tag_arr.shape, tags.n_grow_vect)]
+            tag_valid[phi_valid > self.tag_threshold] = amr.TagBox.SET
+
+
+def test_amrcore_two_level_lifecycle():
+    core = GaussianCore()
+    sd = amr.Config.spacedim
+
+    # nothing tagged: a single level
+    core.init_from_scratch(0.0)
+    assert core.finest_level == 0
+    assert core.count_cells(0) == 32**sd
+    assert ("scratch", 0) in core.calls
+
+    # lower the threshold: regrid creates level 1 from the coarse level
+    core.tag_threshold = 1.5
+    core.regrid(0, 0.0)
+    assert core.finest_level == 1
+    assert ("error_est", 0) in core.calls
+    assert ("coarse", 1) in core.calls
+    assert core.level_defined(1)
+    assert core.max_ref_ratio(0) == 2
+    assert core.box_array(1).numPts > 0
+    assert core.phi[1] is not None
+
+    # conservative interpolation: averaging level 1 down reproduces the
+    # coarse data exactly on the covered region
+    crse_check = core.phi[0].copy()
+    amr.average_down(core.phi[1], crse_check, 0, 1, core.ref_ratio(0))
+    # same BoxArray/DistributionMapping: one MFIter indexes both
+    for mfi in core.phi[0]:
+        a = core.phi[0].array(mfi).to_xp(copy=False, order="F")
+        b = crse_check.array(mfi).to_xp(copy=False, order="F")
+        assert np.allclose(a, b)
+
+    # interpolated maxima cannot overshoot the coarse maxima (limiter)
+    assert core.phi[1].max(0) <= core.phi[0].max(0) + 1.0e-12
+
+    # lower the threshold further: the tagged region grows and level 1
+    # is remade on the new, larger BoxArray
+    # (a regrid with unchanged grids does not call remake_level)
+    core.tag_threshold = 1.2
+    core.regrid(0, 0.0)
+    assert ("remake", 1) in core.calls
+    assert core.finest_level == 1
+
+    # raise the threshold: regrid removes level 1
+    core.tag_threshold = 1.0e30
+    core.regrid(0, 0.0)
+    assert core.finest_level == 0
+    assert ("clear", 1) in core.calls
+    assert core.phi[1] is None

--- a/tests/test_fillpatch.py
+++ b/tests/test_fillpatch.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import amrex.space3d as amr
+
+
+def make_geom(box, periodic=True):
+    """Cartesian unit-box Geometry"""
+    sd = amr.Config.spacedim
+    real_box = amr.RealBox([0.0] * sd, [1.0] * sd)
+    return amr.Geometry(box, real_box, 0, [1 if periodic else 0] * sd)
+
+
+def fill_global_linear_x(mf):
+    """f(i,j,k) = i (global cell index in x), filled incl. ghost cells"""
+    for mfi in mf:
+        bx = mfi.validbox()
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        ngx = mf.n_grow_vect[0]
+        i = np.arange(bx.small_end[0] - ngx, bx.small_end[0] - ngx + arr.shape[0])
+        arr[...] = i[(slice(None),) + (np.newaxis,) * 3]
+
+
+def int_dir_bcs():
+    sd = amr.Config.spacedim
+    return amr.Vector_BCRec(
+        [amr.BCRec(lo=[amr.BCType.int_dir] * sd, hi=[amr.BCType.int_dir] * sd)]
+    )
+
+
+def test_fill_patch_single_level():
+    """fill valid + periodic ghost cells from a source MultiFab"""
+    n_cell = 16
+    box = amr.Box(amr.IntVect(0), amr.IntVect(n_cell - 1))
+    geom = make_geom(box)
+    ba = amr.BoxArray(box)
+    ba.max_size(8)
+    dm = amr.DistributionMapping(ba)
+
+    src = amr.MultiFab(ba, dm, 1, 0)
+    fill_global_linear_x(src)
+
+    dst = amr.MultiFab(ba, dm, 1, 1)
+    dst.set_val(-42.0)
+
+    physbc = amr.PhysBCFunctNoOp()
+    amr.fill_patch_single_level(dst, 0.0, [src], [0.0], 0, 0, 1, geom, physbc, 0)
+
+    for mfi in dst:
+        bx = mfi.validbox()
+        arr = dst.array(mfi).to_xp(copy=False, order="F")
+        # global x indices of the view, including the ghost cells
+        i = np.arange(bx.small_end[0] - 1, bx.big_end[0] + 2)
+        # periodic wrap-around
+        expected = i % n_cell
+        assert np.allclose(arr, expected[(slice(None),) + (np.newaxis,) * 3])
+
+
+def test_fill_patch_single_level_time_interp():
+    """source data at two times is interpolated linearly in time"""
+    box = amr.Box(amr.IntVect(0), amr.IntVect(7))
+    geom = make_geom(box)
+    ba = amr.BoxArray(box)
+    dm = amr.DistributionMapping(ba)
+
+    src_old = amr.MultiFab(ba, dm, 1, 0)
+    src_old.set_val(1.0)
+    src_new = amr.MultiFab(ba, dm, 1, 0)
+    src_new.set_val(3.0)
+
+    dst = amr.MultiFab(ba, dm, 1, 1)
+    physbc = amr.PhysBCFunctNoOp()
+    amr.fill_patch_single_level(
+        dst, 0.5, [src_old, src_new], [0.0, 1.0], 0, 0, 1, geom, physbc, 0
+    )
+    assert np.isclose(dst.min(0), 2.0)
+    assert np.isclose(dst.max(0), 2.0)
+
+
+def test_interp_from_coarse_level():
+    """interpolation from a coarse level: exact for constant data;
+    exact in the interior for linear data"""
+    n_cell = 16
+
+    crse_dom = amr.Box(amr.IntVect(0), amr.IntVect(n_cell - 1))
+    fine_dom = amr.Box(amr.IntVect(0), amr.IntVect(2 * n_cell - 1))
+    cgeom = make_geom(crse_dom)
+    fgeom = make_geom(fine_dom)
+
+    ba_c = amr.BoxArray(crse_dom)
+    dm_c = amr.DistributionMapping(ba_c)
+    crse = amr.MultiFab(ba_c, dm_c, 1, 1)
+    fill_global_linear_x(crse)
+
+    # fine patch covering the center of the domain
+    fine_box = amr.Box(amr.IntVect(n_cell // 2), amr.IntVect(3 * n_cell // 2 - 1))
+    ba_f = amr.BoxArray(fine_box)
+    dm_f = amr.DistributionMapping(ba_f)
+    fine = amr.MultiFab(ba_f, dm_f, 1, 0)
+    fine.set_val(-42.0)
+
+    physbc = amr.PhysBCFunctNoOp()
+    amr.interp_from_coarse_level(
+        fine,
+        0.0,
+        crse,
+        0,
+        0,
+        1,
+        cgeom,
+        fgeom,
+        physbc,
+        0,
+        physbc,
+        0,
+        amr.IntVect(2),
+        amr.cell_cons_interp,
+        int_dir_bcs(),
+        0,
+    )
+
+    # for f(i_c) = i_c, linear conservative interpolation gives
+    # f(i_f) = i_f / 2 - 1/4 away from limited slopes
+    for mfi in fine:
+        bx = mfi.validbox()
+        arr = fine.array(mfi).to_xp(copy=False, order="F")
+        i = np.arange(bx.small_end[0], bx.big_end[0] + 1)
+        expected = (i / 2.0 - 0.25)[(slice(None),) + (np.newaxis,) * 3]
+        assert np.allclose(arr, expected)
+
+    # the same, dispatched through the MFInterpolater overload set
+    fine2 = amr.MultiFab(ba_f, dm_f, 1, 0)
+    fine2.set_val(-42.0)
+    amr.interp_from_coarse_level(
+        fine2,
+        0.0,
+        crse,
+        0,
+        0,
+        1,
+        cgeom,
+        fgeom,
+        physbc,
+        0,
+        physbc,
+        0,
+        amr.IntVect(2),
+        amr.mf_cell_cons_interp,
+        int_dir_bcs(),
+        0,
+    )
+    # mean conservation: both interpolations preserve the coarse mean
+    assert np.isclose(fine2.sum(0), fine.sum(0))
+
+    # conservation: averaging the interpolated fine data back down
+    # reproduces the coarse data on the covered region
+    crse_check = crse.copy()
+    amr.average_down(fine, crse_check, 0, 1, amr.IntVect(2))
+    # same BoxArray/DistributionMapping: one MFIter indexes both
+    for mfi in crse:
+        a = crse.array(mfi).to_xp(copy=False, order="F")
+        b = crse_check.array(mfi).to_xp(copy=False, order="F")
+        assert np.allclose(a, b)
+
+
+def test_fill_patch_two_levels():
+    """valid cells come from the fine data, ghost cells outside the fine
+    region from coarse interpolation"""
+    n_cell = 16
+
+    crse_dom = amr.Box(amr.IntVect(0), amr.IntVect(n_cell - 1))
+    fine_dom = amr.Box(amr.IntVect(0), amr.IntVect(2 * n_cell - 1))
+    cgeom = make_geom(crse_dom)
+    fgeom = make_geom(fine_dom)
+
+    ba_c = amr.BoxArray(crse_dom)
+    dm_c = amr.DistributionMapping(ba_c)
+    crse = amr.MultiFab(ba_c, dm_c, 1, 1)
+    crse.set_val(7.0)
+
+    fine_box = amr.Box(amr.IntVect(n_cell // 2), amr.IntVect(3 * n_cell // 2 - 1))
+    ba_f = amr.BoxArray(fine_box)
+    dm_f = amr.DistributionMapping(ba_f)
+    fine_src = amr.MultiFab(ba_f, dm_f, 1, 0)
+    fine_src.set_val(7.0)
+
+    dst = amr.MultiFab(ba_f, dm_f, 1, 2)
+    dst.set_val(-42.0)
+
+    physbc = amr.PhysBCFunctNoOp()
+    amr.fill_patch_two_levels(
+        dst,
+        0.0,
+        [crse],
+        [0.0],
+        [fine_src],
+        [0.0],
+        0,
+        0,
+        1,
+        cgeom,
+        fgeom,
+        physbc,
+        0,
+        physbc,
+        0,
+        amr.IntVect(2),
+        amr.cell_cons_interp,
+        int_dir_bcs(),
+        0,
+    )
+
+    # for a globally constant field, valid and ghost cells (filled from
+    # the coarse level) are all the constant
+    for mfi in dst:
+        arr = dst.array(mfi).to_xp(copy=False, order="F")
+        assert np.allclose(arr, 7.0)
+
+
+def test_fill_patch_user_bc_called():
+    """the Python physical boundary functor is invoked by fill_patch"""
+    box = amr.Box(amr.IntVect(0), amr.IntVect(7))
+    geom = make_geom(box, periodic=False)
+    ba = amr.BoxArray(box)
+    dm = amr.DistributionMapping(ba)
+
+    src = amr.MultiFab(ba, dm, 1, 0)
+    src.set_val(1.0)
+    dst = amr.MultiFab(ba, dm, 1, 1)
+    dst.set_val(-42.0)
+
+    called = []
+
+    def fill(mf, dcomp, ncomp, nghost, time, bccomp):
+        called.append((dcomp, ncomp, time, bccomp))
+        # fill all (domain boundary) ghost cells with a marker value
+        for mfi in mf:
+            arr = mf.array(mfi).to_xp(copy=False, order="F")
+            arr[arr == -42.0] = 99.0
+
+    physbc = amr.PhysBCFunctUser(fill)
+    amr.fill_patch_single_level(dst, 0.25, [src], [0.0], 0, 0, 1, geom, physbc, 0)
+
+    assert len(called) == 1
+    assert called[0][0] == 0  # dcomp
+    assert called[0][1] == 1  # ncomp
+    assert np.isclose(called[0][2], 0.25)  # time
+    # valid cells from src, ghost cells from the Python callback
+    assert np.isclose(dst.min(0, nghost=1), 1.0)
+    assert np.isclose(dst.max(0, nghost=1), 99.0)

--- a/tests/test_fluxregister.py
+++ b/tests/test_fluxregister.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import amrex.space3d as amr
+
+
+def make_geom(box):
+    sd = amr.Config.spacedim
+    real_box = amr.RealBox([0.0] * sd, [1.0] * sd)
+    return amr.Geometry(box, real_box, 0, [0] * sd)
+
+
+def setup():
+    """A coarse level covering the domain and a fine level covering the
+    center region"""
+    sd = amr.Config.spacedim
+    n_cell = 8
+    ratio = amr.IntVect(2)
+
+    crse_dom = amr.Box(amr.IntVect(0), amr.IntVect(n_cell - 1))
+    ba_c = amr.BoxArray(crse_dom)
+    dm_c = amr.DistributionMapping(ba_c)
+
+    fine_box = amr.Box(amr.IntVect(4), amr.IntVect(11))  # cells 2..5 refined
+    ba_f = amr.BoxArray(fine_box)
+    dm_f = amr.DistributionMapping(ba_f)
+
+    ncomp = 1
+    fr = amr.FluxRegister(ba_f, dm_f, ratio, 1, ncomp)
+    return sd, crse_dom, ba_c, dm_c, ba_f, dm_f, fr
+
+
+def face_mfab(ba, dm, dir, val):
+    ba_face = amr.BoxArray(ba)
+    ba_face.surroundingNodes(dir)
+    mf = amr.MultiFab(ba_face, dm, 1, 0)
+    mf.set_val(val)
+    return mf
+
+
+def test_fluxregister_construct():
+    sd, crse_dom, ba_c, dm_c, ba_f, dm_f, fr = setup()
+    assert fr.fine_level == 1
+    assert fr.crse_level == 0
+    assert fr.n_comp == 1
+    assert fr.ref_ratio == amr.IntVect(2)
+
+    fr.set_val(0.0)
+    assert np.isclose(fr.sum_reg(0), 0.0)
+
+
+def test_fluxregister_matched_fluxes_cancel():
+    """coarse and consistently scaled fine fluxes cancel: no correction"""
+    sd, crse_dom, ba_c, dm_c, ba_f, dm_f, fr = setup()
+    cgeom = make_geom(crse_dom)
+    ratio = 2
+
+    fr.set_val(0.0)
+
+    c = 3.0
+    for d in range(sd):
+        cflux = face_mfab(ba_c, dm_c, d, c)
+        # integrated coarse flux per coarse face
+        fr.crse_init(cflux, d, 0, 0, 1, mult=-1.0)
+        # each coarse face consists of ratio^(sd-1) fine faces
+        fflux = face_mfab(ba_f, dm_f, d, c / ratio ** (sd - 1))
+        fr.fine_add(fflux, d, 0, 0, 1, mult=1.0)
+
+    assert np.isclose(fr.sum_reg(0), 0.0)
+
+    # refluxing with a zero register leaves the solution unchanged
+    phi = amr.MultiFab(ba_c, dm_c, 1, 0)
+    phi.set_val(1.0)
+    fr.reflux(phi, 1.0, 0, 0, 1, cgeom)
+    assert np.isclose(phi.min(0), 1.0)
+    assert np.isclose(phi.max(0), 1.0)
+
+
+def test_fluxregister_mismatch_corrects():
+    """mismatched fine fluxes produce a non-zero correction"""
+    sd, crse_dom, ba_c, dm_c, ba_f, dm_f, fr = setup()
+    cgeom = make_geom(crse_dom)
+    ratio = 2
+
+    fr.set_val(0.0)
+
+    c = 3.0
+    d = 0  # only x-direction fluxes
+    cflux = face_mfab(ba_c, dm_c, d, c)
+    fr.crse_init(cflux, d, 0, 0, 1, mult=-1.0)
+    # fine fluxes twice as large as the matched value:
+    # per coarse boundary face the register holds -c + 2c = c
+    fflux = face_mfab(ba_f, dm_f, d, 2.0 * c / ratio ** (sd - 1))
+    fr.fine_add(fflux, d, 0, 0, 1, mult=1.0)
+
+    # note: sum_reg sums lo faces minus hi faces, which cancels for a
+    # constant register; the local corrections below do not
+    assert np.isclose(fr.sum_reg(0), 0.0)
+
+    phi = amr.MultiFab(ba_c, dm_c, 1, 0)
+    phi.set_val(1.0)
+    sum_before = phi.sum(0)
+    fr.reflux(phi, 1.0, 0, 0, 1, cgeom)
+    # the correction changed the coarse cells next to the fine boundary...
+    assert not np.isclose(phi.max(0), 1.0)
+    assert not np.isclose(phi.min(0), 1.0)
+    # ...but conserves the total: the same constant flux mismatch enters
+    # on the low side and leaves on the high side of the fine patch
+    assert np.isclose(phi.sum(0), sum_before)

--- a/tests/test_interpolater.py
+++ b/tests/test_interpolater.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import amrex.space3d as amr
+
+
+def test_interpolater_singletons():
+    """The global C++ interpolater instances are exposed by reference"""
+    assert isinstance(amr.pc_interp, amr.PCInterp)
+    assert isinstance(amr.node_bilinear_interp, amr.NodeBilinear)
+    assert isinstance(amr.face_divfree_interp, amr.FaceDivFree)
+    assert isinstance(amr.face_linear_interp, amr.FaceLinear)
+    assert isinstance(amr.face_cons_linear_interp, amr.FaceConservativeLinear)
+    assert isinstance(amr.lincc_interp, amr.CellConservativeLinear)
+    assert isinstance(amr.cell_cons_interp, amr.CellConservativeLinear)
+    assert isinstance(amr.cell_bilinear_interp, amr.CellBilinear)
+    assert isinstance(amr.protected_interp, amr.CellConservativeProtected)
+    assert isinstance(amr.quartic_interp, amr.CellConservativeQuartic)
+    assert isinstance(amr.quadratic_interp, amr.CellQuadratic)
+    assert isinstance(amr.cell_quartic_interp, amr.CellQuartic)
+
+    # every Interpolater is an InterpBase
+    assert isinstance(amr.cell_cons_interp, amr.Interpolater)
+    assert isinstance(amr.cell_cons_interp, amr.InterpBase)
+
+
+def test_mf_interpolater_singletons():
+    assert isinstance(amr.mf_pc_interp, amr.MFPCInterp)
+    assert isinstance(amr.mf_cell_cons_interp, amr.MFCellConsLinInterp)
+    assert isinstance(amr.mf_lincc_interp, amr.MFCellConsLinInterp)
+    assert isinstance(
+        amr.mf_linear_slope_minmax_interp, amr.MFCellConsLinMinmaxLimitInterp
+    )
+    assert isinstance(amr.mf_cell_bilinear_interp, amr.MFCellBilinear)
+    assert isinstance(amr.mf_node_bilinear_interp, amr.MFNodeBilinear)
+
+    assert isinstance(amr.mf_cell_cons_interp, amr.MFInterpolater)
+    assert isinstance(amr.mf_cell_cons_interp, amr.InterpBase)
+
+
+def test_singletons_identical():
+    """Repeated access returns the same global instance"""
+    assert amr.cell_cons_interp is amr.cell_cons_interp

--- a/tests/test_multifabutil.py
+++ b/tests/test_multifabutil.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+import amrex.space3d as amr
+
+
+def make_geom(box):
+    """Non-periodic Cartesian unit-box Geometry"""
+    sd = amr.Config.spacedim
+    real_box = amr.RealBox([0.0] * sd, [1.0] * sd)
+    return amr.Geometry(box, real_box, 0, [0] * sd)
+
+
+def fill_global_linear_x(mf):
+    """f(i,j,k) = i (global cell index in x), filled incl. ghost cells"""
+    for mfi in mf:
+        bx = mfi.validbox()
+        arr = mf.array(mfi).to_xp(copy=False, order="F")
+        ngx = mf.n_grow_vect[0]
+        i = np.arange(bx.small_end[0] - ngx, bx.small_end[0] - ngx + arr.shape[0])
+        arr[...] = i[(slice(None),) + (np.newaxis,) * 3]
+
+
+def test_average_down_cell():
+    """average_down conserves the (volume-weighted) sum"""
+    sd = amr.Config.spacedim
+    ratio = 2
+
+    crse_dom = amr.Box(amr.IntVect(0), amr.IntVect(15))
+    fine_dom = amr.Box(amr.IntVect(0), amr.IntVect(2 * 15 + 1))
+
+    ba_f = amr.BoxArray(fine_dom)
+    ba_f.max_size(16)
+    dm_f = amr.DistributionMapping(ba_f)
+    mf_f = amr.MultiFab(ba_f, dm_f, 1, 0)
+    fill_global_linear_x(mf_f)
+
+    ba_c = amr.BoxArray(crse_dom)
+    ba_c.max_size(8)
+    dm_c = amr.DistributionMapping(ba_c)
+    mf_c = amr.MultiFab(ba_c, dm_c, 1, 0)
+    mf_c.set_val(-42.0)
+
+    # with geometries (volume weighted; arithmetic mean in Cartesian)
+    amr.average_down(mf_f, mf_c, make_geom(fine_dom), make_geom(crse_dom), 0, 1, ratio)
+    assert np.isclose(mf_c.sum(0) * ratio**sd, mf_f.sum(0))
+
+    # without geometries, IntVect ratio
+    mf_c.set_val(-42.0)
+    amr.average_down(mf_f, mf_c, 0, 1, amr.IntVect(ratio))
+    assert np.isclose(mf_c.sum(0) * ratio**sd, mf_f.sum(0))
+
+    # without geometries, int ratio
+    mf_c.set_val(-42.0)
+    amr.average_down(mf_f, mf_c, 0, 1, ratio)
+    assert np.isclose(mf_c.sum(0) * ratio**sd, mf_f.sum(0))
+
+
+def test_average_cellcenter_to_face_roundtrip():
+    """cc -> face -> cc is exact for linear data"""
+    sd = amr.Config.spacedim
+    box = amr.Box(amr.IntVect(0), amr.IntVect(15))
+    geom = make_geom(box)
+    ba = amr.BoxArray(box)
+    dm = amr.DistributionMapping(ba)
+
+    # average_cellcenter_to_face requires >= 1 ghost cell on cc
+    cc = amr.MultiFab(ba, dm, 1, 1)
+    fill_global_linear_x(cc)
+
+    fc = []
+    for d in range(sd):
+        ba_face = amr.BoxArray(ba)
+        ba_face.surroundingNodes(d)
+        fc.append(amr.MultiFab(ba_face, dm, 1, 0))
+        fc[d].set_val(-42.0)
+
+    amr.average_cellcenter_to_face(fc, cc, geom)
+
+    # interior x-face value at face index i is the midpoint between
+    # cells i-1 and i: f = i - 0.5
+    for mfi in fc[0]:
+        bx = mfi.validbox()
+        arr = fc[0].array(mfi).to_xp(copy=False, order="F")
+        i = np.arange(bx.small_end[0], bx.big_end[0] + 1)
+        expected = (i - 0.5)[(slice(None),) + (np.newaxis,) * 3]
+        # skip the domain boundary faces (filled from ghost cells)
+        assert np.allclose(arr[1:-1, ...], expected[1:-1, ...])
+
+    # round trip back to cell centers: face -> cc produces a vector
+    # field with one component per direction
+    cc2 = amr.MultiFab(ba, dm, sd, 0)
+    cc2.set_val(-42.0)
+    amr.average_face_to_cellcenter(cc2, 0, fc)
+    for mfi in cc2:
+        bx = mfi.validbox()
+        arr = cc2.array(mfi).to_xp(copy=False, order="F")
+        i = np.arange(bx.small_end[0], bx.big_end[0] + 1)
+        # the d-faces of a cell average back to the cell value i for
+        # data linear in x in every direction d
+        expected = i[(slice(None),) + (np.newaxis,) * 3]
+        for d in range(sd):
+            assert np.allclose(arr[..., d], expected[..., 0])
+
+    # invalid arguments raise instead of corrupting memory
+    if sd > 1:
+        # too few components in cc
+        cc_bad = amr.MultiFab(ba, dm, 1, 0)
+        with pytest.raises(ValueError):
+            amr.average_face_to_cellcenter(cc_bad, 0, fc)
+        # too few per-direction MultiFabs
+        with pytest.raises(ValueError):
+            amr.average_face_to_cellcenter(cc2, 0, fc[: sd - 1])
+
+
+def test_average_node_to_cellcenter():
+    """nodal -> cc averaging is exact for linear data"""
+    box = amr.Box(amr.IntVect(0), amr.IntVect(15))
+    ba = amr.BoxArray(box)
+    dm = amr.DistributionMapping(ba)
+
+    ba_nd = amr.BoxArray(ba)
+    ba_nd.surroundingNodes()
+    nd = amr.MultiFab(ba_nd, dm, 1, 0)
+    # f = i at the nodes (linear in x)
+    for mfi in nd:
+        bx = mfi.validbox()
+        arr = nd.array(mfi).to_xp(copy=False, order="F")
+        i = np.arange(bx.small_end[0], bx.big_end[0] + 1)
+        arr[...] = i[(slice(None),) + (np.newaxis,) * 3]
+
+    cc = amr.MultiFab(ba, dm, 1, 0)
+    cc.set_val(-42.0)
+    amr.average_node_to_cellcenter(cc, 0, nd, 0, 1)
+
+    for mfi in cc:
+        bx = mfi.validbox()
+        arr = cc.array(mfi).to_xp(copy=False, order="F")
+        i = np.arange(bx.small_end[0], bx.big_end[0] + 1)
+        expected = (i + 0.5)[(slice(None),) + (np.newaxis,) * 3]
+        assert np.allclose(arr, expected)
+
+
+def test_average_down_faces():
+    """average_down_faces conserves a constant field"""
+    sd = amr.Config.spacedim
+
+    crse_dom = amr.Box(amr.IntVect(0), amr.IntVect(7))
+    fine_dom = amr.Box(amr.IntVect(0), amr.IntVect(15))
+
+    fine, crse = [], []
+    for d in range(sd):
+        ba_f = amr.BoxArray(fine_dom)
+        ba_f.surroundingNodes(d)
+        dm_f = amr.DistributionMapping(ba_f)
+        fine.append(amr.MultiFab(ba_f, dm_f, 1, 0))
+        fine[d].set_val(7.0)
+
+        ba_c = amr.BoxArray(crse_dom)
+        ba_c.surroundingNodes(d)
+        dm_c = amr.DistributionMapping(ba_c)
+        crse.append(amr.MultiFab(ba_c, dm_c, 1, 0))
+        crse[d].set_val(-42.0)
+
+    amr.average_down_faces(fine, crse, amr.IntVect(2))
+    for d in range(sd):
+        assert np.isclose(crse[d].min(0), 7.0)
+        assert np.isclose(crse[d].max(0), 7.0)
+
+
+def test_write_multi_level_plotfile(tmpdir):
+    """write a two-level plotfile and read it back"""
+    plt = str(tmpdir.join("plt_ml00000"))
+    if amr.Config.have_mpi:
+        # pytest creates a different tmpdir on every rank: broadcast the
+        # path so all ranks write to (and read from) the same plotfile
+        from mpi4py import MPI
+
+        plt = MPI.COMM_WORLD.bcast(plt, root=0)
+
+    domains = [
+        amr.Box(amr.IntVect(0), amr.IntVect(15)),
+        amr.Box(amr.IntVect(0), amr.IntVect(31)),
+    ]
+    mfs, geoms = [], []
+    for lev, dom in enumerate(domains):
+        ba = amr.BoxArray(dom)
+        ba.max_size(16)
+        dm = amr.DistributionMapping(ba)
+        mf = amr.MultiFab(ba, dm, 1, 0)
+        mf.set_val(1.0 + lev)
+        mfs.append(mf)
+        geoms.append(make_geom(dom))
+
+    amr.write_multi_level_plotfile(
+        plt,
+        mfs,
+        ["phi"],
+        geoms,
+        0.5,
+        [10, 10],
+        [amr.IntVect(2)],
+    )
+
+    pfd = amr.PlotFileData(plt)
+    assert pfd.finestLevel() == 1
+    assert list(pfd.varNames()) == ["phi"]
+    assert np.isclose(pfd.time(), 0.5)
+    assert pfd.levelStep(0) == 10
+    for lev in range(2):
+        mf_read = pfd.get(lev, "phi")
+        assert np.isclose(mf_read.min(0), 1.0 + lev)
+        assert np.isclose(mf_read.max(0), 1.0 + lev)
+
+
+def test_io_path_helpers():
+    assert amr.level_path(5) == "Level_5"
+    assert amr.multifab_header_path(5) == "Level_5/Cell"
+    assert amr.level_full_path(5, "plt00005") == "plt00005/Level_5"
+    assert amr.multifab_file_full_prefix(5, "plt00005") == "plt00005/Level_5/Cell"
+
+
+def test_directory_helpers(tmpdir):
+    path = str(tmpdir.join("a", "b"))
+    assert not amr.file_exists(path)
+    assert amr.util_create_directory(path)
+    assert amr.file_exists(path)
+    # rename the old one, create a new one
+    amr.util_create_clean_directory(path)
+    assert amr.file_exists(path)
+    # remove the old one, create a new one
+    amr.util_create_directory_destructive(path)
+    assert amr.file_exists(path)

--- a/tests/test_multifabutil.py
+++ b/tests/test_multifabutil.py
@@ -142,6 +142,12 @@ def test_average_node_to_cellcenter():
         expected = (i + 0.5)[(slice(None),) + (np.newaxis,) * 3]
         assert np.allclose(arr, expected)
 
+    # out-of-range components raise instead of corrupting memory
+    with pytest.raises(ValueError):
+        amr.average_node_to_cellcenter(cc, 1, nd, 0, 1)
+    with pytest.raises(ValueError):
+        amr.average_node_to_cellcenter(cc, 0, nd, 1, 1)
+
 
 def test_average_down_faces():
     """average_down_faces conserves a constant field"""

--- a/tests/test_parmparse.py
+++ b/tests/test_parmparse.py
@@ -2,6 +2,7 @@
 import os
 
 import numpy as np
+import pytest
 
 import amrex.space3d as amr
 
@@ -104,6 +105,40 @@ def test_parmparse_query_get():
     assert pp.query_int_arr("ints") == (True, [4, 5, 6])
     assert pp.query_str_arr("strs") == (True, ["a", "b"])
     assert pp.query_real_arr("missing")[0] is False
+
+
+def test_parmparse_get_arr_start_ix():
+    """get_*_arr returns exactly the requested slice (regression test:
+    the leading start_ix entries used to be returned as default-
+    constructed padding, and an omitted num_val used to abort)"""
+    pp = amr.ParmParse("slice")
+    pp.addarr("ints", [1, 2, 3])
+    pp.addarr("reals", [1.5, 2.5, 3.5])
+    pp.addarr("strs", ["a", "b", "c"])
+
+    # explicit num_val
+    assert pp.get_int_arr("ints", 1, 2) == [2, 3]
+    assert np.allclose(pp.get_real_arr("reals", 1, 2), [2.5, 3.5])
+    assert pp.get_str_arr("strs", 1, 2) == ["b", "c"]
+
+    # num_val=-1 (the default): all values after start_ix
+    assert pp.get_int_arr("ints", 1) == [2, 3]
+    assert pp.get_int_arr("ints", 2) == [3]
+    assert np.allclose(pp.get_real_arr("reals", 1), [2.5, 3.5])
+    assert pp.get_str_arr("strs", 1) == ["b", "c"]
+
+    # start_ix at/past the end yields an empty list, not an abort
+    assert pp.get_int_arr("ints", 3) == []
+    assert pp.get_int_arr("ints", 5) == []
+
+    # explicitly requesting zero values
+    assert pp.get_int_arr("ints", 1, 0) == []
+
+    # invalid arguments raise instead of aborting
+    with pytest.raises(ValueError):
+        pp.get_int_arr("ints", -1)
+    with pytest.raises(ValueError):
+        pp.get_int_arr("ints", 0, -2)
 
 
 def test_parmparse_to_dict_prefixed():

--- a/tests/test_parmparse.py
+++ b/tests/test_parmparse.py
@@ -63,3 +63,56 @@ def test_parmparse():
     # import yaml
     # yaml_string = yaml.dump(d)
     # toml_string = toml.dumps(d)
+
+
+def test_parmparse_query_get():
+    pp = amr.ParmParse("q")
+    pp.add("flag", True)
+    pp.add("count", 7)
+    pp.add("dt", 1.5e-3)
+    pp.add("name", "phi")
+    pp.addarr("floats", [1.0, 2.0, 3.0])
+    pp.addarr("ints", [4, 5, 6])
+    pp.addarr("strs", ["a", "b"])
+
+    # get_* of existing values
+    assert pp.get_bool("flag")
+    assert pp.get_int("count") == 7
+    assert np.isclose(pp.get_real("dt"), 1.5e-3)
+    assert pp.get_str("name") == "phi"
+
+    # query_* of existing values
+    assert pp.query_bool("flag") == (True, True)
+    assert pp.query_int("count") == (True, 7)
+    exists, dt = pp.query_real("dt")
+    assert exists and np.isclose(dt, 1.5e-3)
+    assert pp.query_str("name") == (True, "phi")
+
+    # query_* of missing values
+    assert pp.query_bool("missing")[0] is False
+    assert pp.query_int("missing")[0] is False
+    assert pp.query_real("missing")[0] is False
+    assert pp.query_str("missing")[0] is False
+
+    # arrays
+    assert pp.countval("floats") == 3
+    assert np.allclose(pp.get_real_arr("floats"), [1.0, 2.0, 3.0])
+    assert pp.get_int_arr("ints") == [4, 5, 6]
+    assert pp.get_str_arr("strs") == ["a", "b"]
+    exists, floats = pp.query_real_arr("floats")
+    assert exists and np.allclose(floats, [1.0, 2.0, 3.0])
+    assert pp.query_int_arr("ints") == (True, [4, 5, 6])
+    assert pp.query_str_arr("strs") == (True, ["a", "b"])
+    assert pp.query_real_arr("missing")[0] is False
+
+
+def test_parmparse_to_dict_prefixed():
+    """to_dict is independent of the ParmParse prefix (regression test:
+    this used to fail with prefixed instances)"""
+    pp = amr.ParmParse("pre")
+    pp.add("value", 3)
+
+    d_root = amr.ParmParse().to_dict()
+    d_pre = pp.to_dict()
+    assert d_pre["pre"]["value"] == 3
+    assert d_root["pre"]["value"] == 3

--- a/tests/test_tagbox.py
+++ b/tests/test_tagbox.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import amrex.space3d as amr
+
+
+def test_tagval_values():
+    assert int(amr.TagBox.CLEAR) == 0
+    assert int(amr.TagBox.BUF) == 1
+    assert int(amr.TagBox.SET) == 2
+
+
+def test_tagboxarray_construct(boxarr, distmap):
+    tba = amr.TagBoxArray(boxarr, distmap, 1)
+    assert tba.n_grow_vect == amr.IntVect(1)
+    assert tba.box_array == boxarr
+
+    tba = amr.TagBoxArray(boxarr, distmap, amr.IntVect(2))
+    assert tba.n_grow_vect == amr.IntVect(2)
+
+
+def test_tagboxarray_setval(boxarr, distmap, std_box):
+    tba = amr.TagBoxArray(boxarr, distmap)
+    assert not tba.has_tags(std_box)
+
+    tba.set_val(amr.TagBox.SET)
+    assert tba.has_tags(std_box)
+
+    tba.set_val(amr.TagBox.CLEAR)
+    assert not tba.has_tags(std_box)
+
+    # set tags in a sub-region only
+    sub_box = amr.Box(amr.IntVect(8), amr.IntVect(15))
+    other_box = amr.Box(amr.IntVect(24), amr.IntVect(31))
+    tba.set_val(amr.BoxArray(sub_box), amr.TagBox.SET)
+    assert tba.has_tags(sub_box)
+    assert not tba.has_tags(other_box)
+
+
+def test_tagboxarray_array_mask(boxarr, distmap):
+    """Tag cells through zero-copy Array4 (of char) views, as a Python
+    AmrCore.error_est override does"""
+    sd = amr.Config.spacedim
+    tba = amr.TagBoxArray(boxarr, distmap)
+
+    tag_box = amr.Box(amr.IntVect(4), amr.IntVect(11))
+
+    for mfi in tba:
+        bx = mfi.validbox()
+        tags = tba.array(mfi).to_xp(copy=False, order="F")
+        assert tags.dtype == np.int8
+
+        # global index arrays for the local view (no ghost cells here)
+        idx = [
+            np.arange(bx.small_end[d], bx.big_end[d] + 1).reshape(
+                [-1 if i == d else 1 for i in range(4)]
+            )
+            for d in range(sd)
+        ]
+        inside = np.ones_like(tags, dtype=bool)
+        for d in range(sd):
+            inside &= (idx[d] >= tag_box.small_end[d]) & (idx[d] <= tag_box.big_end[d])
+        tags[inside] = amr.TagBox.SET
+
+    assert tba.has_tags(tag_box)
+    assert not tba.has_tags(amr.Box(amr.IntVect(48), amr.IntVect(55)))
+
+
+def test_tagboxarray_buffer_coarsen(boxarr, distmap):
+    tba = amr.TagBoxArray(boxarr, distmap, 2)
+    sub_box = amr.Box(amr.IntVect(8), amr.IntVect(15))
+    tba.set_val(amr.BoxArray(sub_box), amr.TagBox.SET)
+
+    # buffering grows the tagged region
+    grown_box = amr.Box(amr.IntVect(7), amr.IntVect(16))
+    assert not tba.has_tags(amr.Box(amr.IntVect(7), amr.IntVect(7)))
+    tba.buffer(amr.IntVect(1))
+    assert tba.has_tags(grown_box)
+
+    # coarsening shrinks the index space of the tags
+    tba.coarsen(amr.IntVect(2))
+    assert tba.has_tags(amr.Box(amr.IntVect(4), amr.IntVect(7)))

--- a/tests/test_tagbox.py
+++ b/tests/test_tagbox.py
@@ -49,7 +49,12 @@ def test_tagboxarray_array_mask(boxarr, distmap):
     for mfi in tba:
         bx = mfi.validbox()
         tags = tba.array(mfi).to_xp(copy=False, order="F")
-        assert tags.dtype == np.int8
+        # amrex::TagBox::TagType is plain char, whose signedness is
+        # implementation-defined: int8 where char is signed (x86-64,
+        # macOS, MSVC), uint8 where it is unsigned (e.g. Linux aarch64,
+        # ppc64le). Only the 1-byte integer nature is portable.
+        assert tags.dtype.kind in "iu"
+        assert tags.dtype.itemsize == 1
 
         # global index arrays for the local view (no ghost cells here)
         idx = [

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -11,3 +11,28 @@ def test_concatenate():
 def test_print():
     print("hello from everyone")
     amr.Print("byeee from IO processor")
+
+
+def test_parallel_reductions():
+    """ParallelDescriptor reductions (single rank: identity; the values
+    are returned, not modified in place)"""
+    pd = amr.ParallelDescriptor
+    nprocs = pd.NProcs()
+
+    assert pd.ReduceRealSum(1.5) == 1.5 * nprocs
+    assert pd.ReduceRealMin(2.5) == 2.5
+    assert pd.ReduceRealMax(3.5) == 3.5
+    assert pd.ReduceRealMin([1.0, 2.0]) == [1.0, 2.0]
+    assert pd.ReduceRealMax([1.0, 2.0]) == [1.0, 2.0]
+    assert pd.ReduceRealSum([1.0, 2.0]) == [1.0 * nprocs, 2.0 * nprocs]
+
+    assert pd.ReduceIntSum(2) == 2 * nprocs
+    assert pd.ReduceIntMin(2) == 2
+    assert pd.ReduceIntMax(2) == 2
+    assert pd.ReduceLongSum(2) == 2 * nprocs
+    assert pd.ReduceLongMin(2) == 2
+    assert pd.ReduceLongMax(2) == 2
+    assert pd.ReduceBoolAnd(True)
+    assert pd.ReduceBoolOr(False) is False
+
+    pd.Barrier()


### PR DESCRIPTION
Several largely independent binding additions that together enable writing multi-level (`AmrCore`) applications in pure pyAMReX. Grouped by subsystem below; see the per-commit split for review.

## MultiFabUtil & IO (`AMReX_MultiFabUtil.H`, `AMReX_PlotFileUtil.H`)
Inter-level and inter-centering averaging operations:
- `average_down` (cell-centered w/ volume weighting; centering-agnostic
  without), `average_down_faces`, `average_down_edges`, `average_down_nodal`
- `average_node_to_cellcenter`, `average_edge_to_cellcenter`,
  `average_face_to_cellcenter`, `average_cellcenter_to_face`
- `sum_fine_to_coarse`

Per-direction MultiFab lists and destination component counts are validated:
AMReX release builds otherwise corrupt memory on, e.g., a cell-centered
destination with too few components.

Multi-level IO:
- `write_multi_level_plotfile`, plotfile path helpers (`level_path`,
  `multifab_header_path`, `level_full_path`, `multifab_file_full_prefix`),
  `pre_build_director_hierarchy`
- `util_create_directory`, `util_create_clean_directory`,
  `util_create_directory_destructive`, `file_exists`

## AmrCore application support
Building blocks to implement an `AmrCore` app (regrid + error estimation +
level fill) from Python:
- **TagBox**: `TagBox` (tag values `TagBox.SET`/`CLEAR`/`BUF`) and
  `TagBoxArray` (`set_val` overloads, zero-copy `array`/`const_array` views,
  `buffer`, `coarsen`, `has_tags`, ...) — used by `AmrCore.error_est`.
- **Interpolater** objects: `pc_interp`, `node_bilinear_interp`,
  `cell_bilinear_interp`, `cell_cons_interp`, `lincc_interp`,
  `quartic_interp`, `protected_interp`, `face_linear_interp`,
  `face_divfree_interp`, `face_cons_linear_interp` (+ `mf_*` variants).
- **FillPatchUtil**: `fill_patch_single_level`, `fill_patch_two_levels`,
  `interp_from_coarse_level`.
- **FluxRegister**: `crse_init`, `fine_add`, `reflux`, `set_val`, `sum_reg`, ...
- **AmrMesh** accessors: `box_array`, `dist_map`, `set_box_array`/`set_dist_map`/
  `clear_*`, `blocking_factor`, `max_grid_size`, `n_error_buf`,
  `max_ref_ratio`, `count_cells`, `level_defined`, and `set_finest_level`
  (checkpoint restarts).
- `BoxArray` `==`/`!=` and `Array4<char>` registration (for tag views).

## ParmParse
- Scalar queries returning `(found, value)`: `query_bool`, `query_int`,
  `query_real`, `query_str`.
- Array getters/queries: `get_int_arr`, `get_real_arr`, `get_str_arr`,
  `query_int_arr`, `query_real_arr`, `query_str_arr`, and `countval`.
- Fix `to_dict` for prefixed `ParmParse` instances (lookups now use an
  unprefixed instance, since table names are already fully qualified).

## ParallelDescriptor
- Reductions `Reduce{Real,Int,Long}{Min,Max,Sum}` and `ReduceBool{And,Or}`,
  plus `Barrier`.

- [x] rebase after #582 and #583
