### PR TITLE
Docs: Fix README Badges CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![Python3][api-py3]](https://www.python.org/)
 [![Documentation Status](https://readthedocs.org/projects/pyamrex/badge/?version=latest)](https://pyamrex.readthedocs.io)
 [![Discussions](https://img.shields.io/badge/chat-discussions-turquoise.svg)](https://github.com/AMReX-Codes/pyamrex/discussions)
-![Linux](https://github.com/AMReX-Codes/pyamrex/actions/workflows/ubuntu.yml/badge.svg?branch=development)
-![macOS](https://github.com/AMReX-Codes/pyamrex/actions/workflows/macos.yml/badge.svg?branch=development)
-![Windows](https://github.com/AMReX-Codes/pyamrex/actions/workflows/windows.yml/badge.svg?branch=development)
+[![CI Status](https://github.com/AMReX-Codes/pyamrex/actions/workflows/ci.yml/badge.svg?branch=development)](https://github.com/AMReX-Codes/pyamrex/actions/workflows/ci.yml)
+![Platforms](https://img.shields.io/badge/platforms-Linux%20%7C%20macOS%20%7C%20Windows-blue.svg)  
 [![License pyAMReX](https://img.shields.io/badge/license-BSD--3--Clause--LBNL-blue.svg)](https://spdx.org/licenses/BSD-3-Clause-LBNL.html)
 [![DOI (source)](https://img.shields.io/badge/DOI%20(source)-10.5281/zenodo.8408733-blue.svg)](https://doi.org/10.5281/zenodo.8408733)
 


### PR DESCRIPTION
Our CI was reorganized a while ago, so our badges showed "no status". This fixes it.