### PR TITLE
CI: Actions Cache Hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,17 @@
 name: 👑 CI
 
-on: [push, pull_request]
+on:
+  # Developers work from forks, whose pushes never trigger us here; the only
+  # branches pushed directly to this repo are mainline and the pre-commit.ci /
+  # dependabot update branches, which open PRs and are covered by the
+  # pull_request trigger below. Running on those pushes as well would only
+  # duplicate the CI and store a second, redundant set of Actions caches under
+  # refs/heads/<branch> next to the refs/pull/<n>/merge ones.
+  # A branch filter also excludes tag pushes, which would otherwise cache under
+  # the never-restorable refs/heads/refs/tags/<tag>.
+  push:
+    branches: [development]
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ci

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -2,7 +2,9 @@ name: CleanUpCache
 
 on:
   workflow_run:
-    workflows: [👑 CI]
+    # 🔎 CodeQL also runs standalone on a schedule; those runs store their
+    # caches under `ccache-🔎 CodeQL-...` and need cleaning up, too.
+    workflows: [👑 CI, 🔎 CodeQL]
     types:
       - completed
 
@@ -59,6 +61,25 @@ jobs:
           do
             # Delete all entries except the last used one
             old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "${j}-git-" --sort last-used | cut -f 1 | tail -n +2)
+            for k in $old_keys
+            do
+              gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+            done
+          done
+          unset IFS
+
+          # github/codeql-action stores its own TRAP database caches, which are
+          # the single largest entries we keep (~1 GB each). They do not carry
+          # the `ccache-` prefix and look like
+          #   codeql-trap-<n>-<codeql-version>-<language>-<git-hash>
+          # Strip the trailing git hash to group them per language and version,
+          # then keep only the last used entry of each group.
+          codeql_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "codeql-trap-" | cut -f 1 | sed -E 's/-[0-9a-f]{40}$//' | sort | uniq)
+
+          IFS=$'\n'
+          for j in $codeql_jobs
+          do
+            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "${j}-" --sort last-used | cut -f 1 | tail -n +2)
             for k in $old_keys
             do
               gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set Up Cache
         if: ${{ matrix.language == 'cpp' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ccache
           key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/dependencies/dependencies_ccache.sh
+++ b/.github/workflows/dependencies/dependencies_ccache.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
-if [[ $# -eq 2 ]]; then
+set -eu -o pipefail
+
+if [[ $# -eq 1 ]]; then
   CVER=$1
 else
-  CVER=4.8
+  CVER=4.13.6
 fi
 
-wget https://github.com/ccache/ccache/releases/download/v${CVER}/ccache-${CVER}-linux-x86_64.tar.xz
-tar xvf ccache-${CVER}-linux-x86_64.tar.xz
-sudo mv -f ccache-${CVER}-linux-x86_64/ccache /usr/local/bin/
-sudo rm -rf ccache-${CVER}-linux-x86_64
-sudo rm -f ccache-${CVER}-linux-x86_64.tar.xz
+wget https://github.com/ccache/ccache/releases/download/v${CVER}/ccache-${CVER}-linux-x86_64-glibc.tar.xz
+tar xvf ccache-${CVER}-linux-x86_64-glibc.tar.xz
+sudo mv -f ccache-${CVER}-linux-x86_64-glibc/ccache /usr/local/bin/
+sudo rm -rf ccache-${CVER}-linux-x86_64-glibc
+sudo rm -f ccache-${CVER}-linux-x86_64-glibc.tar.xz

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -21,7 +21,7 @@ jobs:
         .github/workflows/dependencies/hip.sh 6.3.2
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -17,7 +17,7 @@ jobs:
         .github/workflows/dependencies/dpcpp.sh
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
@@ -66,7 +66,7 @@ jobs:
         .github/workflows/dependencies/dpcpp.sh
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Dependencies
       run: .github/workflows/dependencies/dependencies_mac.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/Library/Caches/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/stubs.yml
+++ b/.github/workflows/stubs.yml
@@ -47,7 +47,7 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
 
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
         .github/workflows/dependencies/dependencies_gcc.sh 11
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
@@ -67,7 +67,7 @@ jobs:
         .github/workflows/dependencies/dependencies_gcc.sh 14
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
@@ -119,7 +119,7 @@ jobs:
         .github/workflows/dependencies/dependencies_clang14_libcpp.sh
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
@@ -166,7 +166,7 @@ jobs:
         .github/workflows/dependencies/dependencies_clang18.sh
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
@@ -216,7 +216,7 @@ jobs:
           .github/workflows/dependencies/dependencies_clang18.sh
           .github/workflows/dependencies/dependencies_ccache.sh
       - name: Set Up Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ccache
           key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
@@ -270,7 +270,7 @@ jobs:
         .github/workflows/dependencies/dependencies_nvcc.sh 12.2
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,7 +94,7 @@ jobs:
       # live on the Windows-side workspace. The build below copies it into a
       # native ext4 directory inside WSL (fast) for the actual ccache I/O and
       # writes it back here at the end, avoiding slow 9p-mounted ccache access.
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/zenodo.yml
+++ b/.github/workflows/zenodo.yml
@@ -7,7 +7,10 @@
 
 name: 🗃️ Zenodo
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [development]
+  pull_request:
 
 jobs:
   zenodo:


### PR DESCRIPTION
## Problem

The repository sits at the **10 GB GitHub Actions cache quota** (9.57 GB when measured), so GitHub LRU-evicts entries. The `stubs` job loses its cache every time: `ci.yml` serializes `stubs → ubuntu → everything else`, so its ~58 MB entry is both the smallest and the oldest-accessed by the time the rest of CI has filled the quota.

Measured on PR #603 versus the last `development` run:

| | `Set Up Cache` | `Build & Install` | ccache hits |
|---|---|---|---|
| cache evicted (PR #603) | 1 s, no restore | **21m54s** | — |
| cache present (development) | 2 s, 58 MB | **46 s** | 596/599 (99.5%) |

`gh cache list --key "ccache-👑 CI-stubs"` returned nothing at all — every generation had been evicted, even though each run kept saving one.

## Changes

Reclaim quota and align the cache handling with WarpX, which does not have this problem:

- **Only run on pushes to `development`.** Developers work from forks, whose pushes never trigger this repository; the only branches pushed here directly are mainline and the pre-commit.ci / dependabot update branches, which open PRs anyway. Running on those pushes as well stored a second, redundant cache set under `refs/heads/<branch>` next to the `refs/pull/<n>/merge` one — 2.02 GB when measured. A branch filter also excludes tag pushes, which cached under the never-restorable `refs/heads/refs/tags/<tag>` (382 MB when measured).

- **Clean up the CodeQL caches like every other runner.** The scheduled `🔎 CodeQL` runs are standalone, so their caches are keyed `ccache-🔎 CodeQL-...` rather than `ccache-👑 CI-...` and were pruned by nothing — `CleanUpCache` only triggered on `👑 CI`. Additionally prune the TRAP database caches that `github/codeql-action` stores itself (~1 GB per generation, 1.93 GB when measured); those carry neither the `ccache-` prefix nor a `-git-` separator, so they need their own pass.

- **Update ccache 4.8 → 4.13.6 and `actions/cache` v4 → v6**, matching WarpX.

## Effect

Together with a one-off manual purge of the duplicates described above, cache usage went from 9.57 GB to 6.84 GB, and PR #603's next run stored a `ccache-👑 CI-stubs-*` entry again — the first one to exist in the repository during this investigation.

## Notes

- `CCACHE_MAXSIZE` values are deliberately left alone. WarpX caps at 600 M, but the `gcc10`/`stubs` jobs here build `AMReX_SPACEDIM="1;2;3"`; shrinking their budget would trade eviction at the GitHub level for thrashing inside ccache.
- The `2:distributionDirectory_Ubuntu_24.4.4` cache (371 MB, from the oneAPI setup) is still unmanaged. Left for a follow-up.