### PR TITLE
Config: Refactor into Dedicated Module

### DIFF
--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -3,14 +3,9 @@
 #include <AMReX.H>
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
-#include <AMReX_SIMD.H>
 
 #include <string>
 
-
-namespace amrex {
-   struct Config {};
-}
 
 void init_AMReX(py::module& m)
 {
@@ -23,101 +18,6 @@ void init_AMReX(py::module& m)
         .def_static("top", &AMReX::top,
                     py::return_value_policy::reference)
     ;
-
-    py::class_<Config>(m, "Config")
-        .def_property_readonly_static(
-            "amrex_version",
-            [](py::object) { return Version(); },
-            "AMReX library version")
-        .def_property_readonly_static(
-            "spacedim",
-            [](py::object) { return AMREX_SPACEDIM; })
-        .def_property_static(
-            "verbose",
-            [](py::object) { return Verbose(); },
-            [](py::object, const int v) { SetVerbose(v); })
-        .def_property_readonly_static(
-            "have_eb",
-            [](py::object){
-#ifdef AMREX_USE_EB
-                return true;
-#else
-                return false;
-#endif
-            })
-        .def_property_readonly_static(
-            "have_mpi",
-            [](py::object){
-#ifdef AMREX_USE_MPI
-                return true;
-#else
-                return false;
-#endif
-            })
-        .def_property_readonly_static(
-            "have_gpu",
-            [](py::object){
-#ifdef AMREX_USE_GPU
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "have_omp",
-            [](py::object){
-#ifdef AMREX_USE_OMP
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "have_simd",
-            [](py::object const &){
-#ifdef AMREX_USE_SIMD
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "simd_size",
-            [](py::object const &){
-                return amrex::simd::native_simd_size_real;
-        })
-        .def_property_readonly_static(
-            "gpu_backend",
-            [](py::object){
-#ifdef AMREX_USE_CUDA
-                return "CUDA";
-#elif defined(AMREX_USE_HIP)
-                return "HIP";
-#elif defined(AMREX_USE_DPCPP)
-                return "SYCL";
-#else
-                return py::none();
-#endif
-            })
-        .def_property_readonly_static(
-            "precision",
-            [](py::object){
-#ifdef AMREX_USE_FLOAT
-                return "SINGLE";
-#else
-                return "DOUBLE";
-#endif
-        })
-        .def_property_readonly_static(
-            "precision_particles",
-            [](py::object){
-#ifdef AMREX_SINGLE_PRECISION_PARTICLES
-                return "SINGLE";
-#else
-                return "DOUBLE";
-#endif
-            })
-        ;
 
     m.def("initialize",
           [](const py::list args) {

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -17,6 +17,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
         Box.cpp
         RealBox.cpp
         BoxArray.cpp
+        Config.cpp
         CoordSys.cpp
         Dim3.cpp
         DistributionMapping.cpp

--- a/src/Base/Config.cpp
+++ b/src/Base/Config.cpp
@@ -75,9 +75,11 @@ void init_Config (py::module& m)
             {"amrex_version", {
                 Version(),
                 "AMReX library version"}},
+
             {"gpu_backend", {
                 gpu_backend,
                 "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"}},
+
             {"have_eb", {
 #ifdef AMREX_USE_EB
                 true,
@@ -85,6 +87,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports embedded boundaries"}},
+
             {"have_gpu", {
 #ifdef AMREX_USE_GPU
                 true,
@@ -92,6 +95,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports GPUs"}},
+
             {"have_mpi", {
 #ifdef AMREX_USE_MPI
                 true,
@@ -99,6 +103,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports MPI"}},
+
             {"have_omp", {
 #ifdef AMREX_USE_OMP
                 true,
@@ -106,6 +111,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports OpenMP"}},
+
             {"have_simd", {
 #ifdef AMREX_USE_SIMD
                 true,
@@ -113,6 +119,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports explicit SIMD vectorization"}},
+
             {"precision", {
 #ifdef AMREX_USE_FLOAT
                 std::string{"SINGLE"},
@@ -120,6 +127,7 @@ void init_Config (py::module& m)
                 std::string{"DOUBLE"},
 #endif
                 "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"}},
+
             {"precision_particles", {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
                 std::string{"SINGLE"},
@@ -127,9 +135,11 @@ void init_Config (py::module& m)
                 std::string{"DOUBLE"},
 #endif
                 "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"}},
+
             {"simd_size", {
                 static_cast<int>(amrex::simd::native_simd_size_real),
                 "Number of amrex::Real elements in a native SIMD vector"}},
+
             {"spacedim", {
                 AMREX_SPACEDIM,
                 "Number of spatial dimensions (AMREX_SPACEDIM)"}}
@@ -154,8 +164,10 @@ void init_Config (py::module& m)
     py::class_<Config> pyAMReXConfig(
         m, "Config", py::metaclass(config_metaclass)
     );
-    for (auto const & [name, entry] : *config)
+    for (auto const & kv : *config)
     {
+        std::string const & name = kv.first;
+        ConfigEntry const & entry = kv.second;
         pyAMReXConfig.def_property_readonly_static(
             name.c_str(),
             [config, name](py::object const &) {

--- a/src/Base/Config.cpp
+++ b/src/Base/Config.cpp
@@ -1,0 +1,184 @@
+/* Copyright 2021-2026 The AMReX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyAMReX.H"
+
+#include <AMReX.H>
+#include <AMReX_SIMD.H>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+
+
+namespace amrex {
+   struct Config {};
+}
+
+namespace
+{
+    using ConfigValue = std::variant<
+        bool,
+        int,
+        std::string,
+        std::optional<std::string>
+    >;
+    using ConfigMap = std::map<std::string, ConfigValue>;
+
+    std::string config_repr (ConfigMap const & config)
+    {
+        std::size_t name_width = 0;
+        for (auto const & entry : config)
+        {
+            if (entry.first.size() > name_width)
+            {
+                name_width = entry.first.size();
+            }
+        }
+
+        std::string repr = "amrex.Config:";
+        for (auto const & [name, value] : config)
+        {
+            repr += "\n    " + name;
+            repr.append(name_width - name.size(), ' ');
+            repr += " = ";
+            repr += py::repr(py::cast(value)).cast<std::string>();
+        }
+        return repr;
+    }
+}
+
+void init_Config (py::module& m)
+{
+    using namespace amrex;
+
+    std::optional<std::string> gpu_backend;
+#ifdef AMREX_USE_CUDA
+    gpu_backend = "CUDA";
+#elif defined(AMREX_USE_HIP)
+    gpu_backend = "HIP";
+#elif defined(AMREX_USE_DPCPP)
+    gpu_backend = "SYCL";
+#endif
+
+    std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
+        ConfigMap{
+            {"amrex_version", Version()},
+            {"gpu_backend", gpu_backend},
+            {"have_eb",
+#ifdef AMREX_USE_EB
+                true
+#else
+                false
+#endif
+            },
+            {"have_gpu",
+#ifdef AMREX_USE_GPU
+                true
+#else
+                false
+#endif
+            },
+            {"have_mpi",
+#ifdef AMREX_USE_MPI
+                true
+#else
+                false
+#endif
+            },
+            {"have_omp",
+#ifdef AMREX_USE_OMP
+                true
+#else
+                false
+#endif
+            },
+            {"have_simd",
+#ifdef AMREX_USE_SIMD
+                true
+#else
+                false
+#endif
+            },
+            {"precision",
+#ifdef AMREX_USE_FLOAT
+                std::string{"SINGLE"}
+#else
+                std::string{"DOUBLE"}
+#endif
+            },
+            {"precision_particles",
+#ifdef AMREX_SINGLE_PRECISION_PARTICLES
+                std::string{"SINGLE"}
+#else
+                std::string{"DOUBLE"}
+#endif
+            },
+            {"simd_size",
+                static_cast<int>(amrex::simd::native_simd_size_real)},
+            {"spacedim", AMREX_SPACEDIM}
+        }
+    );
+
+    std::map<std::string, char const *> const doc = {
+        {"amrex_version", "AMReX library version"},
+        {"gpu_backend", "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"},
+        {"have_eb", "Build supports embedded boundaries"},
+        {"have_gpu", "Build supports GPUs"},
+        {"have_mpi", "Build supports MPI"},
+        {"have_omp", "Build supports OpenMP"},
+        {"have_simd", "Build supports explicit SIMD vectorization"},
+        {"precision", "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"},
+        {"precision_particles", "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"},
+        {"simd_size", "Number of amrex::Real elements in a native SIMD vector"},
+        {"spacedim", "Number of spatial dimensions (AMREX_SPACEDIM)"}
+    };
+
+    py::dict config_metaclass_namespace;
+    config_metaclass_namespace["__module__"] = m.attr("__name__");
+    config_metaclass_namespace["__repr__"] = py::cpp_function(
+        [config]() {
+            return config_repr(*config);
+        }
+    );
+    py::object const amrex_class = m.attr("AMReX");
+    py::object const pybind11_metaclass = py::type::of(amrex_class);
+    py::object const config_metaclass = py::type::of(pybind11_metaclass)(
+        "ConfigMeta",
+        py::make_tuple(pybind11_metaclass),
+        config_metaclass_namespace
+    );
+
+    py::class_<Config> pyAMReXConfig(
+        m, "Config", py::metaclass(config_metaclass)
+    );
+    for (auto const & entry : *config)
+    {
+        pyAMReXConfig.def_property_readonly_static(
+            entry.first.c_str(),
+            [config, name = entry.first](py::object const &) {
+                return config->at(name);
+            },
+            doc.at(entry.first)
+        );
+    }
+    pyAMReXConfig.def_static(
+        "to_dict",
+        [config]() {
+            return *config;
+        },
+        "Return the AMReX build configuration as a dictionary."
+    );
+
+    // runtime-mutable option, not part of the static build configuration
+    pyAMReXConfig.def_property_static(
+        "verbose",
+        [](py::object const &) { return Verbose(); },
+        [](py::object const &, int const v) { SetVerbose(v); },
+        "Verbosity level of AMReX outputs"
+    );
+}

--- a/src/Base/Config.cpp
+++ b/src/Base/Config.cpp
@@ -27,7 +27,12 @@ namespace
         std::string,
         std::optional<std::string>
     >;
-    using ConfigMap = std::map<std::string, ConfigValue>;
+    struct ConfigEntry
+    {
+        ConfigValue value;
+        char const * doc;
+    };
+    using ConfigMap = std::map<std::string, ConfigEntry>;
 
     std::string config_repr (ConfigMap const & config)
     {
@@ -41,12 +46,12 @@ namespace
         }
 
         std::string repr = "amrex.Config:";
-        for (auto const & [name, value] : config)
+        for (auto const & [name, entry] : config)
         {
             repr += "\n    " + name;
             repr.append(name_width - name.size(), ' ');
             repr += " = ";
-            repr += py::repr(py::cast(value)).cast<std::string>();
+            repr += py::repr(py::cast(entry.value)).cast<std::string>();
         }
         return repr;
     }
@@ -67,76 +72,69 @@ void init_Config (py::module& m)
 
     std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
         ConfigMap{
-            {"amrex_version", Version()},
-            {"gpu_backend", gpu_backend},
-            {"have_eb",
+            {"amrex_version", {
+                Version(),
+                "AMReX library version"}},
+            {"gpu_backend", {
+                gpu_backend,
+                "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"}},
+            {"have_eb", {
 #ifdef AMREX_USE_EB
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_gpu",
+                "Build supports embedded boundaries"}},
+            {"have_gpu", {
 #ifdef AMREX_USE_GPU
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_mpi",
+                "Build supports GPUs"}},
+            {"have_mpi", {
 #ifdef AMREX_USE_MPI
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_omp",
+                "Build supports MPI"}},
+            {"have_omp", {
 #ifdef AMREX_USE_OMP
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_simd",
+                "Build supports OpenMP"}},
+            {"have_simd", {
 #ifdef AMREX_USE_SIMD
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"precision",
+                "Build supports explicit SIMD vectorization"}},
+            {"precision", {
 #ifdef AMREX_USE_FLOAT
-                std::string{"SINGLE"}
+                std::string{"SINGLE"},
 #else
-                std::string{"DOUBLE"}
+                std::string{"DOUBLE"},
 #endif
-            },
-            {"precision_particles",
+                "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"}},
+            {"precision_particles", {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-                std::string{"SINGLE"}
+                std::string{"SINGLE"},
 #else
-                std::string{"DOUBLE"}
+                std::string{"DOUBLE"},
 #endif
-            },
-            {"simd_size",
-                static_cast<int>(amrex::simd::native_simd_size_real)},
-            {"spacedim", AMREX_SPACEDIM}
+                "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"}},
+            {"simd_size", {
+                static_cast<int>(amrex::simd::native_simd_size_real),
+                "Number of amrex::Real elements in a native SIMD vector"}},
+            {"spacedim", {
+                AMREX_SPACEDIM,
+                "Number of spatial dimensions (AMREX_SPACEDIM)"}}
         }
     );
-
-    std::map<std::string, char const *> const doc = {
-        {"amrex_version", "AMReX library version"},
-        {"gpu_backend", "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"},
-        {"have_eb", "Build supports embedded boundaries"},
-        {"have_gpu", "Build supports GPUs"},
-        {"have_mpi", "Build supports MPI"},
-        {"have_omp", "Build supports OpenMP"},
-        {"have_simd", "Build supports explicit SIMD vectorization"},
-        {"precision", "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"},
-        {"precision_particles", "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"},
-        {"simd_size", "Number of amrex::Real elements in a native SIMD vector"},
-        {"spacedim", "Number of spatial dimensions (AMREX_SPACEDIM)"}
-    };
 
     py::dict config_metaclass_namespace;
     config_metaclass_namespace["__module__"] = m.attr("__name__");
@@ -156,20 +154,25 @@ void init_Config (py::module& m)
     py::class_<Config> pyAMReXConfig(
         m, "Config", py::metaclass(config_metaclass)
     );
-    for (auto const & entry : *config)
+    for (auto const & [name, entry] : *config)
     {
         pyAMReXConfig.def_property_readonly_static(
-            entry.first.c_str(),
-            [config, name = entry.first](py::object const &) {
-                return config->at(name);
+            name.c_str(),
+            [config, name](py::object const &) {
+                return config->at(name).value;
             },
-            doc.at(entry.first)
+            entry.doc
         );
     }
     pyAMReXConfig.def_static(
         "to_dict",
         [config]() {
-            return *config;
+            py::dict d;
+            for (auto const & [name, entry] : *config)
+            {
+                d[name.c_str()] = entry.value;
+            }
+            return d;
         },
         "Return the AMReX build configuration as a dictionary."
     );

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -26,6 +26,7 @@ void init_BCUtil(py::module&);
 void init_Box(py::module &);
 void init_RealBox(py::module &);
 void init_BoxArray(py::module &);
+void init_Config(py::module&);
 void init_CoordSys(py::module&);
 void init_Dim3(py::module&);
 void init_DistributionMapping(py::module&);
@@ -125,6 +126,7 @@ PYBIND11_MODULE(amrex_3d_pybind, m) {
     // note: order from parent to child classes and argument usage
 
     init_AMReX(m);
+    init_Config(m);  // after AMReX (metaclass is derived from its type)
     init_Arena(m);
     init_Dim3(m);
     init_Algorithm(m);


### PR DESCRIPTION
Port the improved Config treatment from ImpactX
(BLAST-ImpactX/impactx#1580) to pyAMReX:

- move the `Config` bindings from `AMReX.cpp` into a new `Config.cpp`
- centralize all build-time options in a single `std::variant`-based map, from which the read-only static properties are generated
- add a custom metaclass `__repr__` that prints the build configuration as an aligned table
- add `Config.to_dict()` returning the build configuration as a dict
- keep the runtime-mutable `verbose` option as a separate read/write static property