### PR TITLE
DLPack: fix SYCL interop teardown

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -2,6 +2,6 @@
     "version_pyamrex": "26.08",
     "version_amrex": "26.08",
     "version_pybind11_min": "v3.0.0",
-    "commit_amrex": "26.08",
+    "commit_amrex": "5273b558c13011573e1b6bf71860db4fcc1f0cfb",
     "commit_pybind11": "v3.0.4"
 }

--- a/docs/source/usage/zerocopy.rst
+++ b/docs/source/usage/zerocopy.rst
@@ -82,5 +82,11 @@ Frameworks not covered above can exchange data with pyAMReX through the standard
 Data objects of pyAMReX implement ``__dlpack__`` and ``__dlpack_device__`` and can be consumed by, e.g., ``numpy.from_dlpack``, ``cupy.from_dlpack``, ``dpnp.from_dlpack``, ``torch.from_dlpack`` or ``jax.dlpack``.
 Both DLPack 1.x ("versioned") and legacy consumers are supported, including device-to-host transfers via ``from_dlpack(..., device="cpu")``.
 
+A consuming NumPy, CuPy, dpnp, PyTorch or other DLPack array must be released
+before calling ``amrex.finalize()``.  Finalization runs Python's garbage
+collector and raises ``RuntimeError`` if a DLPack managed tensor is still
+alive, because it can retain an AMReX object or arena allocation after runtime
+teardown.  Delete all consuming arrays and capsules, then retry finalization.
+
 An exception is the `deprecated <https://github.com/AMReX-Codes/pyamrex/issues/459>`__ particle ``ArrayOfStructs``: DLPack cannot describe its record (struct) element type.
 Use its structured ``__array_interface__``/``__cuda_array_interface__`` or the per-component particle struct-of-arrays data instead.

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -1,9 +1,11 @@
 #include "pyAMReX.H"
+#include "dlpack/DLPackHelpers.H"
 
 #include <AMReX.H>
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
 
+#include <stdexcept>
 #include <string>
 
 
@@ -61,14 +63,26 @@ void init_AMReX(py::module& m)
         collect();
     };
 
+    constexpr auto prepare_finalize = [run_gc]() {
+        run_gc();
+        auto const exports = pyAMReX::dlpack::outstanding_exports();
+        if (exports != 0) {
+            throw std::runtime_error(
+                "amrex.finalize(): cannot finalize while " +
+                std::to_string(exports) +
+                " DLPack export(s) are still alive; delete all consuming "
+                "arrays and capsules, then retry");
+        }
+    };
+
     m.def("finalize",
-          [run_gc]() {
-              run_gc();
+          [prepare_finalize]() {
+              prepare_finalize();
               amrex::Finalize();
           });
     m.def("finalize",
-          [run_gc](AMReX* pamrex) {
-              run_gc();
+          [prepare_finalize](AMReX* pamrex) {
+              prepare_finalize();
               amrex::Finalize(pamrex);
           });
 }

--- a/src/dlpack/DLPackHelpers.H
+++ b/src/dlpack/DLPackHelpers.H
@@ -17,6 +17,7 @@
 #include "dlpack.h"
 
 #include <complex>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <tuple>
@@ -58,6 +59,14 @@ namespace pyAMReX
 
 namespace pyAMReX::dlpack
 {
+    /** Number of DLPack exports whose managed tensor is still alive.
+     *
+     * An outstanding consumer can keep an AMReX object or arena allocation
+     * alive past amrex::Finalize(), so the Python finalization bindings use
+     * this count to reject unsafe teardown.
+     */
+    std::size_t outstanding_exports () noexcept;
+
     /** Does the element type T have a DLPack representation?
      *
      * Containers instantiated for element types without a DLPack

--- a/src/dlpack/DLPackHelpers.cpp
+++ b/src/dlpack/DLPackHelpers.cpp
@@ -8,14 +8,18 @@
 #include <AMReX_Arena.H>
 #include <AMReX_Gpu.H>
 
+#include <atomic>
 #include <cstring>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 
 
 namespace
 {
     using namespace pyAMReX::dlpack;
+
+    std::atomic<std::size_t> num_outstanding_exports{0};
 
     /** Owns everything the exported tensor refers to.
      *
@@ -24,6 +28,19 @@ namespace
      */
     struct TensorHolder
     {
+        TensorHolder () noexcept
+        {
+            num_outstanding_exports.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        ~TensorHolder ()
+        {
+            num_outstanding_exports.fetch_sub(1, std::memory_order_relaxed);
+        }
+
+        TensorHolder (TensorHolder const&) = delete;
+        TensorHolder& operator= (TensorHolder const&) = delete;
+
         //! owned reference keeping the producing Python object alive
         PyObject* producer = nullptr;
         std::vector<std::int64_t> shape;
@@ -34,6 +51,21 @@ namespace
         DLManagedTensorVersioned versioned{};
         DLManagedTensor legacy{};
     };
+
+#if defined(AMREX_USE_SYCL)
+    //! Root-device ordinal used by dpctl's process-global numeric selector.
+    std::int32_t oneapi_device_id (sycl::device const& device)
+    {
+        auto const devices = sycl::device::get_devices();
+        for (std::size_t i = 0; i < devices.size(); ++i) {
+            if (devices[i] == device) {
+                return static_cast<std::int32_t>(i);
+            }
+        }
+        throw std::runtime_error(
+            "DLPack: the selected SYCL device is not a visible root device");
+    }
+#endif
 
     void destroy_holder (TensorHolder* holder)
     {
@@ -384,6 +416,11 @@ namespace
 
 namespace pyAMReX::dlpack
 {
+    std::size_t outstanding_exports () noexcept
+    {
+        return num_outstanding_exports.load(std::memory_order_relaxed);
+    }
+
     DLDevice detect_device_from_pointer ([[maybe_unused]] void const* ptr,
                                          bool* host_accessible)
     {
@@ -442,17 +479,10 @@ namespace pyAMReX::dlpack
                 usm_type == sycl::usm::alloc::shared)
             {
                 device.device_type = kDLOneAPI;
-                device.device_id = 0;
                 // device USM is device-only; shared USM is host-accessible
                 host_ok = (usm_type == sycl::usm::alloc::shared);
                 auto const dev = sycl::get_pointer_device(ptr, context);
-                auto const devices = context.get_devices();
-                for (std::size_t i = 0; i < devices.size(); ++i) {
-                    if (devices[i] == dev) {
-                        device.device_id = static_cast<std::int32_t>(i);
-                        break;
-                    }
-                }
+                device.device_id = oneapi_device_id(dev);
             }
             // sycl::usm::alloc::host (pinned): host-accessible everywhere,
             // keep kDLCPU so host consumers (NumPy et al.) can view it
@@ -489,11 +519,12 @@ namespace pyAMReX::dlpack
 #elif defined(AMREX_USE_SYCL)
         // shared (managed) and device USM are kDLOneAPI; host USM is re-badged
         // to kDLCPU (as in detect_device_from_pointer) so host consumers work.
-        // device_id is the context-relative index: AMReX builds the SYCL
-        // context with only the selected device, so it is 0 (matching the
-        // pointer path), not the global Gpu::Device::deviceId()
-        if (arena->isManaged()) { return DLDevice{kDLOneAPI, 0}; }
-        if (arena->isDevice())  { return DLDevice{kDLOneAPI, 0}; }
+        // Use the process-global root-device ordinal expected by oneAPI
+        // DLPack consumers, not AMReX's platform-relative device id.
+        if (arena->isManaged() || arena->isDevice()) {
+            auto const device_id = oneapi_device_id(amrex::Gpu::Device::syclDevice());
+            return DLDevice{kDLOneAPI, device_id};
+        }
 #endif
         return DLDevice{kDLCPU, 0};
     }

--- a/tests/test_array4.py
+++ b/tests/test_array4.py
@@ -166,6 +166,18 @@ def test_array4_dlpack_keeps_alive(assert_keeps_python_alive):
     assert copied[0, 0, 0, 0] == 3
 
 
+def test_dlpack_export_blocks_finalize():
+    arr = amr.Array4_double(np.ones((2, 3, 4)))
+    capsule = arr.__dlpack__()
+
+    with pytest.raises(RuntimeError, match="DLPack export.*still alive"):
+        amr.finalize()
+
+    # The failed call leaves AMReX initialized. Releasing the managed tensor
+    # lets the fixture finalize the runtime normally.
+    del capsule
+
+
 def test_array4_dlpack_empty():
     empty = amr.Array4_double()
     assert empty.__dlpack_device__() == (int(amr.DLDeviceType.kDLCPU), 0)

--- a/tests/test_dlpack_sycl.py
+++ b/tests/test_dlpack_sycl.py
@@ -14,6 +14,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def test_array4_dlpack_dpnp(mfab_device):
+    dpctl = pytest.importorskip("dpctl")
     dp = pytest.importorskip("dpnp")
 
     # device pointer is reported as a oneAPI device
@@ -26,6 +27,7 @@ def test_array4_dlpack_dpnp(mfab_device):
         # AMReX -> dpnp: zero-copy view on the device
         marr = arr.to_dpnp()
         assert marr.sycl_device.is_gpu
+        assert marr.sycl_device == dpctl.SyclDevice(str(device_id))
         marr[...] = 5.0
 
     # mutations through the view are visible in the MultiFab
@@ -40,6 +42,18 @@ def test_array4_dlpack_dpnp(mfab_device):
         c_marr[...] = 6.0
         assert float(dp.from_dlpack(arr).max()) == 5.0
         break
+
+
+def test_empty_device_vector_uses_selected_device_ordinal():
+    dpctl = pytest.importorskip("dpctl")
+
+    values = amr.DeviceVector_real()
+    empty_device = values.__dlpack_device__()
+    assert empty_device[0] == int(amr.DLDeviceType.kDLOneAPI)
+    assert dpctl.SyclDevice(str(empty_device[1])).is_gpu
+
+    values.push_back(1.0)
+    assert values.__dlpack_device__() == empty_device
 
 
 def test_array4_dlpack_dpnp_to_host(mfab_device):


### PR DESCRIPTION
Report the process-global SYCL root-device ordinal expected by oneAPI consumers for pointer-backed and empty arena-backed exports. Track live managed tensors and reject amrex.finalize() while a DLPack consumer still retains AMReX-owned state.

Existing data exchange and rank-to-GPU selection remain unchanged. The only user-visible teardown change is a clear RuntimeError when finalization would invalidate a live DLPack consumer.

This is a follow-up to #454.

SYCL default-context sharing is provided by:
- [x] https://github.com/AMReX-Codes/amrex/pull/5597