### PR TITLE
ParticleHeader: Grid Table, Species Discovery

### DIFF
--- a/docs/source/usage/workflows/read_plotfiles.rst
+++ b/docs/source/usage/workflows/read_plotfiles.rst
@@ -31,7 +31,15 @@ Particle Data
 -------------
 
 Particle data in a plotfile or checkpoint is stored in a sub-directory (often called ``particles``, per species name, or similar).
-Use :py:func:`~amrex.space3d.read_particles` to read it back into a particle container - no prior knowledge of the writing container's compile-time layout is needed, the number and names of the particle components are discovered from the file:
+Use :py:func:`~amrex.space3d.list_particle_species` to discover which particle sub-directories a file contains:
+
+.. literalinclude:: ../../../../tests/test_readparticles.py
+   :language: python3
+   :dedent: 4
+   :start-after: # Manual: List Particle Species START
+   :end-before: # Manual: List Particle Species END
+
+Use :py:func:`~amrex.space3d.read_particles` to read a species back into a particle container - no prior knowledge of the writing container's compile-time layout is needed, the number and names of the particle components are discovered from the file:
 
 .. literalinclude:: ../../../../tests/test_readparticles.py
    :language: python3
@@ -50,6 +58,14 @@ To only inspect the on-disk layout, e.g., to check which components a file conta
    :dedent: 4
    :start-after: # Manual: Read Particle Header START
    :end-before: # Manual: Read Particle Header END
+
+The header also exposes the per-level grid table that locates each grid's binary particle data on disk - useful for tools that process the file layout directly, e.g., converters and parallel readers:
+
+.. literalinclude:: ../../../../tests/test_readparticles.py
+   :language: python3
+   :dedent: 4
+   :start-after: # Manual: Read Particle Grid Table START
+   :end-before: # Manual: Read Particle Grid Table END
 
 
 Read Into an Existing Container

--- a/src/Particle/ParticleHeader.cpp
+++ b/src/Particle/ParticleHeader.cpp
@@ -13,7 +13,26 @@ void init_ParticleHeader(py::module& m)
 {
     using namespace amrex;
 
-    py::class_<ParticleHeader>(m, "ParticleHeader")
+    py::class_<ParticleHeader> particle_header(m, "ParticleHeader");
+
+    py::class_<ParticleHeader::GridEntry>(particle_header, "GridEntry")
+        .def(py::init<>())
+        .def_readwrite("which", &ParticleHeader::GridEntry::which,
+            "index of the binary data file (DATA_XXXXX) holding this grid's particles")
+        .def_readwrite("count", &ParticleHeader::GridEntry::count,
+            "number of particles stored for this grid")
+        .def_readwrite("where", &ParticleHeader::GridEntry::where,
+            "byte offset of this grid's particle data within the data file")
+        .def("__repr__",
+            [](ParticleHeader::GridEntry const & e) {
+                return "<amrex.ParticleHeader.GridEntry: DATA_" +
+                    std::to_string(e.which) + ", " +
+                    std::to_string(e.count) + " particles at byte " +
+                    std::to_string(e.where) + ">";
+            })
+        ;
+
+    particle_header
         .def(py::init<>())
 
         .def_static("read", &ParticleHeader::read,
@@ -53,6 +72,22 @@ void init_ParticleHeader(py::module& m)
             "the next particle id to hand out")
         .def_readwrite("finest_level", &ParticleHeader::finest_level,
             "finest level present in the file")
+        .def_property_readonly("grids",
+            [](ParticleHeader const & h) {
+                py::list levels;
+                for (auto const & lev : h.grids) {
+                    py::list entries;
+                    for (auto const & entry : lev) {
+                        entries.append(entry);
+                    }
+                    levels.append(entries);
+                }
+                return levels;
+            },
+            "per level and grid: where each grid's binary particle data is\n"
+            "stored, as a list (levels) of lists of\n"
+            ":py:class:`~amrex.ParticleHeader.GridEntry`. Grids without\n"
+            "particles have a zero ``count``.")
 
         .def("__repr__",
             [](ParticleHeader const & h) {

--- a/src/amrex/extensions/ParticleContainer.py
+++ b/src/amrex/extensions/ParticleContainer.py
@@ -172,6 +172,47 @@ def pc_to_df(self, local=True, comm=None, root_rank=0):
     return df
 
 
+def list_particle_species(plotfile):
+    """List the particle species stored in a plotfile or checkpoint.
+
+    Particle data lives in sub-directories of a plotfile, named by the writing
+    application (e.g. ``"particles"``, ``"electrons"``, ``"particle0"``). This
+    scans the plotfile for sub-directories that contain a particle ``Header``
+    file and returns their names, ready to be passed as ``particle_dir`` to
+    :py:func:`read_particles` or :py:class:`amrex.ParticleHeader`.
+
+    Parameters
+    ----------
+    plotfile : str
+        Path to the plotfile / checkpoint directory.
+
+    Returns
+    -------
+    list of str
+        Names of the particle species sub-directories, sorted alphabetically.
+    """
+    import os
+
+    species = []
+    for entry in sorted(os.scandir(plotfile), key=lambda e: e.name):
+        if not entry.is_dir():
+            continue
+        header = os.path.join(entry.path, "Header")
+        if not os.path.isfile(header):
+            continue
+        try:
+            with open(header) as f:
+                first_token = f.readline().strip()
+        except OSError:
+            continue
+        # particle Headers start with a version string like
+        # "Version_Two_Dot_One_double"; the mesh Header sits at the top level
+        # and mesh level directories (Level_*) contain no Header file
+        if first_token.startswith("Version_"):
+            species.append(entry.name)
+    return species
+
+
 def read_particles(
     amr, plotfile, particle_dir="particles", communicate=True, container=None
 ):

--- a/src/amrex/space1d/__init__.py
+++ b/src/amrex/space1d/__init__.py
@@ -50,6 +50,7 @@ register_AoS_extension(amrex_1d_pybind)
 register_ParticleContainer_extension(amrex_1d_pybind)
 
 
+from ..extensions.ParticleContainer import list_particle_species  # noqa
 from ..extensions.ParticleContainer import read_particles as _read_particles
 
 

--- a/src/amrex/space2d/__init__.py
+++ b/src/amrex/space2d/__init__.py
@@ -50,6 +50,7 @@ register_AoS_extension(amrex_2d_pybind)
 register_ParticleContainer_extension(amrex_2d_pybind)
 
 
+from ..extensions.ParticleContainer import list_particle_species  # noqa
 from ..extensions.ParticleContainer import read_particles as _read_particles
 
 

--- a/src/amrex/space3d/__init__.py
+++ b/src/amrex/space3d/__init__.py
@@ -50,6 +50,7 @@ register_AoS_extension(amrex_3d_pybind)
 register_ParticleContainer_extension(amrex_3d_pybind)
 
 
+from ..extensions.ParticleContainer import list_particle_species  # noqa
 from ..extensions.ParticleContainer import read_particles as _read_particles
 
 

--- a/tests/test_readparticles.py
+++ b/tests/test_readparticles.py
@@ -90,6 +90,52 @@ def test_read_particles_header():
 
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_read_particles_grid_table():
+    """The particle Header's grid table locates every grid's binary data."""
+    plt_file_name = "plt_read_grids"
+    n_part = 15
+    write_test_plotfile(plt_file_name, n_part)
+
+    # Manual: Read Particle Grid Table START
+    # the per-level grid table locates each grid's binary particle data:
+    # data file index (DATA_XXXXX), particle count and byte offset
+    header = amr.ParticleHeader.read(plt_file_name, "particles")
+
+    for lev, entries in enumerate(header.grids):
+        for entry in entries:
+            print(lev, entry.which, entry.count, entry.where)
+    # Manual: Read Particle Grid Table END
+
+    assert len(header.grids) == header.finest_level + 1
+    counted = sum(entry.count for entries in header.grids for entry in entries)
+    assert counted == header.num_particles == n_part
+    for entries in header.grids:
+        for entry in entries:
+            assert entry.which >= 0
+            assert entry.count >= 0
+            assert entry.where >= 0
+
+    shutil.rmtree(plt_file_name)
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
+def test_list_particle_species():
+    """Particle species sub-directories are discovered by name."""
+    plt_file_name = "plt_read_species"
+    write_test_plotfile(plt_file_name, 5)
+
+    # Manual: List Particle Species START
+    # discover the particle species stored in a plotfile
+    species = amr.list_particle_species(plt_file_name)
+    print(species)  # e.g., ["particles"]
+    # Manual: List Particle Species END
+
+    assert species == ["particles"]
+
+    shutil.rmtree(plt_file_name)
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="Requires AMREX_SPACEDIM = 3")
 def test_read_particles_roundtrip():
     """amr.read_particles reconstructs a container from a plotfile with no prior
     knowledge of its compile-time layout."""
@@ -294,6 +340,9 @@ def test_read_particles_multilevel():
     )
     header = amr.ParticleHeader.read(plt_file_name, "particles")
     assert header.finest_level == 1
+    # the grid table accounts for the particles level by level
+    table_lev = [sum(e.count for e in entries) for entries in header.grids]
+    assert table_lev == n_lev
 
     pc_read = amr.read_particles(plt_file_name, "particles")
     assert pc_read.finest_level == 0


### PR DESCRIPTION
Follow-up to #581 (stacked on its branch; the first commits shown here belong to #581).

Depends on:
- [x] #581 (runtime-SoA particle reading)
- [x] AMReX-Codes/amrex#5577 (`ParticleHeader` grid table) - the binding needs an AMReX pin that includes it

## Summary

- **Bind the particle grid table**: `amrex.ParticleHeader.grids` exposes AMReX's per-level table locating each grid's binary particle data (`GridEntry`: data file index `which`, particle `count`, byte offset `where`) - same C++ parser as `ParticleContainer::Restart`, no duplicated format logic. Useful for standalone tools, e.g. format converters and parallel readers.
- **Species discovery**: `amrex.space3d.list_particle_species(plotfile)` lists the particle sub-directories of a plotfile/checkpoint by their particle `Header` files.
- **Compat**: disambiguate `Redistribute` for AMReX development (new `IntVect nGrow` overload).
- Docs: both features added to the "Read Back Plotfiles" workflow page.

## Testing

Built against AMReX `development` + AMReX-Codes/amrex#5577 + AMReX-Codes/amrex#5578 (`-DpyAMReX_amrex_src=...`):

```
python -m pytest tests/test_readparticles.py tests/test_plotfiledata.py -v
```

10 passed - including new `test_read_particles_grid_table` (table totals match `num_particles`) and `test_list_particle_species`, and per-level grid-table count assertions in `test_read_particles_multilevel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)