### PR TITLE
Add wheel build isolation option and fix platform tagging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel
     ${CMAKE_COMMAND} -E rm -f -r amrex-whl
     COMMAND
         ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/
-            ${Python_EXECUTABLE} -m pip ${PY_PIP_OPTIONS} wheel --no-build-isolation --no-deps --wheel-dir=amrex-whl "${pyAMReX_SOURCE_DIR}"
+            ${Python_EXECUTABLE} -m pip ${PY_PIP_OPTIONS} wheel --no-deps --wheel-dir=amrex-whl "${pyAMReX_SOURCE_DIR}"
     COMMAND_EXPAND_LISTS VERBATIM
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,15 @@ set(PY_PIP_OPTIONS "-v" CACHE STRING
     "Additional parameters to pass to `pip` as ; separated list")
 set(PY_PIP_INSTALL_OPTIONS "" CACHE STRING
     "Additional parameters to pass to `pip install` as ; separated list")
+option(pip-build-isolation
+    "Build the Python wheel in an isolated build environment"
+    OFF
+)
+if(pip-build-isolation)
+    set(_pyAMReX_PIP_BUILD_ISOLATION_OPTION "")
+else()
+    set(_pyAMReX_PIP_BUILD_ISOLATION_OPTION "--no-build-isolation")
+endif()
 
 # add a prefix to custom targets so we do not collide if used as a subproject
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
@@ -311,7 +320,9 @@ add_custom_target(${pyAMReX_CUSTOM_TARGET_PREFIX}pip_wheel
     ${CMAKE_COMMAND} -E rm -f -r amrex-whl
     COMMAND
         ${CMAKE_COMMAND} -E env PYAMREX_LIBDIR=${CMAKE_PYTHON_OUTPUT_DIRECTORY}/amrex/
-            ${Python_EXECUTABLE} -m pip ${PY_PIP_OPTIONS} wheel --no-deps --wheel-dir=amrex-whl "${pyAMReX_SOURCE_DIR}"
+            ${Python_EXECUTABLE} -m pip ${PY_PIP_OPTIONS} wheel
+            ${_pyAMReX_PIP_BUILD_ISOLATION_OPTION} --no-deps
+            --wheel-dir=amrex-whl "${pyAMReX_SOURCE_DIR}"
     COMMAND_EXPAND_LISTS VERBATIM
     WORKING_DIRECTORY
         ${pyAMReX_BINARY_DIR}

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Furthermore, pyAMReX adds a few selected CMake build options:
 | `pyAMReX_CCACHE`             | **ON**/OFF                                 | Search and use CCache to speed up rebuilds                    |
 | `pyAMReX_IPO`                | **ON**/OFF                                 | Compile with interprocedural/link optimization (IPO/LTO)      |
 | `pyAMReX_INSTALL`            | **ON**/OFF                                 | Enable install targets for pyAMReX                            |
+| `pip-build-isolation`        | ON/**OFF**                                 | Build the Python wheel in an isolated build environment       |
 | `pyAMReX_amrex_src`          | *None*                                     | Absolute path to AMReX source directory (preferred if set)    |
 | `pyAMReX_amrex_internal`     | **ON**/OFF                                 | Needs a pre-installed AMReX library if set to `OFF`           |
 | `pyAMReX_amrex_repo`         | `https://github.com/AMReX-Codes/amrex.git` | Repository URI to pull and build AMReX from                   |

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -91,6 +91,7 @@ CMake Option                    Default & Values                             Des
 ``AMReX_SPACEDIM``              ``3``                                        Dimension(s) of AMReX as a ``;``-separated list
 ``AMReX_BUILD_SHARED_LIBS``     ON/**OFF**                                   Build AMReX library as shared (required for app extensions)
 ``pyAMReX_INSTALL``             **ON**/OFF                                   Enable install targets for pyAMReX
+``pip-build-isolation``         ON/**OFF**                                   Build the Python wheel in an isolated build environment
 ``PY_PIP_OPTIONS``              ``-v``                                       Additional options for ``pip``, e.g., ``-vvv;-q``
 ``PY_PIP_INSTALL_OPTIONS``      *None*                                       Additional options for ``pip install``, e.g., ``--user;-q``
 ``Python_EXECUTABLE``           (newest found)                               Path to Python executable

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import sysconfig
 
-from setuptools import Extension, setup
+from setuptools import Distribution, Extension, setup
 from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
 
@@ -45,8 +45,17 @@ class CopyPreBuild(build):
             PYAMREX_libdir,
             dst_path,
             dirs_exist_ok=True,
-            ignore=shutil.ignore_patterns("chk*", "diags*", "plt*"),
+            ignore=shutil.ignore_patterns(
+                "__pycache__", "*.pyc", "chk*", "diags*", "plt*"
+            ),
         )
+
+
+class BinaryDistribution(Distribution):
+    """Keep prebuilt-artifact wheels correctly tagged as platform wheels."""
+
+    def has_ext_modules(self):
+        return True
 
 
 class CMakeExtension(Extension):
@@ -273,6 +282,7 @@ setup(
     },
     # CMake: self-built as extension module
     ext_modules=cxx_modules,
+    distclass=BinaryDistribution,
     cmdclass=cmdclass,
     zip_safe=False,
     python_requires=">=3.11",


### PR DESCRIPTION
## Summary

Separates wheel-install reliability fixes from the nanobind migration.

- add an option to enable pip build isolation for the CMake wheel target
- mark prebuilt artifact wheels as platform wheels
- exclude Python bytecode caches from staged package contents

## Why

The wheel target often needs its declared build requirements installed in an isolated environment, and a wheel containing compiled artifacts must receive a platform-specific tag.

## Validation

```console
$ uv venv --python 3.13 .venv
$ source .venv/bin/activate
$ AMREX_SPACEDIM=3 \
   CMAKE_BUILD_PARALLEL_LEVEL=8 \
   uv pip install -e .
$ python -c 'import amrex.space3d as amr; print(amr.Config.spacedim)'
3
```
