### PR TITLE
Free-Threaded Python: Declare `py::mod_gil_not_used()`

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -56,6 +56,66 @@ jobs:
       run: |
         mpiexec -np 1 python3 -m pytest tests/
 
+  free_threading:
+    name: GNU@13 Free-Threaded Python
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-13
+      CXX: g++-13
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v5
+      name: Install free-threaded Python
+      with:
+        python-version: '3.14t'
+    - name: Dependencies
+      run: |
+        .github/workflows/dependencies/dependencies_gcc.sh 13
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build & Install
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=800M
+        ccache -z
+
+        export CMAKE_BUILD_PARALLEL_LEVEL=4
+
+        python3 -c "import sys, sysconfig; assert sysconfig.get_config_var('Py_GIL_DISABLED'), 'not a free-threaded interpreter'; print(sys.version)"
+
+        python3 -m pip install -U pip
+        python3 -m pip install -U build packaging setuptools[core] wheel
+        # CMake >= 4.1 to find Development.Module for the free-threaded ABI:
+        # 3.31 and 4.0 locate the interpreter but not the 't' ABI's headers.
+        python3 -m pip install -U "cmake>=4.1" pytest pytest-repeat numpy
+        AMREX_MPI=OFF AMREX_SPACEDIM=3 python3 -m pip install -v .
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
+    - name: The GIL stays off
+      run: |
+        python3 -X warn_default_gil -c "import sys, amrex.space3d as amr; assert sys._is_gil_enabled() is False, 'importing pyAMReX re-enabled the GIL'; print('GIL disabled:', not sys._is_gil_enabled())"
+
+    - name: Unit tests, GIL disabled
+      run: |
+        PYTHON_GIL=0 python3 -m pytest tests/
+
+    - name: Unit tests, GIL forced back on
+      run: |
+        PYTHON_GIL=1 python3 -m pytest tests/
+
+    - name: Concurrency tests, repeated
+      run: |
+        PYTHON_GIL=0 python3 -m pytest tests/test_free_threading.py --count=20
+
   gcc14:
     name: GNU@14 Debug
     runs-on: ubuntu-24.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,9 +370,15 @@ add_dependencies(pyAMReX_python_sources pyAMReX_${AMReX_SPACEDIM_LAST}d)
 # Tests #######################################################################
 #
 if(pyAMReX_BUILD_TESTING)
+    # test_free_threading.py is ignored here and gets its own test below: this
+    # one runs with OMP_NUM_THREADS=3, so on an AMReX_OMP=ON build its worker
+    # threads would each open a 3-thread OpenMP team -- the oversubscription
+    # docs/source/usage/threading.rst tells users to avoid, and the one
+    # configuration in which AMReX hands two host threads the same RNG.
     add_test(NAME pytest.AMReX
         COMMAND ${Python_EXECUTABLE} -m pytest -s -vvvv
             ${pyAMReX_SOURCE_DIR}/tests
+            --ignore=${pyAMReX_SOURCE_DIR}/tests/test_free_threading.py
         WORKING_DIRECTORY
             ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,9 +383,11 @@ if(pyAMReX_BUILD_TESTING)
     # set PYTHONPATH and PATH (for .dll files)
     pyamrex_test_set_pythonpath(pytest.AMReX)
 
-    # Free-threading (PEP 703) concurrency tests, with the GIL forced off.
-    #   On a GIL-enabled interpreter PYTHON_GIL is ignored and these still run,
-    #   just serialized, so the test is registered unconditionally.
+    # Free-threading (PEP 703) concurrency tests. They are meaningful on any
+    # build -- serialized under a GIL -- so the test is registered always, but
+    # PYTHON_GIL=0 is only set where it is accepted: CPython 3.13+ aborts at
+    # startup ("Disabling the GIL is not supported by this build") if it is set
+    # on a GIL-enabled interpreter.
     add_test(NAME pytest.AMReX.free_threading
         COMMAND ${Python_EXECUTABLE} -m pytest -s -vvvv
             ${pyAMReX_SOURCE_DIR}/tests/test_free_threading.py
@@ -393,7 +395,15 @@ if(pyAMReX_BUILD_TESTING)
             ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
     )
     set_property(TEST pytest.AMReX.free_threading APPEND PROPERTY ENVIRONMENT
-        "OMP_NUM_THREADS=1" "PYTHON_GIL=0")
+        "OMP_NUM_THREADS=1")
+    execute_process(
+        COMMAND ${Python_EXECUTABLE} -c
+            "import sysconfig,sys; sys.exit(0 if sysconfig.get_config_var('Py_GIL_DISABLED') else 1)"
+        RESULT_VARIABLE pyAMReX_PY_FREE_THREADED)
+    if(pyAMReX_PY_FREE_THREADED EQUAL 0)
+        set_property(TEST pytest.AMReX.free_threading APPEND PROPERTY ENVIRONMENT
+            "PYTHON_GIL=0")
+    endif()
     pyamrex_test_set_pythonpath(pytest.AMReX.free_threading)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,15 +370,18 @@ add_dependencies(pyAMReX_python_sources pyAMReX_${AMReX_SPACEDIM_LAST}d)
 # Tests #######################################################################
 #
 if(pyAMReX_BUILD_TESTING)
-    # test_free_threading.py is ignored here and gets its own test below: this
-    # one runs with OMP_NUM_THREADS=3, so on an AMReX_OMP=ON build its worker
-    # threads would each open a 3-thread OpenMP team -- the oversubscription
-    # docs/source/usage/threading.rst tells users to avoid, and the one
-    # configuration in which AMReX hands two host threads the same RNG.
+    # The free-threading tests are ignored here and get their own test below:
+    # this one runs with OMP_NUM_THREADS=3, so on an AMReX_OMP=ON build their
+    # worker threads would each open a 3-thread OpenMP team -- the
+    # oversubscription docs/source/usage/threading.rst tells users to avoid,
+    # and the one configuration in which AMReX hands two host threads the same
+    # RNG. The perf module is gated on PYAMREX_BENCH=1 as well, but that is a
+    # different mechanism and not the one this reasoning relies on.
     add_test(NAME pytest.AMReX
         COMMAND ${Python_EXECUTABLE} -m pytest -s -vvvv
             ${pyAMReX_SOURCE_DIR}/tests
             --ignore=${pyAMReX_SOURCE_DIR}/tests/test_free_threading.py
+            --ignore=${pyAMReX_SOURCE_DIR}/tests/test_free_threading_perf.py
         WORKING_DIRECTORY
             ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,19 @@ if(pyAMReX_BUILD_TESTING)
 
     # set PYTHONPATH and PATH (for .dll files)
     pyamrex_test_set_pythonpath(pytest.AMReX)
+
+    # Free-threading (PEP 703) concurrency tests, with the GIL forced off.
+    #   On a GIL-enabled interpreter PYTHON_GIL is ignored and these still run,
+    #   just serialized, so the test is registered unconditionally.
+    add_test(NAME pytest.AMReX.free_threading
+        COMMAND ${Python_EXECUTABLE} -m pytest -s -vvvv
+            ${pyAMReX_SOURCE_DIR}/tests/test_free_threading.py
+        WORKING_DIRECTORY
+            ${CMAKE_PYTHON_OUTPUT_DIRECTORY}
+    )
+    set_property(TEST pytest.AMReX.free_threading APPEND PROPERTY ENVIRONMENT
+        "OMP_NUM_THREADS=1" "PYTHON_GIL=0")
+    pyamrex_test_set_pythonpath(pytest.AMReX.free_threading)
 endif()
 
 

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -83,7 +83,13 @@ set(pyAMReX_amrex_src ""
 
 # Git fetcher
 option(pyAMReX_amrex_internal "Download & build AMReX" ON)
-set(pyAMReX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
+# TEMPORARY, REVERT BEFORE MERGE (with commit_amrex in dependencies.json):
+#   points at the AMReX-Codes/amrex#5615 branch so this PR's CI can build at
+#   all -- it calls ParmParse::tableCopy(), which only exists there -- and so
+#   the concurrency tests actually run instead of being skipped. A plain clone
+#   of AMReX-Codes/amrex cannot check out a commit that only exists on the
+#   fork, hence the URI here and not just the SHA.
+set(pyAMReX_amrex_repo "https://github.com/ax3l/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(pyAMReX_amrex_internal)")
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,6 +2,6 @@
     "version_pyamrex": "26.08",
     "version_amrex": "26.08",
     "version_pybind11_min": "v3.0.0",
-    "commit_amrex": "e833cfbf248eaf014e40aec94b8c5ec475edc7ac",
+    "commit_amrex": "c9072a47f6da680fde9c220196aa858fbe3751ef",
     "commit_pybind11": "v3.1.0"
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,6 +2,6 @@
     "version_pyamrex": "26.08",
     "version_amrex": "26.08",
     "version_pybind11_min": "v3.0.0",
-    "commit_amrex": "5273b558c13011573e1b6bf71860db4fcc1f0cfb",
+    "commit_amrex": "e833cfbf248eaf014e40aec94b8c5ec475edc7ac",
     "commit_pybind11": "v3.1.0"
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,6 +2,6 @@
     "version_pyamrex": "26.08",
     "version_amrex": "26.08",
     "version_pybind11_min": "v3.0.0",
-    "commit_amrex": "c9072a47f6da680fde9c220196aa858fbe3751ef",
+    "commit_amrex": "32f03b02f9b0bd0b8ffcb0c41869b56cd1713bbf",
     "commit_pybind11": "v3.1.0"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,7 @@ Usage
    usage/api
    usage/zerocopy
    usage/compute
+   usage/threading
    usage/workflows
 ..   usage/tests
 

--- a/docs/source/usage/compute.rst
+++ b/docs/source/usage/compute.rst
@@ -152,5 +152,9 @@ Other C++ Calls
 pyAMReX exposes many more C++-written and GPU-accelerated AMReX functions for :py:class:`~amrex.space3d.MultiFab` and :ref:`particles <usage-api-particles>` to Python, which can be used to set, reduce, rescale, redistribute, etc. contained data.
 Check out the detailed :ref:`API docs for more details <usage-api>` and use further third party libraries at will on the exposed data structures, replacing the hot loops described above.
 
+On a free-threaded (PEP 703) interpreter, the per-block loops above can run on
+several Python threads at once; see :ref:`usage-threading` for the rules and the
+two patterns we support.
+
 You can also leave the Python world in pyAMReX and go back to C++ whenever needed.
 For :ref:`some applications <usage_run>`, pyAMReX might act as *scriptable glue* that transports fields and particles from one (C++) function to another without recompilation, by exposing the functions and methods to Python.

--- a/docs/source/usage/threading.rst
+++ b/docs/source/usage/threading.rst
@@ -20,8 +20,11 @@ the GIL:
 .. code-block:: python
 
    import sys
-   import amrex.space3d as amr
 
+   # importing pyAMReX is what used to switch the GIL back on
+   import amrex.space3d as amr  # noqa: F401
+
+   # sys._is_gil_enabled() exists on CPython 3.13 and newer
    assert sys._is_gil_enabled() is False
 
 Free-threaded interpreters are named ``python3.13t`` / ``python3.14t``, and
@@ -82,8 +85,10 @@ Main thread only:
   *process-global* state -- and on a GPU build frees and reallocates the device
   RNG state array. Seed once before starting worker threads. (Drawing numbers
   is fine concurrently on the host: each thread has its own generator.)
-* :cpp:class:`amrex::TinyProfiler` (``tiny_profiler.enabled=1``). Its section
-  stack is global and asserts on nesting; use it single-threaded.
+* :cpp:class:`amrex::TinyProfiler`. Its section stack is global and asserts on
+  nesting, so use it single-threaded. Note this is opt-*out*: in an
+  ``AMReX_TINY_PROFILE=ON`` build it is on unless you pass
+  ``tiny_profiler.enabled=0``, which is what ``tests/conftest.py`` does.
 * Building embedded-boundary geometry (``EB2_Build``, ``makeEBFabFactory``):
   AMReX keeps the index spaces on an unguarded global stack.
 * ``AMReX.top()`` / ``size()`` / ``empty()``, the ``Geometry.ResetDefault*``

--- a/docs/source/usage/threading.rst
+++ b/docs/source/usage/threading.rst
@@ -1,0 +1,194 @@
+.. _usage-threading:
+
+Threading (Free-Threaded Python)
+================================
+
+CPython 3.13 introduced a *free-threaded* build (`PEP 703 <https://peps.python.org/pep-0703/>`__)
+in which the global interpreter lock is disabled, so Python threads run in
+parallel on separate cores. pyAMReX supports it: the extension modules declare
+``Py_mod_gil = Py_MOD_GIL_NOT_USED``, so importing pyAMReX does **not** switch
+the GIL back on.
+
+This matters most for the code pyAMReX exists to enable: per-block Python
+kernels, in-situ analysis, and data-science glue, which are written in Python
+and therefore serialized by the GIL no matter how many blocks a ``MultiFab``
+has.
+
+Check that you are on a free-threaded interpreter and that nothing re-enabled
+the GIL:
+
+.. code-block:: python
+
+   import sys
+   import amrex.space3d as amr
+
+   assert sys._is_gil_enabled() is False
+
+Free-threaded interpreters are named ``python3.13t`` / ``python3.14t``, and
+their wheels carry the ``cp313t`` / ``cp314t`` ABI tag. On a regular
+(GIL-enabled) build the declaration is inert and everything below still works,
+just without the parallelism.
+
+
+.. _usage-threading-contract:
+
+What is guaranteed
+------------------
+
+pyAMReX follows the same rule NumPy does: **the library's own global state is
+race-free; your data is yours to synchronize.**
+
+Safe from any number of threads:
+
+* Working on **distinct** objects -- each thread with its own ``MultiFab``,
+  ``ParticleContainer``, ``BoxArray``, ``Geometry``, and so on, including
+  objects built from the same :py:class:`~amrex.space3d.BoxArray` and
+  :py:class:`~amrex.space3d.DistributionMapping`.
+* **Reading** the same object concurrently.
+* Each thread driving **its own** :py:class:`~amrex.space3d.MFIter`, even over
+  the same ``MultiFab``, as long as the threads write to disjoint boxes.
+* Creating and releasing zero-copy views (``to_numpy``, ``to_cupy``, ``to_xp``,
+  ``__dlpack__``) concurrently.
+* Querying :py:class:`~amrex.space3d.ParmParse` concurrently.
+
+Your responsibility, exactly as with a NumPy array:
+
+* **Writing to the same data from two threads.** Two threads writing the same
+  box, or writing overlapping regions of one array, is a data race. Partition
+  the work, or use a lock.
+* Keeping an object alive while another thread uses a view into it. A zero-copy
+  view keeps its Python owner alive, but calling ``clear()`` on a ``MultiFab``
+  while another thread iterates it is not defensible.
+
+Main thread only:
+
+* :py:func:`~amrex.space3d.initialize` and :py:func:`~amrex.space3d.finalize`.
+  They start and stop process-wide state -- the AMReX instance stack, the
+  memory arenas, the parameter table, signal and floating-point-exception
+  handlers. pyAMReX serializes them so a mistake is not silent corruption, but
+  they are not meant to overlap with anything.
+* **MPI-collective calls** (reductions such as ``min``/``max``/``norm0``/``sum``
+  with ``local=False``, plotfile writes, ``Redistribute`` across ranks) unless
+  AMReX was built with ``AMReX_MPI_THREAD_MULTIPLE=ON``. Without it, AMReX
+  calls ``MPI_Init`` rather than ``MPI_Init_thread``, and MPI is not safe to
+  enter from two threads.
+* Process-wide policy switches: ``Config.verbose``, the AMReX error handler,
+  ``amrex.throw_exception``.
+* **Reseeding the random number generator.**
+  :py:meth:`~amrex.space3d.ParticleContainer_2_1_3_1_default.init_random` and
+  ``init_random_per_box`` forward to ``amrex::InitRandom``, which reseeds
+  *process-global* state -- and on a GPU build frees and reallocates the device
+  RNG state array. Seed once before starting worker threads. (Drawing numbers
+  is fine concurrently on the host: each thread has its own generator.)
+* :cpp:class:`amrex::TinyProfiler` (``tiny_profiler.enabled=1``). Its section
+  stack is global and asserts on nesting; use it single-threaded.
+* Externally supplied GPU streams (``Gpu::setExternalStream``).
+* ``MFItInfo().set_dynamic(True)``. Dynamic MFIter scheduling shares one
+  counter across an OpenMP team; two threads each opening their own team would
+  share it.
+
+
+.. _usage-threading-patterns:
+
+Two patterns
+------------
+
+**Each thread drives its own MFIter.** Threads pick their boxes by index, so no
+two touch the same data:
+
+.. code-block:: python
+
+   from concurrent.futures import ThreadPoolExecutor
+
+   import amrex.space3d as amr
+
+   nthreads = 8
+
+   def work(t):
+       for mfi in mfab:                       # this thread's own iterator
+           if mfi.index % nthreads != t:      # claim every nth box
+               continue
+           field = mfab.array(mfi).to_xp()
+           field[...] = field * 2.0 + 1.0
+
+   with ThreadPoolExecutor(max_workers=nthreads) as pool:
+       list(pool.map(work, range(nthreads)))  # list() so errors propagate
+
+**Snapshot the tiles, then run the kernels in a pool.** One serial ``MFIter``
+pass collects the per-box views, and only the kernel bodies are threaded. Use
+this when the kernel is what costs, and you would rather keep iteration
+obviously sequential:
+
+.. code-block:: python
+
+   views = [mfab.array(mfi).to_xp() for mfi in mfab]
+
+   with ThreadPoolExecutor(max_workers=nthreads) as pool:
+       list(pool.map(lambda v: v.__setitem__(Ellipsis, v * 2.0 + 1.0), views))
+
+Both scale about the same. The first is more direct; the second composes better
+when the tile list is built once and reused.
+
+
+.. _usage-threading-openmp:
+
+Threads and OpenMP
+------------------
+
+Python threads and an ``AMReX_OMP=ON`` build are two separate thread pools over
+the same cores. Running both oversubscribes the node and usually ends up slower
+than either alone -- pick one:
+
+* **Python threads** (``AMREX_OMP=OFF``, the default for pyAMReX wheels) when
+  the hot loop is Python.
+* **OpenMP** (``AMREX_OMP=ON``, ``OMP_NUM_THREADS=N``) when the hot loop is
+  inside AMReX's own C++ kernels and Python is only orchestrating.
+
+If you must use both, cap them so the product matches the core count, e.g.
+``OMP_NUM_THREADS=2`` with four Python threads on eight cores.
+
+
+.. _usage-threading-numbers:
+
+What to expect
+--------------
+
+A per-box kernel written in Python, over a 128³ domain decomposed into 64
+boxes, on a 14-core / 20-thread CPU:
+
+=========  =================  ==================
+threads    GIL enabled        GIL disabled
+=========  =================  ==================
+1          1.00x              1.00x
+2          1.03x              1.92x
+4          1.04x              3.31x
+8          1.01x              4.87x
+14         0.95x              6.16x
+20         0.90x              6.92x
+=========  =================  ==================
+
+A NumPy-vectorised kernel over the same data is memory-bandwidth-bound and
+scales only weakly either way -- but note that *with* the GIL it actively
+degrades past four threads (0.31x at 20 threads), because the threads spend
+their time contending for the lock rather than computing.
+
+Reproduce with ``tools/bench_free_threading.py``; the same binary, run twice::
+
+    PYTHON_GIL=0 python tools/bench_free_threading.py --json off.json
+    PYTHON_GIL=1 python tools/bench_free_threading.py --json on.json
+    python tools/bench_free_threading.py --compare off.json on.json
+
+
+.. _usage-threading-testing:
+
+Testing your own code
+---------------------
+
+``PYTHON_GIL=0`` / ``PYTHON_GIL=1`` (or ``-X gil=0`` / ``-X gil=1``) force the
+GIL off or on in a free-threaded interpreter, so you can A/B the same build.
+Races are timing-dependent, so run concurrency tests repeatedly --
+``pytest --count=50`` with `pytest-repeat
+<https://pypi.org/project/pytest-repeat/>`__ -- and prefer assertions on
+computed values over "it did not crash".
+
+pyAMReX's own concurrency tests are in ``tests/test_free_threading.py``.

--- a/docs/source/usage/threading.rst
+++ b/docs/source/usage/threading.rst
@@ -84,6 +84,11 @@ Main thread only:
   is fine concurrently on the host: each thread has its own generator.)
 * :cpp:class:`amrex::TinyProfiler` (``tiny_profiler.enabled=1``). Its section
   stack is global and asserts on nesting; use it single-threaded.
+* Building embedded-boundary geometry (``EB2_Build``, ``makeEBFabFactory``):
+  AMReX keeps the index spaces on an unguarded global stack.
+* ``AMReX.top()`` / ``size()`` / ``empty()``, the ``Geometry.ResetDefault*``
+  functions and ``Arena.finalize()`` -- all read or write process-wide state
+  that ``initialize``/``finalize`` own.
 * Externally supplied GPU streams (``Gpu::setExternalStream``).
 * ``MFItInfo().set_dynamic(True)``. Dynamic MFIter scheduling shares one
   counter across an OpenMP team; two threads each opening their own team would
@@ -162,17 +167,17 @@ boxes, on a 14-core / 20-thread CPU:
 threads    GIL enabled        GIL disabled
 =========  =================  ==================
 1          1.00x              1.00x
-2          1.03x              1.92x
-4          1.04x              3.31x
-8          1.01x              4.87x
-14         0.95x              6.16x
-20         0.90x              6.92x
+2          1.07x              1.93x
+4          1.06x              3.55x
+8          0.99x              4.92x
+14         0.97x              6.25x
+20         0.97x              7.29x
 =========  =================  ==================
 
-A NumPy-vectorised kernel over the same data is memory-bandwidth-bound and
-scales only weakly either way -- but note that *with* the GIL it actively
-degrades past four threads (0.31x at 20 threads), because the threads spend
-their time contending for the lock rather than computing.
+A NumPy-vectorised kernel over the same data is memory-bandwidth-bound and so
+scales only weakly either way (2.6x at 20 threads without the GIL) -- but note
+that *with* the GIL it actively degrades, to 0.39x at 20 threads, the threads
+spending their time contending for the lock rather than computing.
 
 Reproduce with ``tools/bench_free_threading.py``; the same binary, run twice::
 

--- a/docs/source/usage/threading.rst
+++ b/docs/source/usage/threading.rst
@@ -139,9 +139,9 @@ Python threads and an ``AMReX_OMP=ON`` build are two separate thread pools over
 the same cores. Running both oversubscribes the node and usually ends up slower
 than either alone -- pick one:
 
-* **Python threads** (``AMREX_OMP=OFF``, the default for pyAMReX wheels) when
+* **Python threads** (``AMReX_OMP=OFF``, the default for pyAMReX wheels) when
   the hot loop is Python.
-* **OpenMP** (``AMREX_OMP=ON``, ``OMP_NUM_THREADS=N``) when the hot loop is
+* **OpenMP** (``AMReX_OMP=ON``, ``OMP_NUM_THREADS=N``) when the hot loop is
   inside AMReX's own C++ kernels and Python is only orchestrating.
 
 If you must use both, cap them so the product matches the core count, e.g.

--- a/docs/source/usage/threading.rst
+++ b/docs/source/usage/threading.rst
@@ -73,10 +73,16 @@ Main thread only:
   collector, and waiting on a lock inside a binding call would deadlock a
   free-threaded interpreter's stop-the-world collection.
 * **MPI-collective calls** (reductions such as ``min``/``max``/``norm0``/``sum``
-  with ``local=False``, plotfile writes, ``Redistribute`` across ranks) unless
-  AMReX was built with ``AMReX_MPI_THREAD_MULTIPLE=ON``. Without it, AMReX
-  calls ``MPI_Init`` rather than ``MPI_Init_thread``, and MPI is not safe to
-  enter from two threads.
+  with ``local=False``, plotfile writes, ``Redistribute`` across ranks, and
+  ``VisMF.Read``, which reduces across ranks to agree on a cached
+  ``DistributionMapping``). Two threads entering a collective can pair up the
+  calls differently on different ranks, which hangs. Whether MPI itself
+  tolerates concurrent entry depends on the thread level actually negotiated:
+  ``AMReX_MPI_THREAD_MULTIPLE=ON`` makes AMReX request it, but if something
+  else initialized MPI first -- ``import mpi4py.MPI`` does, and
+  ``tests/conftest.py`` relies on that -- then the level is whatever *that*
+  caller asked for and AMReX only duplicates the communicator. Either way the
+  ordering problem above remains, so keep collectives on one thread.
 * Process-wide policy switches: ``Config.verbose``, the AMReX error handler,
   ``amrex.throw_exception``.
 * **Reseeding the random number generator.**
@@ -91,9 +97,16 @@ Main thread only:
   ``tiny_profiler.enabled=0``, which is what ``tests/conftest.py`` does.
 * Building embedded-boundary geometry (``EB2_Build``, ``makeEBFabFactory``):
   AMReX keeps the index spaces on an unguarded global stack.
-* ``AMReX.top()`` / ``size()`` / ``empty()``, the ``Geometry.ResetDefault*``
-  functions and ``Arena.finalize()`` -- all read or write process-wide state
-  that ``initialize``/``finalize`` own.
+* ``AMReX.top()`` / ``size()`` / ``empty()`` / ``erase()`` and
+  ``Arena.finalize()`` -- all read or write process-wide state that
+  ``initialize``/``finalize`` own. ``AMReX.erase()`` in particular destroys an
+  AMReX instance and the default ``Geometry`` hanging off it, and unlike
+  ``initialize``/``finalize`` it is *not* guarded, so calling it while another
+  thread is in a binding is a use-after-free.
+* Mutating ``ParmParse`` (``add``/``addarr``) while another thread reads it.
+  Individual queries are safe, but ``ParmParse.to_dict()`` reads each value
+  after snapshotting the key set, so an entry whose type changes underneath it
+  aborts.
 * Externally supplied GPU streams (``Gpu::setExternalStream``).
 * ``MFItInfo().set_dynamic(True)``. Dynamic MFIter scheduling shares one
   counter across an OpenMP team; two threads each opening their own team would

--- a/docs/source/usage/threading.rst
+++ b/docs/source/usage/threading.rst
@@ -65,8 +65,10 @@ Main thread only:
 * :py:func:`~amrex.space3d.initialize` and :py:func:`~amrex.space3d.finalize`.
   They start and stop process-wide state -- the AMReX instance stack, the
   memory arenas, the parameter table, signal and floating-point-exception
-  handlers. pyAMReX serializes them so a mistake is not silent corruption, but
-  they are not meant to overlap with anything.
+  handlers. Calling either while another thread is inside one raises
+  ``RuntimeError`` rather than waiting -- ``finalize()`` runs the garbage
+  collector, and waiting on a lock inside a binding call would deadlock a
+  free-threaded interpreter's stop-the-world collection.
 * **MPI-collective calls** (reductions such as ``min``/``max``/``norm0``/``sum``
   with ``local=False``, plotfile writes, ``Redistribute`` across ranks) unless
   AMReX was built with ``AMReX_MPI_THREAD_MULTIPLE=ON``. Without it, AMReX

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,10 @@ class CMakeBuild(build_ext):
             "-DPython_FIND_VERSION_EXACT=" + ("FALSE" if emscripten else "TRUE"),
             "-DPython_FIND_STRATEGY=LOCATION",
         ]
+        # Free-threaded (PEP 703) gil_disabled is OFF by default
+        #   https://cmake.org/cmake/help/latest/module/FindPython.html#variable:Python_FIND_ABI
+        if sysconfig.get_config_var("Py_GIL_DISABLED"):
+            cmake_args.append("-DPython_FIND_ABI=OFF;OFF;OFF;ON")
         if emscripten:
             cmake_args += [
                 "-DPython_INCLUDE_DIR=" + sysconfig.get_config_var("INCLUDEPY")

--- a/setup.py
+++ b/setup.py
@@ -303,6 +303,9 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
+        # bump to "3 - Stable" once the free-threading tests have soaked in CI
+        # across platforms; see docs/source/usage/threading.rst
+        "Programming Language :: Python :: Free Threading :: 2 - Beta",
     ],
     # new PEP 639 format
     license="BSD-3-Clause-LBNL",

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -5,9 +5,21 @@
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
 
+#include <mutex>
 #include <stdexcept>
 #include <string>
 
+namespace
+{
+    /** Serializes amrex.initialize()/finalize().
+     *
+     * Both mutate process-global state (the AMReX instance stack, ParmParse,
+     * the arenas, signal handlers). The threading contract says to call them
+     * from one thread; this makes a violation a clean serialization rather
+     * than a corrupted instance stack.
+     */
+    std::mutex init_finalize_mutex;
+}
 
 void init_AMReX(py::module& m)
 {
@@ -23,6 +35,8 @@ void init_AMReX(py::module& m)
 
     m.def("initialize",
           [](const py::list args) {
+              std::scoped_lock lock(init_finalize_mutex);
+
               Vector<std::string> cargs{"amrex"};
               Vector<char*> argv;
 
@@ -77,11 +91,13 @@ void init_AMReX(py::module& m)
 
     m.def("finalize",
           [prepare_finalize]() {
+              std::scoped_lock lock(init_finalize_mutex);
               prepare_finalize();
               amrex::Finalize();
           });
     m.def("finalize",
           [prepare_finalize](AMReX* pamrex) {
+              std::scoped_lock lock(init_finalize_mutex);
               prepare_finalize();
               amrex::Finalize(pamrex);
           });

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -11,14 +11,39 @@
 
 namespace
 {
-    /** Serializes amrex.initialize()/finalize().
+    /** Guards amrex.initialize()/finalize() against concurrent entry.
      *
      * Both mutate process-global state (the AMReX instance stack, ParmParse,
-     * the arenas, signal handlers). The threading contract says to call them
-     * from one thread; this makes a violation a clean serialization rather
-     * than a corrupted instance stack.
+     * the arenas, signal handlers), and the threading contract says to call
+     * them from one thread.
+     *
+     * We refuse rather than wait. finalize() runs the garbage collector, which
+     * on a free-threaded interpreter stops the world and waits for every
+     * attached thread to reach a safe point -- a thread blocked in
+     * lock() inside a pybind11 call is attached and never gets there, so
+     * waiting would deadlock. Failing loudly also matches what the docs
+     * promise: these are main-thread only.
      */
     std::mutex init_finalize_mutex;
+
+    /** Non-blocking lock; throws if another thread is already in there. */
+    class ScopedInitFinalizeLock
+    {
+    public:
+        ScopedInitFinalizeLock ()
+        {
+            if (!init_finalize_mutex.try_lock()) {
+                throw std::runtime_error(
+                    "amrex.initialize()/finalize() must be called from a "
+                    "single thread; another thread is inside one of them");
+            }
+        }
+        ~ScopedInitFinalizeLock () { init_finalize_mutex.unlock(); }
+        ScopedInitFinalizeLock (ScopedInitFinalizeLock const &) = delete;
+        ScopedInitFinalizeLock & operator= (ScopedInitFinalizeLock const &) = delete;
+        ScopedInitFinalizeLock (ScopedInitFinalizeLock &&) = delete;
+        ScopedInitFinalizeLock & operator= (ScopedInitFinalizeLock &&) = delete;
+    };
 }
 
 void init_AMReX(py::module& m)
@@ -35,7 +60,7 @@ void init_AMReX(py::module& m)
 
     m.def("initialize",
           [](const py::list args) {
-              std::scoped_lock lock(init_finalize_mutex);
+              ScopedInitFinalizeLock lock;
 
               Vector<std::string> cargs{"amrex"};
               Vector<char*> argv;
@@ -91,13 +116,13 @@ void init_AMReX(py::module& m)
 
     m.def("finalize",
           [prepare_finalize]() {
-              std::scoped_lock lock(init_finalize_mutex);
+              ScopedInitFinalizeLock lock;
               prepare_finalize();
               amrex::Finalize();
           });
     m.def("finalize",
           [prepare_finalize](AMReX* pamrex) {
-              std::scoped_lock lock(init_finalize_mutex);
+              ScopedInitFinalizeLock lock;
               prepare_finalize();
               amrex::Finalize(pamrex);
           });

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -51,6 +51,11 @@ namespace
                     "inside amrex.initialize()/finalize() -- most likely from "
                     "a __del__ run by the garbage collector during finalize()");
             }
+            // try_lock() may fail spuriously per [thread.mutex.requirements.mutex],
+            // so this can in principle refuse a genuinely single-threaded call.
+            // Not retried on purpose: a retry loop is what the stop-the-world GC
+            // deadlock above rules out, and a spurious failure raises a clear
+            // error rather than corrupting the instance stack.
             if (!init_finalize_mutex.try_lock()) {
                 throw std::runtime_error(
                     "amrex.initialize()/finalize() must be called from a "

--- a/src/Base/AMReX.cpp
+++ b/src/Base/AMReX.cpp
@@ -5,9 +5,11 @@
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
 
+#include <atomic>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 
 namespace
 {
@@ -26,19 +28,41 @@ namespace
      */
     std::mutex init_finalize_mutex;
 
-    /** Non-blocking lock; throws if another thread is already in there. */
+    /** Thread currently inside initialize()/finalize(), if any.
+     *
+     * Tracked explicitly because try_lock() on a std::mutex the calling thread
+     * already owns is undefined behaviour, and re-entry is reachable: finalize()
+     * holds the lock across the garbage collector, which runs arbitrary Python
+     * finalizers, and a __del__ that calls amrex.finalize() defensively lands
+     * right back here on the same thread.
+     */
+    std::atomic<std::thread::id> init_finalize_owner{};
+
+    /** Non-blocking lock; throws instead of waiting or re-entering. */
     class ScopedInitFinalizeLock
     {
     public:
         ScopedInitFinalizeLock ()
         {
+            auto const self = std::this_thread::get_id();
+            if (init_finalize_owner.load(std::memory_order_acquire) == self) {
+                throw std::runtime_error(
+                    "amrex.initialize()/finalize() cannot be called from "
+                    "inside amrex.initialize()/finalize() -- most likely from "
+                    "a __del__ run by the garbage collector during finalize()");
+            }
             if (!init_finalize_mutex.try_lock()) {
                 throw std::runtime_error(
                     "amrex.initialize()/finalize() must be called from a "
                     "single thread; another thread is inside one of them");
             }
+            init_finalize_owner.store(self, std::memory_order_release);
         }
-        ~ScopedInitFinalizeLock () { init_finalize_mutex.unlock(); }
+        ~ScopedInitFinalizeLock ()
+        {
+            init_finalize_owner.store(std::thread::id{}, std::memory_order_release);
+            init_finalize_mutex.unlock();
+        }
         ScopedInitFinalizeLock (ScopedInitFinalizeLock const &) = delete;
         ScopedInitFinalizeLock & operator= (ScopedInitFinalizeLock const &) = delete;
         ScopedInitFinalizeLock (ScopedInitFinalizeLock &&) = delete;

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <iostream>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -19,13 +20,13 @@
 
 namespace
 {
-    /** Serializes pretty_print_table().
+    /** Serializes the std::cout redirection in pretty_print_table().
      *
-     * py::scoped_ostream_redirect swaps std::cout's stream buffer for the
-     * duration of the call, which is process-wide state. Two threads printing
-     * at once would restore each other's buffer. Note that this only makes
-     * concurrent pretty_print_table() calls safe -- an amrex::Print() on a
-     * third thread still lands in the redirected buffer for the duration.
+     * py::scoped_ostream_redirect swaps std::cout's stream buffer, which is
+     * process-wide state; two threads printing at once would restore each
+     * other's buffer. Note this only makes concurrent pretty_print_table()
+     * calls safe -- an amrex::Print() on a third thread still lands in the
+     * redirected buffer for the duration.
      */
     std::mutex pretty_print_mutex;
 }
@@ -125,12 +126,21 @@ void init_ParmParse(py::module &m)
         .def(
             "pretty_print_table",
             [](ParmParse &pp) {
+                // Render first, print second. prettyPrintTable() holds AMReX's
+                // ParmParse table mutex, and writing through
+                // scoped_ostream_redirect runs Python on flush -- which on a
+                // free-threaded interpreter can stop the world and wait for
+                // every attached thread, including one blocked on that same
+                // table mutex in another query. Never hold it across Python.
+                std::ostringstream oss;
+                pp.prettyPrintTable(oss);
+
                 std::scoped_lock lock(pretty_print_mutex);
                 py::scoped_ostream_redirect stream(
                     std::cout,                               // std::ostream&
                     py::module_::import("sys").attr("stdout") // Python output
                 );
-                pp.prettyPrintTable(std::cout);
+                std::cout << oss.str();
             },
             "Write the table in a pretty way to the ostream. If there are "
             "duplicates, only the last one is printed."

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -137,7 +137,16 @@ void init_ParmParse(py::module &m)
             [](ParmParse &pp) {
                 py::dict d;
 
-                auto g_table = pp.tableCopy();  // snapshot under AMReX's table lock
+                // Snapshot under AMReX's table lock. This stabilises the key
+                // set and the type hints we dispatch on; the values below are
+                // still read from the live table via pp.get()/pp.getarr(), so
+                // a concurrent add() of a different type could still make the
+                // hint and the entry disagree. Holding the table lock across
+                // the loop instead is not an option: it would build Python
+                // objects under a C++ mutex, and a stop-the-world GC waiting
+                // on a thread blocked on that mutex deadlocks. Mutating
+                // ParmParse while reading it stays the caller's business.
+                auto g_table = pp.tableCopy();
 
                 // sort all keys
                 std::vector<std::string> sorted_names;

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -11,25 +11,11 @@
 
 #include <functional>
 #include <iostream>
-#include <mutex>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
-
-namespace
-{
-    /** Serializes the std::cout redirection in pretty_print_table().
-     *
-     * py::scoped_ostream_redirect swaps std::cout's stream buffer, which is
-     * process-wide state; two threads printing at once would restore each
-     * other's buffer. Note this only makes concurrent pretty_print_table()
-     * calls safe -- an amrex::Print() on a third thread still lands in the
-     * redirected buffer for the duration.
-     */
-    std::mutex pretty_print_mutex;
-}
 
 void init_ParmParse(py::module &m)
 {
@@ -126,21 +112,19 @@ void init_ParmParse(py::module &m)
         .def(
             "pretty_print_table",
             [](ParmParse &pp) {
-                // Render first, print second. prettyPrintTable() holds AMReX's
-                // ParmParse table mutex, and writing through
-                // scoped_ostream_redirect runs Python on flush -- which on a
-                // free-threaded interpreter can stop the world and wait for
-                // every attached thread, including one blocked on that same
-                // table mutex in another query. Never hold it across Python.
+                // Render into our own buffer, then hand the text to Python.
+                //
+                // Two reasons not to redirect std::cout here. AMReX holds its
+                // ParmParse table lock inside prettyPrintTable(), and writing
+                // through scoped_ostream_redirect runs Python on every buffer
+                // flush -- on a free-threaded interpreter that can stop the
+                // world and wait for a thread blocked on that same lock in
+                // another query. And swapping std::cout's stream buffer is
+                // process-wide, so a concurrent amrex::Print() on a third
+                // thread would land in our buffer.
                 std::ostringstream oss;
                 pp.prettyPrintTable(oss);
-
-                std::scoped_lock lock(pretty_print_mutex);
-                py::scoped_ostream_redirect stream(
-                    std::cout,                               // std::ostream&
-                    py::module_::import("sys").attr("stdout") // Python output
-                );
-                std::cout << oss.str();
+                py::print(oss.str(), py::arg("end") = "");
             },
             "Write the table in a pretty way to the ostream. If there are "
             "duplicates, only the last one is printed."
@@ -153,7 +137,7 @@ void init_ParmParse(py::module &m)
             [](ParmParse &pp) {
                 py::dict d;
 
-                auto g_table = pp.table();
+                auto g_table = pp.tableCopy();  // snapshot under AMReX's table lock
 
                 // sort all keys
                 std::vector<std::string> sorted_names;

--- a/src/Base/ParmParse.cpp
+++ b/src/Base/ParmParse.cpp
@@ -11,10 +11,24 @@
 
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <vector>
 
+
+namespace
+{
+    /** Serializes pretty_print_table().
+     *
+     * py::scoped_ostream_redirect swaps std::cout's stream buffer for the
+     * duration of the call, which is process-wide state. Two threads printing
+     * at once would restore each other's buffer. Note that this only makes
+     * concurrent pretty_print_table() calls safe -- an amrex::Print() on a
+     * third thread still lands in the redirected buffer for the duration.
+     */
+    std::mutex pretty_print_mutex;
+}
 
 void init_ParmParse(py::module &m)
 {
@@ -111,6 +125,7 @@ void init_ParmParse(py::module &m)
         .def(
             "pretty_print_table",
             [](ParmParse &pp) {
+                std::scoped_lock lock(pretty_print_mutex);
                 py::scoped_ostream_redirect stream(
                     std::cout,                               // std::ostream&
                     py::module_::import("sys").attr("stdout") // Python output

--- a/src/pyAMReX.cpp
+++ b/src/pyAMReX.cpp
@@ -62,12 +62,18 @@ void init_VisMF(py::module &);
 void init_EB(py::module &);
 #endif
 
+// py::mod_gil_not_used() declares that this module is safe to run on a
+// free-threaded (PEP 703) interpreter. Without it, CPython re-enables the GIL
+// process-wide the moment the module is imported.
+//
+// It is a promise, not a flag: see docs/source/usage/threading.rst for what
+// pyAMReX and AMReX do and do not guarantee across threads.
 #if AMREX_SPACEDIM == 1
-PYBIND11_MODULE(amrex_1d_pybind, m) {
+PYBIND11_MODULE(amrex_1d_pybind, m, py::mod_gil_not_used()) {
 #elif AMREX_SPACEDIM == 2
-PYBIND11_MODULE(amrex_2d_pybind, m) {
+PYBIND11_MODULE(amrex_2d_pybind, m, py::mod_gil_not_used()) {
 #elif AMREX_SPACEDIM == 3
-PYBIND11_MODULE(amrex_3d_pybind, m) {
+PYBIND11_MODULE(amrex_3d_pybind, m, py::mod_gil_not_used()) {
 #else
 #  error "AMREX_SPACEDIM must be 1, 2 or 3"
 #endif

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,27 @@ def needs_amrex_free_threading():
         )
 
 
+@pytest.fixture(scope="function")
+def single_rank_only(amrex_init):
+    """Skip a test that drives MPI-collective calls from several threads.
+
+    ``fill_boundary``, ``sum_boundary``, ``Redistribute`` and ``PlotFileData``
+    (via ``VisMF::Read``'s ``ReduceBoolAnd``) are collective on more than one
+    rank, and the threading contract puts collectives on one thread: two
+    threads can be admitted in different orders on different ranks and pair
+    the calls up wrongly, which hangs. On a single rank they are local and the
+    tests are meaningful, so gate rather than delete them -- that makes the
+    constraint enforced rather than accidentally satisfied by CI always running
+    ``mpiexec -np 1``.
+
+    A fixture, not a ``skipif``: ``ParallelDescriptor.NProcs()`` segfaults
+    before ``amrex.initialize()``, and mark conditions are evaluated at import
+    time. Depending on ``amrex_init`` makes the ordering explicit.
+    """
+    if amr.ParallelDescriptor.NProcs() > 1:
+        pytest.skip("drives MPI-collective calls from several threads; one rank only")
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import itertools
 import os
 import platform
+import subprocess
 import sys
 
 import numpy as np
@@ -25,6 +26,89 @@ if amr.Config.have_mpi:
 
 # base path for input files
 basepath = os.getcwd()
+
+
+def _probe_concurrent_mfiter():
+    """Does the AMReX we are linked against allow one MFIter per thread?
+
+    Two iterators on *different* threads, both alive at once -- nesting them on
+    one thread is a different thing and is still rejected. Probed in a
+    subprocess because on an AMReX without AMReX-Codes/amrex#5615 the failure
+    leaves the global depth counter non-zero, which would poison every later
+    test in this process.
+    """
+    probe = """
+import threading
+import amrex.space3d as amr
+
+amr.initialize(['amrex.verbose=0', 'amrex.throw_exception=1',
+                'amrex.signal_handling=0', 'tiny_profiler.enabled=0'])
+bx = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(7, 7, 7))
+ba = amr.BoxArray(bx)
+mf = amr.MultiFab(ba, amr.DistributionMapping(ba), 1, 0)
+
+errors = []
+barrier = threading.Barrier(2)
+
+
+def work(i):
+    # Ordered, not simultaneous: thread 0's iterator is provably alive before
+    # thread 1 builds its own. Racing both constructions would let two
+    # non-atomic ++depth from 0 lose an update on an old AMReX, so both would
+    # read depth==1 and the probe would wrongly report success.
+    try:
+        if i == 0:
+            it = amr.MFIter(mf)  # noqa: F841  -- held alive across the barriers
+            barrier.wait(timeout=60)
+            barrier.wait(timeout=60)
+        else:
+            barrier.wait(timeout=60)
+            it = amr.MFIter(mf)  # noqa: F841  -- must succeed alongside 0's
+            barrier.wait(timeout=60)
+    except Exception as e:       # noqa: BLE001
+        errors.append(e)
+
+
+threads = [threading.Thread(target=work, args=(i,)) for i in range(2)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+del mf, ba
+amr.finalize()
+if not errors:
+    print('yes')
+"""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return proc.returncode == 0 and proc.stdout.strip().endswith("yes")
+
+
+#: Whether AMReX has the host-thread-safety work (AMReX-Codes/amrex#5615).
+#: Probed via one-MFIter-per-thread, which is the cheapest observable symptom;
+#: the tests below depend on the whole of it, not only on that piece.
+AMREX_IS_FREE_THREADING_SAFE = _probe_concurrent_mfiter()
+
+
+@pytest.fixture(scope="session")
+def needs_amrex_free_threading():
+    """Skip unless AMReX has the host-thread-safety work.
+
+    A fixture rather than a module-level ``skipif`` mark, so that the test
+    modules need not import conftest -- which only resolves under pytest's
+    default ``prepend`` import mode.
+    """
+    if not AMREX_IS_FREE_THREADING_SAFE:
+        pytest.skip(
+            "AMReX predates the host-thread-safety work (AMReX-Codes/amrex#5615)"
+        )
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,13 @@ if amr.Config.have_mpi:
 basepath = os.getcwd()
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "perf: timing-based scaling benchmark; set PYAMREX_BENCH=1 to run",
+    )
+
+
 @pytest.fixture(scope="function")
 def make_real_array4():
     """Create an Array4 of ones matching the compiled amrex::Real precision."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,11 @@ def work(i):
             barrier.wait(timeout=60)
     except Exception as e:       # noqa: BLE001
         errors.append(e)
+        # Break the barrier so the other thread stops waiting immediately. On
+        # an AMReX without the fix this is the expected path, and without the
+        # abort the surviving thread sits out the full timeout -- 60 s added to
+        # every CI run, since dependencies.json still pins a pre-#5615 AMReX.
+        barrier.abort()
 
 
 threads = [threading.Thread(target=work, args=(i,)) for i in range(2)]
@@ -79,33 +84,46 @@ amr.finalize()
 if not errors:
     print('yes')
 """
+    # Drop the MPI launcher's environment. The suite itself is normally run
+    # under `mpiexec -n 1`, and a child that inherits those variables tries to
+    # join the parent's job instead of starting as a singleton -- which either
+    # hangs or takes the whole job down with it. Without them, the probe is an
+    # ordinary one-rank process.
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("OMPI_", "PMIX_", "PMI_", "HYDRA_", "MPIR_CVAR_"))
+        and k not in ("MPI_LOCALRANKID", "MPI_LOCALNRANKS")
+    }
     try:
         proc = subprocess.run(
             [sys.executable, "-c", probe],
             capture_output=True,
             text=True,
             timeout=300,
+            env=env,
         )
     except (subprocess.TimeoutExpired, OSError):
         return False
     return proc.returncode == 0 and proc.stdout.strip().endswith("yes")
 
 
-#: Whether AMReX has the host-thread-safety work (AMReX-Codes/amrex#5615).
-#: Probed via one-MFIter-per-thread, which is the cheapest observable symptom;
-#: the tests below depend on the whole of it, not only on that piece.
-AMREX_IS_FREE_THREADING_SAFE = _probe_concurrent_mfiter()
-
-
 @pytest.fixture(scope="session")
 def needs_amrex_free_threading():
     """Skip unless AMReX has the host-thread-safety work.
 
-    A fixture rather than a module-level ``skipif`` mark, so that the test
-    modules need not import conftest -- which only resolves under pytest's
-    default ``prepend`` import mode.
+    Probed via one-MFIter-per-thread, the cheapest observable symptom of
+    AMReX-Codes/amrex#5615; the tests that ask for this depend on the whole of
+    that work, not only on that piece.
+
+    A session fixture rather than a module-level constant on two counts. The
+    probe costs a subprocess ``amrex.initialize``, and running it at conftest
+    import charged that to every pytest session, including ones with no
+    concurrency test in them. And a fixture means the test modules need not
+    import conftest, which only resolves under pytest's default ``prepend``
+    import mode.
     """
-    if not AMREX_IS_FREE_THREADING_SAFE:
+    if not _probe_concurrent_mfiter():
         pytest.skip(
             "AMReX predates the host-thread-safety work (AMReX-Codes/amrex#5615)"
         )

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -39,75 +39,6 @@ NTHREADS = max(2, min(8, os.cpu_count() or 2))
 BARRIER_TIMEOUT = 120.0
 
 
-def _probe_concurrent_mfiter():
-    """Does the AMReX we are linked against allow one MFIter per thread?
-
-    Two iterators on *different* threads, both alive at once -- nesting them on
-    one thread is a different thing and is still rejected. Probed in a
-    subprocess because on an AMReX without AMReX-Codes/amrex#5615 the failure
-    leaves the global depth counter non-zero, which would poison every later
-    test in this process.
-    """
-    probe = """
-import threading
-import amrex.space3d as amr
-
-amr.initialize(['amrex.verbose=0', 'amrex.throw_exception=1',
-                'amrex.signal_handling=0', 'tiny_profiler.enabled=0'])
-bx = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(7, 7, 7))
-ba = amr.BoxArray(bx)
-mf = amr.MultiFab(ba, amr.DistributionMapping(ba), 1, 0)
-
-errors = []
-barrier = threading.Barrier(2)
-
-
-def work(i):
-    # Ordered, not simultaneous: thread 0's iterator is provably alive before
-    # thread 1 builds its own. Racing both constructions would let two
-    # non-atomic ++depth from 0 lose an update on an old AMReX, so both would
-    # read depth==1 and the probe would wrongly report success.
-    try:
-        if i == 0:
-            it = amr.MFIter(mf)  # noqa: F841  -- held alive across the barriers
-            barrier.wait(timeout=60)
-            barrier.wait(timeout=60)
-        else:
-            barrier.wait(timeout=60)
-            it = amr.MFIter(mf)  # noqa: F841  -- must succeed alongside 0's
-            barrier.wait(timeout=60)
-    except Exception as e:       # noqa: BLE001
-        errors.append(e)
-
-
-threads = [threading.Thread(target=work, args=(i,)) for i in range(2)]
-for t in threads:
-    t.start()
-for t in threads:
-    t.join()
-if not errors:
-    print('yes')
-"""
-    proc = subprocess.run(
-        [sys.executable, "-c", probe],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    return proc.returncode == 0 and proc.stdout.strip().endswith("yes")
-
-
-#: Whether AMReX has the host-thread-safety work (AMReX-Codes/amrex#5615).
-#: Probed via one-MFIter-per-thread, which is the cheapest observable symptom;
-#: the tests below depend on the whole of it, not only on that piece.
-AMREX_IS_FREE_THREADING_SAFE = _probe_concurrent_mfiter()
-
-needs_amrex_free_threading = pytest.mark.skipif(
-    not AMREX_IS_FREE_THREADING_SAFE,
-    reason="AMReX predates the host-thread-safety work (AMReX-Codes/amrex#5615)",
-)
-
-
 def run_concurrently(fn, nthreads=NTHREADS):
     """Run ``fn(i)`` on ``nthreads`` threads, started as close to simultaneously
     as a barrier allows.
@@ -198,8 +129,7 @@ def test_module_does_not_reenable_the_gil():
 # ---------------------------------------------------------------------------
 
 
-@needs_amrex_free_threading
-def test_concurrent_multifab_lifetime(boxarr, distmap):
+def test_concurrent_multifab_lifetime(needs_amrex_free_threading, boxarr, distmap):
     """Concurrent MultiFab construction and destruction.
 
     Every FabArray ctor/dtor runs ``FabArrayBase::addThisBD``/``clearThisBD``,
@@ -224,8 +154,9 @@ def test_concurrent_multifab_lifetime(boxarr, distmap):
     assert run_concurrently(work) == list(range(NTHREADS))
 
 
-@needs_amrex_free_threading
-def test_concurrent_mfiter_distinct_multifabs(boxarr, distmap):
+def test_concurrent_mfiter_distinct_multifabs(
+    needs_amrex_free_threading, boxarr, distmap
+):
     """Each thread iterates its own MultiFab -- the plainest data-parallel case."""
 
     def work(t):
@@ -246,8 +177,7 @@ def test_concurrent_mfiter_distinct_multifabs(boxarr, distmap):
     assert len(set(counts)) == 1, counts
 
 
-@needs_amrex_free_threading
-def test_concurrent_mfiter_same_multifab(mfab):
+def test_concurrent_mfiter_same_multifab(needs_amrex_free_threading, mfab):
     """Each thread drives its *own* MFIter over one shared MultiFab.
 
     AMReX asserts only one live MFIter per process (``MFIter::depth``, a plain
@@ -278,8 +208,7 @@ def test_concurrent_mfiter_same_multifab(mfab):
         assert float(arr.max()) == expected, f"box {mfi.index}"
 
 
-@needs_amrex_free_threading
-def test_concurrent_fill_boundary(boxarr, distmap):
+def test_concurrent_fill_boundary(needs_amrex_free_threading, boxarr, distmap):
     """Concurrent ``fill_boundary`` on distinct MultiFabs with identical shape.
 
     ``FabArrayBase::getFB`` looks up and inserts into a process-global multimap
@@ -317,8 +246,7 @@ def test_concurrent_fill_boundary(boxarr, distmap):
     assert run_concurrently(work) == [reference] * NTHREADS
 
 
-@needs_amrex_free_threading
-def test_concurrent_sum_boundary(boxarr, distmap):
+def test_concurrent_sum_boundary(needs_amrex_free_threading, boxarr, distmap):
     """Concurrent ``sum_boundary`` -- exercises the global copy-plan cache
     (``FabArrayBase::getCPC``), which is likewise unlocked."""
 
@@ -350,8 +278,7 @@ def test_concurrent_sum_boundary(boxarr, distmap):
 # ---------------------------------------------------------------------------
 
 
-@needs_amrex_free_threading
-def test_concurrent_parmparse_query():
+def test_concurrent_parmparse_query(needs_amrex_free_threading):
     """Concurrent queries against the process-global ParmParse table.
 
     A ParmParse *query* is not read-only: it bumps the entry's use count and
@@ -388,8 +315,9 @@ def test_concurrent_parmparse_query():
 # ---------------------------------------------------------------------------
 
 
-@needs_amrex_free_threading
-def test_concurrent_particle_containers(std_geometry, distmap, boxarr):
+def test_concurrent_particle_containers(
+    needs_amrex_free_threading, std_geometry, distmap, boxarr
+):
     """Each thread builds, fills and redistributes its own ParticleContainer.
 
     Touches the global particle-id counter (a bare ``++`` without OpenMP), the
@@ -413,8 +341,9 @@ def test_concurrent_particle_containers(std_geometry, distmap, boxarr):
     assert run_concurrently(work) == [npart] * NTHREADS
 
 
-@needs_amrex_free_threading
-def test_concurrent_soa_views(std_geometry, distmap, boxarr):
+def test_concurrent_soa_views(
+    needs_amrex_free_threading, std_geometry, distmap, boxarr
+):
     """Concurrent zero-copy views onto particle SoA data."""
 
     def work(t):
@@ -441,8 +370,7 @@ def test_concurrent_soa_views(std_geometry, distmap, boxarr):
 
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="requires AMREX_SPACEDIM = 3")
-@needs_amrex_free_threading
-def test_concurrent_plotfile_read(tmp_path):
+def test_concurrent_plotfile_read(needs_amrex_free_threading, tmp_path):
     """Several threads read the same plotfile at once.
 
     AMReX caches an open ``ifstream`` per file name. That cache used to be
@@ -508,8 +436,7 @@ def test_concurrent_pyobject_churn():
     assert run_concurrently(work) == [reference(t) for t in range(NTHREADS)]
 
 
-@needs_amrex_free_threading
-def test_concurrent_array_views(boxarr, distmap):
+def test_concurrent_array_views(needs_amrex_free_threading, boxarr, distmap):
     """Concurrent creation and release of zero-copy array views.
 
     pyAMReX keeps a process-global count of outstanding DLPack exports, and each

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -14,9 +14,10 @@ as a crash. Run them repeatedly to shake out timing-dependent races::
 Most of these drive one ``MFIter`` per thread, which needs an AMReX whose
 ``MFIter::depth`` is per-thread (AMReX-Codes/amrex#5615). Older AMReX aborts
 the second concurrent iterator with "Nested or multiple active MFIters is not
-supported by default", so those tests are skipped there -- see
-``AMREX_IS_FREE_THREADING_SAFE``. This is about the AMReX underneath, not about whether
-the GIL is enabled: they are equally valid, if serialized, on a GIL build.
+supported by default", so those tests are skipped there -- see the
+``needs_amrex_free_threading`` fixture in ``conftest.py``. This is about the
+AMReX underneath, not about whether the GIL is enabled: they are equally valid,
+if serialized, on a GIL build.
 """
 
 import os

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -209,7 +209,9 @@ def test_concurrent_mfiter_same_multifab(needs_amrex_free_threading, mfab):
         assert float(arr.max()) == expected, f"box {mfi.index}"
 
 
-def test_concurrent_fill_boundary(needs_amrex_free_threading, boxarr, distmap):
+def test_concurrent_fill_boundary(
+    needs_amrex_free_threading, single_rank_only, boxarr, distmap
+):
     """Concurrent ``fill_boundary`` on distinct MultiFabs with identical shape.
 
     ``FabArrayBase::getFB`` looks up and inserts into a process-global multimap
@@ -247,7 +249,9 @@ def test_concurrent_fill_boundary(needs_amrex_free_threading, boxarr, distmap):
     assert run_concurrently(work) == [reference] * NTHREADS
 
 
-def test_concurrent_sum_boundary(needs_amrex_free_threading, boxarr, distmap):
+def test_concurrent_sum_boundary(
+    needs_amrex_free_threading, single_rank_only, boxarr, distmap
+):
     """Concurrent ``sum_boundary`` -- exercises the global copy-plan cache
     (``FabArrayBase::getCPC``), which is likewise unlocked."""
 
@@ -317,7 +321,7 @@ def test_concurrent_parmparse_query(needs_amrex_free_threading):
 
 
 def test_concurrent_particle_containers(
-    needs_amrex_free_threading, std_geometry, distmap, boxarr
+    needs_amrex_free_threading, single_rank_only, std_geometry, distmap, boxarr
 ):
     """Each thread builds, fills and redistributes its own ParticleContainer.
 
@@ -371,7 +375,9 @@ def test_concurrent_soa_views(
 
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="requires AMREX_SPACEDIM = 3")
-def test_concurrent_plotfile_read(needs_amrex_free_threading, tmp_path):
+def test_concurrent_plotfile_read(
+    needs_amrex_free_threading, single_rank_only, tmp_path
+):
     """Several threads read the same plotfile at once.
 
     AMReX caches an open ``ifstream`` per file name. That cache used to be

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -7,11 +7,16 @@ Threads are spawned *inside* each test, never across tests: the autouse
 stays on one thread.
 
 Every test is written so that a data race shows up as a *wrong value*, not just
-as a crash, and every one of them is a valid (if serialized) test on a
-GIL-enabled build too. Run them repeatedly to shake out timing-dependent
-races::
+as a crash. Run them repeatedly to shake out timing-dependent races::
 
     pytest tests/test_free_threading.py --count=50
+
+Most of these drive one ``MFIter`` per thread, which needs an AMReX whose
+``MFIter::depth`` is per-thread (AMReX-Codes/amrex#5615). Older AMReX aborts
+the second concurrent iterator with "Nested or multiple active MFIters is not
+supported by default", so those tests are skipped there -- see
+``CONCURRENT_MFITER``. This is about the AMReX underneath, not about whether
+the GIL is enabled: they are equally valid, if serialized, on a GIL build.
 """
 
 import os
@@ -32,6 +37,64 @@ NTHREADS = max(2, min(8, os.cpu_count() or 2))
 
 #: Seconds a worker may wait for its peers at the start barrier.
 BARRIER_TIMEOUT = 120.0
+
+
+def _probe_concurrent_mfiter():
+    """Does the AMReX we are linked against allow one MFIter per thread?
+
+    Two iterators on *different* threads, both alive at once -- nesting them on
+    one thread is a different thing and is still rejected. Probed in a
+    subprocess because on an AMReX without AMReX-Codes/amrex#5615 the failure
+    leaves the global depth counter non-zero, which would poison every later
+    test in this process.
+    """
+    probe = """
+import threading
+import amrex.space3d as amr
+
+amr.initialize(['amrex.verbose=0', 'amrex.throw_exception=1',
+                'amrex.signal_handling=0', 'tiny_profiler.enabled=0'])
+bx = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(7, 7, 7))
+ba = amr.BoxArray(bx)
+mf = amr.MultiFab(ba, amr.DistributionMapping(ba), 1, 0)
+
+errors = []
+barrier = threading.Barrier(2)
+
+
+def work():
+    try:
+        barrier.wait(timeout=60)
+        it = amr.MFIter(mf)      # noqa: F841  -- held alive across the barrier
+        barrier.wait(timeout=60)
+    except Exception as e:       # noqa: BLE001
+        errors.append(e)
+
+
+threads = [threading.Thread(target=work) for _ in range(2)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+if not errors:
+    print('yes')
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    return proc.returncode == 0 and proc.stdout.strip().endswith("yes")
+
+
+#: Whether AMReX supports one MFIter per thread (AMReX-Codes/amrex#5615).
+CONCURRENT_MFITER = _probe_concurrent_mfiter()
+
+needs_concurrent_mfiter = pytest.mark.skipif(
+    not CONCURRENT_MFITER,
+    reason="AMReX is too old for one MFIter per thread (AMReX-Codes/amrex#5615)",
+)
 
 
 def run_concurrently(fn, nthreads=NTHREADS):
@@ -124,6 +187,7 @@ def test_module_does_not_reenable_the_gil():
 # ---------------------------------------------------------------------------
 
 
+@needs_concurrent_mfiter
 def test_concurrent_multifab_lifetime(boxarr, distmap):
     """Concurrent MultiFab construction and destruction.
 
@@ -144,9 +208,12 @@ def test_concurrent_multifab_lifetime(boxarr, distmap):
             mf.clear()
         return t
 
+    # the real checks are the asserts inside work(); this only pins down that
+    # every thread ran and results came back in thread order
     assert run_concurrently(work) == list(range(NTHREADS))
 
 
+@needs_concurrent_mfiter
 def test_concurrent_mfiter_distinct_multifabs(boxarr, distmap):
     """Each thread iterates its own MultiFab -- the plainest data-parallel case."""
 
@@ -168,6 +235,7 @@ def test_concurrent_mfiter_distinct_multifabs(boxarr, distmap):
     assert len(set(counts)) == 1, counts
 
 
+@needs_concurrent_mfiter
 def test_concurrent_mfiter_same_multifab(mfab):
     """Each thread drives its *own* MFIter over one shared MultiFab.
 
@@ -199,6 +267,7 @@ def test_concurrent_mfiter_same_multifab(mfab):
         assert float(arr.max()) == expected, f"box {mfi.index}"
 
 
+@needs_concurrent_mfiter
 def test_concurrent_fill_boundary(boxarr, distmap):
     """Concurrent ``fill_boundary`` on distinct MultiFabs with identical shape.
 
@@ -237,6 +306,7 @@ def test_concurrent_fill_boundary(boxarr, distmap):
     assert run_concurrently(work) == [reference] * NTHREADS
 
 
+@needs_concurrent_mfiter
 def test_concurrent_sum_boundary(boxarr, distmap):
     """Concurrent ``sum_boundary`` -- exercises the global copy-plan cache
     (``FabArrayBase::getCPC``), which is likewise unlocked."""
@@ -253,9 +323,12 @@ def test_concurrent_sum_boundary(boxarr, distmap):
         )
 
     reference = total(build_and_sum(1.0))
+    assert reference > 0
 
     def work(t):
-        return total(build_and_sum(1.0))
+        # a per-thread value, so a thread reading another's buffer is visible
+        value = float(t) + 1.0
+        return total(build_and_sum(value)) / value
 
     for got in run_concurrently(work):
         assert got == pytest.approx(reference)
@@ -303,6 +376,7 @@ def test_concurrent_parmparse_query():
 # ---------------------------------------------------------------------------
 
 
+@needs_concurrent_mfiter
 def test_concurrent_particle_containers(std_geometry, distmap, boxarr):
     """Each thread builds, fills and redistributes its own ParticleContainer.
 
@@ -327,6 +401,7 @@ def test_concurrent_particle_containers(std_geometry, distmap, boxarr):
     assert run_concurrently(work) == [npart] * NTHREADS
 
 
+@needs_concurrent_mfiter
 def test_concurrent_soa_views(std_geometry, distmap, boxarr):
     """Concurrent zero-copy views onto particle SoA data."""
 
@@ -354,14 +429,15 @@ def test_concurrent_soa_views(std_geometry, distmap, boxarr):
 
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="requires AMREX_SPACEDIM = 3")
-def test_concurrent_plotfile_read():
+@needs_concurrent_mfiter
+def test_concurrent_plotfile_read(tmp_path):
     """Several threads read the same plotfile at once.
 
     AMReX caches an open ``ifstream`` per file name. That cache used to be
     process-global, so two threads reading the same file shared one stream --
     and therefore one read position.
     """
-    filename = "test_plt_free_threading"
+    filename = str(tmp_path / "test_plt_free_threading")
     domain_box = amr.Box([0, 0, 0], [31, 31, 31])
     real_box = amr.RealBox([-0.5, -0.5, -0.5], [0.5, 0.5, 0.5])
     geom = amr.Geometry(domain_box, real_box, amr.CoordSys.cartesian, [0, 0, 0])
@@ -411,13 +487,16 @@ def test_concurrent_pyobject_churn():
             acc += box.num_pts
         return acc
 
-    reference = sum(
-        amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(1, k % 7 + 1, 3)).num_pts
-        for k in range(nreps)
-    )
-    assert run_concurrently(work)[0] == reference
+    def reference(t):
+        return sum(
+            amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(t + 1, k % 7 + 1, 3)).num_pts
+            for k in range(nreps)
+        )
+
+    assert run_concurrently(work) == [reference(t) for t in range(NTHREADS)]
 
 
+@needs_concurrent_mfiter
 def test_concurrent_array_views(boxarr, distmap):
     """Concurrent creation and release of zero-copy array views.
 
@@ -435,4 +514,6 @@ def test_concurrent_array_views(boxarr, distmap):
             del views
         return t
 
+    # the real checks are the asserts inside work(); this only pins down that
+    # every thread ran and results came back in thread order
     assert run_concurrently(work) == list(range(NTHREADS))

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -1,0 +1,438 @@
+# -*- coding: utf-8 -*-
+"""Concurrency tests for free-threaded CPython (PEP 703).
+
+Threads are spawned *inside* each test, never across tests: the autouse
+``amrex_init`` fixture in ``conftest.py`` wraps every test in
+``amr.initialize()`` / ``amr.finalize()``, which is process-global state and
+stays on one thread.
+
+Every test is written so that a data race shows up as a *wrong value*, not just
+as a crash, and every one of them is a valid (if serialized) test on a
+GIL-enabled build too. Run them repeatedly to shake out timing-dependent
+races::
+
+    pytest tests/test_free_threading.py --count=50
+"""
+
+import os
+import subprocess
+import sys
+import sysconfig
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import amrex.space3d as amr
+
+FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+#: Enough threads to expose races without oversubscribing a CI runner.
+NTHREADS = max(2, min(8, os.cpu_count() or 2))
+
+#: Seconds a worker may wait for its peers at the start barrier.
+BARRIER_TIMEOUT = 120.0
+
+
+def run_concurrently(fn, nthreads=NTHREADS):
+    """Run ``fn(i)`` on ``nthreads`` threads, started as close to simultaneously
+    as a barrier allows.
+
+    Returns the per-thread results in thread-index order. The first exception
+    raised in any worker is re-raised here, so a plain ``assert`` inside ``fn``
+    works as usual.
+    """
+    barrier = threading.Barrier(nthreads)
+
+    def worker(i):
+        barrier.wait(timeout=BARRIER_TIMEOUT)
+        return fn(i)
+
+    with ThreadPoolExecutor(max_workers=nthreads) as pool:
+        futures = [pool.submit(worker, i) for i in range(nthreads)]
+        return [f.result() for f in futures]
+
+
+def valid_slices(arr_shape, n_grow_vect):
+    """Slices into the valid (non-ghost) region of a 4-axis (x,y,z,n) Array4
+    view, for any AMREX_SPACEDIM. Same helper as in test_fill_domain_boundary.py.
+    """
+    sd = amr.Config.spacedim
+    ng = [n_grow_vect[d] if d < sd else 0 for d in range(3)] + [0]
+    return tuple(slice(g, s - g) for g, s in zip(ng, arr_shape))
+
+
+def count_equal(arr, value):
+    """Number of entries equal to ``value``, as a host int (CPU and GPU alike)."""
+    return int((arr == value).sum())
+
+
+def make_particle_container(std_geometry, distmap, boxarr):
+    """Legacy AoS+SoA container, managed memory on GPU (as in test_particleContainer.py)."""
+    if amr.Config.have_gpu:
+        return amr.ParticleContainer_2_1_3_1_managed(std_geometry, distmap, boxarr)
+    return amr.ParticleContainer_2_1_3_1_default(std_geometry, distmap, boxarr)
+
+
+def make_particle_init():
+    myt = amr.ParticleInitType_2_1_3_1()
+    myt.real_struct_data = [0.5, 0.6]
+    myt.int_struct_data = [5]
+    myt.real_array_data = [0.5, 0.2, 0.3]
+    myt.int_array_data = [1]
+    return myt
+
+
+# ---------------------------------------------------------------------------
+# the free-threading opt-in itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not FREE_THREADED, reason="needs a free-threaded CPython build")
+def test_module_does_not_reenable_the_gil():
+    """Importing pyAMReX must not switch the GIL back on.
+
+    Without ``py::mod_gil_not_used()`` on the ``PYBIND11_MODULE``, CPython
+    re-enables the GIL process-wide at import time and the free-threaded
+    interpreter gives no benefit at all (pyamrex#612).
+
+    Checked in a subprocess with a clean environment: ``PYTHON_GIL`` and
+    ``-X gil`` force the outcome either way, so testing in-process would only
+    report how *this* pytest run happened to be launched.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "PYTHON_GIL"}
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import amrex.space3d; print(sys._is_gil_enabled())",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "False", (
+        "importing pyAMReX re-enabled the GIL process-wide; the module is "
+        f"missing py::mod_gil_not_used().\nstderr:\n{proc.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fields
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_multifab_lifetime(boxarr, distmap):
+    """Concurrent MultiFab construction and destruction.
+
+    Every FabArray ctor/dtor runs ``FabArrayBase::addThisBD``/``clearThisBD``,
+    which mutate the process-global ``m_BD_count`` map and, on the last
+    reference, cascade into all the cache flushers.
+    """
+
+    def work(t):
+        value = float(t) + 1.0
+        for _ in range(20):
+            mf = amr.MultiFab(boxarr, distmap, 1, 0)
+            mf.set_val(value)
+            for mfi in mf:
+                arr = mf.array(mfi).to_xp(copy=False, order="F")
+                assert float(arr.min()) == value
+                assert float(arr.max()) == value
+            mf.clear()
+        return t
+
+    assert run_concurrently(work) == list(range(NTHREADS))
+
+
+def test_concurrent_mfiter_distinct_multifabs(boxarr, distmap):
+    """Each thread iterates its own MultiFab -- the plainest data-parallel case."""
+
+    def work(t):
+        value = float(t) + 1.0
+        mf = amr.MultiFab(boxarr, distmap, 1, 0)
+        mf.set_val(0.0)
+        ncells = 0
+        for mfi in mf:
+            arr = mf.array(mfi).to_xp(copy=False, order="F")
+            arr[...] = value
+            ncells += arr.size
+        assert sum(
+            count_equal(mf.array(mfi).to_xp(copy=False), value) for mfi in mf
+        ) == (ncells)
+        return ncells
+
+    counts = run_concurrently(work)
+    assert len(set(counts)) == 1, counts
+
+
+def test_concurrent_mfiter_same_multifab(mfab):
+    """Each thread drives its *own* MFIter over one shared MultiFab.
+
+    AMReX asserts only one live MFIter per process (``MFIter::depth``, a plain
+    global ``int``), and the tile-array cache lookup behind every MFIter is
+    guarded only by ``#pragma omp critical`` -- which compiles away in a
+    non-OpenMP build. Threads here partition the boxes round-robin by index, so
+    no two write to the same data.
+    """
+    mfab.set_val(-1.0)
+    nboxes = sum(1 for _ in mfab)
+
+    def work(t):
+        touched = 0
+        for mfi in mfab:
+            if mfi.index % NTHREADS != t:
+                continue
+            arr = mfab.array(mfi).to_xp(copy=False, order="F")
+            arr[...] = float(t) + 1.0
+            touched += 1
+        return touched
+
+    assert sum(run_concurrently(work)) == nboxes
+
+    for mfi in mfab:
+        arr = mfab.array(mfi).to_xp(copy=False, order="F")
+        expected = float(mfi.index % NTHREADS) + 1.0
+        assert float(arr.min()) == expected, f"box {mfi.index}"
+        assert float(arr.max()) == expected, f"box {mfi.index}"
+
+
+def test_concurrent_fill_boundary(boxarr, distmap):
+    """Concurrent ``fill_boundary`` on distinct MultiFabs with identical shape.
+
+    ``FabArrayBase::getFB`` looks up and inserts into a process-global multimap
+    with no lock at all. Identical shapes mean identical cache keys, i.e. the
+    worst case for that cache.
+    """
+    sentinel = -42.0
+
+    def build_and_fill(value):
+        mf = amr.MultiFab(boxarr, distmap, 1, 1)
+        mf.set_val(sentinel)
+        for mfi in mf:
+            arr = mf.array(mfi).to_xp(copy=False, order="F")
+            arr[valid_slices(arr.shape, mf.n_grow_vect)] = value
+        mf.fill_boundary()
+        return mf
+
+    def filled_cells(mf, value):
+        total = 0
+        for mfi in mf:
+            arr = mf.array(mfi).to_xp(copy=False, order="F")
+            n_value = count_equal(arr, value)
+            # a cross-thread leak would show up as a third value
+            assert n_value + count_equal(arr, sentinel) == arr.size
+            total += n_value
+        return total
+
+    reference = filled_cells(build_and_fill(1.0), 1.0)
+    assert reference > 0
+
+    def work(t):
+        value = float(t) + 1.0
+        return filled_cells(build_and_fill(value), value)
+
+    assert run_concurrently(work) == [reference] * NTHREADS
+
+
+def test_concurrent_sum_boundary(boxarr, distmap):
+    """Concurrent ``sum_boundary`` -- exercises the global copy-plan cache
+    (``FabArrayBase::getCPC``), which is likewise unlocked."""
+
+    def build_and_sum(value):
+        mf = amr.MultiFab(boxarr, distmap, 1, 1)
+        mf.set_val(value)
+        mf.sum_boundary(amr.Periodicity())
+        return mf
+
+    def total(mf):
+        return sum(
+            float(mf.array(mfi).to_xp(copy=False, order="F").sum()) for mfi in mf
+        )
+
+    reference = total(build_and_sum(1.0))
+
+    def work(t):
+        return total(build_and_sum(1.0))
+
+    for got in run_concurrently(work):
+        assert got == pytest.approx(reference)
+
+
+# ---------------------------------------------------------------------------
+# runtime parameters
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_parmparse_query():
+    """Concurrent queries against the process-global ParmParse table.
+
+    A ParmParse *query* is not read-only: it bumps the entry's use count and
+    writes its type hint and last value, all through ``mutable`` members of a
+    table entry shared by every ParmParse object in the process. Recording the
+    last value *grows a vector* the first time an entry is queried, so the keys
+    below are deliberately queried for the first time from several threads at
+    once -- a warm-up query on the main thread would pre-size that vector and
+    hide the race.
+    """
+    nkeys = 32
+    expected = {f"key{i:02d}": 100 + i for i in range(nkeys)}
+
+    pp_setup = amr.ParmParse("ft")
+    for name, value in expected.items():
+        pp_setup.add(name, value)
+
+    def work(t):
+        pp = amr.ParmParse("ft")
+        seen = {}
+        for _ in range(10):
+            for name, value in expected.items():
+                found, got = pp.query_int(name)
+                assert found, name
+                assert got == value, (name, got, value)
+                seen[name] = got
+        return seen
+
+    assert run_concurrently(work) == [expected] * NTHREADS
+
+
+# ---------------------------------------------------------------------------
+# particles
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_particle_containers(std_geometry, distmap, boxarr):
+    """Each thread builds, fills and redistributes its own ParticleContainer.
+
+    Touches the global particle-id counter (a bare ``++`` without OpenMP), the
+    particle-tile runtime pointer caches, and the lazily initialised statics in
+    ``ParticleContainerBase``.
+
+    Note that the particles are placed deterministically rather than with
+    ``init_random``: that call *reseeds the process-global RNG* (it forwards to
+    ``amrex::InitRandom``), so it belongs on one thread before the workers
+    start -- see :ref:`usage-threading`.
+    """
+    npart = int(std_geometry.domain.num_pts)
+
+    def work(t):
+        pc = make_particle_container(std_geometry, distmap, boxarr)
+        pc.init_one_per_cell(0.5, 0.5, 0.5, make_particle_init())
+        pc.redistribute()
+        assert pc.OK()
+        return pc.total_number_of_particles()
+
+    assert run_concurrently(work) == [npart] * NTHREADS
+
+
+def test_concurrent_soa_views(std_geometry, distmap, boxarr):
+    """Concurrent zero-copy views onto particle SoA data."""
+
+    def work(t):
+        pc = make_particle_container(std_geometry, distmap, boxarr)
+        pc.init_one_per_cell(0.5, 0.5, 0.5, make_particle_init())
+        seen = 0
+        for lvl in range(pc.finest_level + 1):
+            for tile in pc.get_particles(lvl).values():
+                real_arrays = tile.get_struct_of_arrays().get_real_data()
+                for pod in real_arrays:
+                    if pod.size() == 0:
+                        continue  # to_xp() rejects empty vectors
+                    seen += int(pod.to_xp(copy=False).size)
+        return seen
+
+    counts = run_concurrently(work)
+    assert len(set(counts)) == 1, counts
+    assert counts[0] > 0
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(amr.Config.spacedim != 3, reason="requires AMREX_SPACEDIM = 3")
+def test_concurrent_plotfile_read():
+    """Several threads read the same plotfile at once.
+
+    AMReX caches an open ``ifstream`` per file name. That cache used to be
+    process-global, so two threads reading the same file shared one stream --
+    and therefore one read position.
+    """
+    filename = "test_plt_free_threading"
+    domain_box = amr.Box([0, 0, 0], [31, 31, 31])
+    real_box = amr.RealBox([-0.5, -0.5, -0.5], [0.5, 0.5, 0.5])
+    geom = amr.Geometry(domain_box, real_box, amr.CoordSys.cartesian, [0, 0, 0])
+    ba = amr.BoxArray(domain_box)
+    ba.max_size(16)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 0)
+    mf.set_val(3.5)
+    amr.write_single_level_plotfile(
+        filename, mf, amr.Vector_string(["density"]), geom, 1.0, 200
+    )
+
+    def work(t):
+        plt = amr.PlotFileData(filename)
+        field = plt.get(0, "density")
+        total = 0.0
+        for mfi in field:
+            arr = field.array(mfi).to_xp(copy=False, order="F")
+            assert count_equal(arr, 3.5) == arr.size
+            total += float(arr.sum())
+        return total
+
+    totals = run_concurrently(work)
+    assert totals == pytest.approx([3.5 * 32**3] * NTHREADS)
+
+
+# ---------------------------------------------------------------------------
+# binding layer
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_pyobject_churn():
+    """Heavy creation and destruction of small bound objects from many threads.
+
+    This is a stress test of pybind11's process-global instance registry rather
+    than of AMReX; it is here so a pybind11 regression is caught by pyAMReX's
+    own suite.
+    """
+    nreps = 2000
+
+    def work(t):
+        acc = 0
+        for k in range(nreps):
+            lo = amr.IntVect(0, 0, 0)
+            hi = amr.IntVect(t + 1, k % 7 + 1, 3)
+            box = amr.Box(lo, hi)
+            acc += box.num_pts
+        return acc
+
+    reference = sum(
+        amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(1, k % 7 + 1, 3)).num_pts
+        for k in range(nreps)
+    )
+    assert run_concurrently(work)[0] == reference
+
+
+def test_concurrent_array_views(boxarr, distmap):
+    """Concurrent creation and release of zero-copy array views.
+
+    pyAMReX keeps a process-global count of outstanding DLPack exports, and each
+    view holds a reference back to its Python owner.
+    """
+
+    def work(t):
+        value = float(t) + 1.0
+        mf = amr.MultiFab(boxarr, distmap, 1, 0)
+        mf.set_val(value)
+        for _ in range(50):
+            views = [mf.array(mfi).to_xp(copy=False) for mfi in mf]
+            assert all(float(v.min()) == value for v in views)
+            del views
+        return t
+
+    assert run_concurrently(work) == list(range(NTHREADS))

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -15,7 +15,7 @@ Most of these drive one ``MFIter`` per thread, which needs an AMReX whose
 ``MFIter::depth`` is per-thread (AMReX-Codes/amrex#5615). Older AMReX aborts
 the second concurrent iterator with "Nested or multiple active MFIters is not
 supported by default", so those tests are skipped there -- see
-``CONCURRENT_MFITER``. This is about the AMReX underneath, not about whether
+``AMREX_IS_FREE_THREADING_SAFE``. This is about the AMReX underneath, not about whether
 the GIL is enabled: they are equally valid, if serialized, on a GIL build.
 """
 
@@ -62,16 +62,25 @@ errors = []
 barrier = threading.Barrier(2)
 
 
-def work():
+def work(i):
+    # Ordered, not simultaneous: thread 0's iterator is provably alive before
+    # thread 1 builds its own. Racing both constructions would let two
+    # non-atomic ++depth from 0 lose an update on an old AMReX, so both would
+    # read depth==1 and the probe would wrongly report success.
     try:
-        barrier.wait(timeout=60)
-        it = amr.MFIter(mf)      # noqa: F841  -- held alive across the barrier
-        barrier.wait(timeout=60)
+        if i == 0:
+            it = amr.MFIter(mf)  # noqa: F841  -- held alive across the barriers
+            barrier.wait(timeout=60)
+            barrier.wait(timeout=60)
+        else:
+            barrier.wait(timeout=60)
+            it = amr.MFIter(mf)  # noqa: F841  -- must succeed alongside 0's
+            barrier.wait(timeout=60)
     except Exception as e:       # noqa: BLE001
         errors.append(e)
 
 
-threads = [threading.Thread(target=work) for _ in range(2)]
+threads = [threading.Thread(target=work, args=(i,)) for i in range(2)]
 for t in threads:
     t.start()
 for t in threads:
@@ -88,12 +97,14 @@ if not errors:
     return proc.returncode == 0 and proc.stdout.strip().endswith("yes")
 
 
-#: Whether AMReX supports one MFIter per thread (AMReX-Codes/amrex#5615).
-CONCURRENT_MFITER = _probe_concurrent_mfiter()
+#: Whether AMReX has the host-thread-safety work (AMReX-Codes/amrex#5615).
+#: Probed via one-MFIter-per-thread, which is the cheapest observable symptom;
+#: the tests below depend on the whole of it, not only on that piece.
+AMREX_IS_FREE_THREADING_SAFE = _probe_concurrent_mfiter()
 
-needs_concurrent_mfiter = pytest.mark.skipif(
-    not CONCURRENT_MFITER,
-    reason="AMReX is too old for one MFIter per thread (AMReX-Codes/amrex#5615)",
+needs_amrex_free_threading = pytest.mark.skipif(
+    not AMREX_IS_FREE_THREADING_SAFE,
+    reason="AMReX predates the host-thread-safety work (AMReX-Codes/amrex#5615)",
 )
 
 
@@ -187,7 +198,7 @@ def test_module_does_not_reenable_the_gil():
 # ---------------------------------------------------------------------------
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_multifab_lifetime(boxarr, distmap):
     """Concurrent MultiFab construction and destruction.
 
@@ -213,7 +224,7 @@ def test_concurrent_multifab_lifetime(boxarr, distmap):
     assert run_concurrently(work) == list(range(NTHREADS))
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_mfiter_distinct_multifabs(boxarr, distmap):
     """Each thread iterates its own MultiFab -- the plainest data-parallel case."""
 
@@ -235,7 +246,7 @@ def test_concurrent_mfiter_distinct_multifabs(boxarr, distmap):
     assert len(set(counts)) == 1, counts
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_mfiter_same_multifab(mfab):
     """Each thread drives its *own* MFIter over one shared MultiFab.
 
@@ -267,7 +278,7 @@ def test_concurrent_mfiter_same_multifab(mfab):
         assert float(arr.max()) == expected, f"box {mfi.index}"
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_fill_boundary(boxarr, distmap):
     """Concurrent ``fill_boundary`` on distinct MultiFabs with identical shape.
 
@@ -306,7 +317,7 @@ def test_concurrent_fill_boundary(boxarr, distmap):
     assert run_concurrently(work) == [reference] * NTHREADS
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_sum_boundary(boxarr, distmap):
     """Concurrent ``sum_boundary`` -- exercises the global copy-plan cache
     (``FabArrayBase::getCPC``), which is likewise unlocked."""
@@ -339,6 +350,7 @@ def test_concurrent_sum_boundary(boxarr, distmap):
 # ---------------------------------------------------------------------------
 
 
+@needs_amrex_free_threading
 def test_concurrent_parmparse_query():
     """Concurrent queries against the process-global ParmParse table.
 
@@ -376,7 +388,7 @@ def test_concurrent_parmparse_query():
 # ---------------------------------------------------------------------------
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_particle_containers(std_geometry, distmap, boxarr):
     """Each thread builds, fills and redistributes its own ParticleContainer.
 
@@ -401,7 +413,7 @@ def test_concurrent_particle_containers(std_geometry, distmap, boxarr):
     assert run_concurrently(work) == [npart] * NTHREADS
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_soa_views(std_geometry, distmap, boxarr):
     """Concurrent zero-copy views onto particle SoA data."""
 
@@ -429,7 +441,7 @@ def test_concurrent_soa_views(std_geometry, distmap, boxarr):
 
 
 @pytest.mark.skipif(amr.Config.spacedim != 3, reason="requires AMREX_SPACEDIM = 3")
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_plotfile_read(tmp_path):
     """Several threads read the same plotfile at once.
 
@@ -496,7 +508,7 @@ def test_concurrent_pyobject_churn():
     assert run_concurrently(work) == [reference(t) for t in range(NTHREADS)]
 
 
-@needs_concurrent_mfiter
+@needs_amrex_free_threading
 def test_concurrent_array_views(boxarr, distmap):
     """Concurrent creation and release of zero-copy array views.
 

--- a/tests/test_free_threading_perf.py
+++ b/tests/test_free_threading_perf.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""Scaling regression tests for free-threaded CPython (PEP 703).
+
+These are timing-based and therefore off by default; a loaded machine would
+make them flap. Enable them explicitly::
+
+    PYAMREX_BENCH=1 pytest tests/test_free_threading_perf.py -s
+
+For the full sweep and the GIL-on/GIL-off comparison, use
+``tools/bench_free_threading.py`` instead -- this file only asserts the floor
+that a regression would break through.
+"""
+
+import os
+import sys
+import sysconfig
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import amrex.space3d as amr
+
+FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+GIL_ENABLED = getattr(sys, "_is_gil_enabled", lambda: True)()
+BENCH_ENABLED = os.environ.get("PYAMREX_BENCH") == "1"
+
+#: Threads to scale to. Kept modest so the floor holds on a busy CI runner.
+NTHREADS = 4
+
+#: Minimum speedup at NTHREADS for a GIL-bound kernel with the GIL disabled.
+#: Linear would be 4.0; 2.0 leaves generous headroom for noise and for the
+#: interpreter's own free-threading overhead.
+MIN_SPEEDUP = 2.0
+
+pytestmark = [
+    pytest.mark.perf,
+    pytest.mark.skipif(not BENCH_ENABLED, reason="set PYAMREX_BENCH=1 to run"),
+]
+
+
+def python_kernel(view, work=2):
+    """Python-level loop over the data: holds the GIL for its whole duration."""
+    flat = view.reshape(-1)
+    n = flat.size
+    stride = max(1, n // 4096)
+    for _ in range(work):
+        acc = 0.0
+        for i in range(0, n, stride):
+            acc += float(flat[i]) * 1.5
+        flat[0] = acc
+
+
+def time_threaded(views, nthreads):
+    """Best-of-3 wall time for running python_kernel over ``views``."""
+    barrier = threading.Barrier(nthreads)
+
+    def worker(t):
+        barrier.wait(timeout=300)
+        for i in range(t, len(views), nthreads):
+            python_kernel(views[i])
+
+    def once():
+        t0 = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=nthreads) as pool:
+            list(pool.map(worker, range(nthreads)))
+        return time.perf_counter() - t0
+
+    once()  # warm-up
+    return min(once() for _ in range(3))
+
+
+@pytest.fixture(scope="function")
+def bench_views():
+    """Per-box zero-copy views of an over-decomposed MultiFab."""
+    ncell, max_grid_size = 128, 32
+    domain = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(*([ncell - 1] * 3)))
+    ba = amr.BoxArray(domain)
+    ba.max_size(max_grid_size)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 0)
+    mf.set_val(1.0)
+    views = [mf.array(mfi).to_xp(copy=False, order="F") for mfi in mf]
+    assert len(views) >= NTHREADS
+    yield views
+    del views
+    mf.clear()
+
+
+@pytest.mark.skipif(
+    not FREE_THREADED or GIL_ENABLED,
+    reason="needs a free-threaded interpreter with the GIL actually disabled",
+)
+@pytest.mark.skipif(
+    (os.cpu_count() or 1) < NTHREADS, reason=f"needs >= {NTHREADS} cores"
+)
+def test_python_kernel_scales_without_the_gil(bench_views):
+    """A GIL-bound per-box kernel must actually get faster with more threads.
+
+    On a GIL build this speedup is ~1.0 by construction, which is the whole
+    point of pyamrex#612.
+    """
+    t1 = time_threaded(bench_views, 1)
+    tn = time_threaded(bench_views, NTHREADS)
+    speedup = t1 / tn
+    print(
+        f"\npython kernel: 1 thread {t1:.4f} s, {NTHREADS} threads {tn:.4f} s "
+        f"-> {speedup:.2f}x ({100 * speedup / NTHREADS:.0f}% efficiency)"
+    )
+    assert speedup >= MIN_SPEEDUP, (
+        f"expected >= {MIN_SPEEDUP}x with the GIL disabled, got {speedup:.2f}x"
+    )
+
+
+@pytest.mark.skipif(
+    (os.cpu_count() or 1) < NTHREADS, reason=f"needs >= {NTHREADS} cores"
+)
+def test_per_thread_mfiter_scales(boxarr, distmap):
+    """The same, but with each thread driving its own MFIter.
+
+    This is the pattern the AMReX free-threading fixes unlock; before them the
+    second concurrent MFIter aborts the process.
+    """
+    mf = amr.MultiFab(boxarr, distmap, 1, 0)
+    mf.set_val(1.0)
+
+    def run(nthreads):
+        barrier = threading.Barrier(nthreads)
+
+        def worker(t):
+            barrier.wait(timeout=300)
+            for mfi in mf:
+                if mfi.index % nthreads == t:
+                    python_kernel(mf.array(mfi).to_xp(copy=False, order="F"))
+
+        t0 = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=nthreads) as pool:
+            list(pool.map(worker, range(nthreads)))
+        return time.perf_counter() - t0
+
+    run(1)  # warm-up
+    t1 = min(run(1) for _ in range(3))
+    tn = min(run(NTHREADS) for _ in range(3))
+    print(f"\nper-thread MFIter: {t1:.4f} s -> {tn:.4f} s ({t1 / tn:.2f}x)")
+
+    if FREE_THREADED and not GIL_ENABLED:
+        assert t1 / tn >= MIN_SPEEDUP
+    mf.clear()

--- a/tests/test_free_threading_perf.py
+++ b/tests/test_free_threading_perf.py
@@ -22,6 +22,14 @@ import pytest
 
 import amrex.space3d as amr
 
+
+def _amrex_is_free_threading_safe():
+    """Same AMReX capability probe the functional suite uses."""
+    from test_free_threading import AMREX_IS_FREE_THREADING_SAFE
+
+    return AMREX_IS_FREE_THREADING_SAFE
+
+
 FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 GIL_ENABLED = getattr(sys, "_is_gil_enabled", lambda: True)()
 BENCH_ENABLED = os.environ.get("PYAMREX_BENCH") == "1"
@@ -115,6 +123,10 @@ def test_python_kernel_scales_without_the_gil(bench_views):
 
 @pytest.mark.skipif(
     (os.cpu_count() or 1) < NTHREADS, reason=f"needs >= {NTHREADS} cores"
+)
+@pytest.mark.skipif(
+    not _amrex_is_free_threading_safe(),
+    reason="AMReX predates the host-thread-safety work (AMReX-Codes/amrex#5615)",
 )
 def test_per_thread_mfiter_scales(boxarr, distmap):
     """The same, but with each thread driving its own MFIter.

--- a/tests/test_free_threading_perf.py
+++ b/tests/test_free_threading_perf.py
@@ -22,14 +22,6 @@ import pytest
 
 import amrex.space3d as amr
 
-
-def _amrex_is_free_threading_safe():
-    """Same AMReX capability probe the functional suite uses."""
-    from test_free_threading import AMREX_IS_FREE_THREADING_SAFE
-
-    return AMREX_IS_FREE_THREADING_SAFE
-
-
 FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 GIL_ENABLED = getattr(sys, "_is_gil_enabled", lambda: True)()
 BENCH_ENABLED = os.environ.get("PYAMREX_BENCH") == "1"
@@ -50,7 +42,11 @@ pytestmark = [
 
 def python_kernel(view, work=2):
     """Python-level loop over the data: holds the GIL for its whole duration."""
-    flat = view.reshape(-1)
+    # order="F" matters: to_xp() hands back an F-contiguous view, and a
+    # default C-order reshape of that cannot alias it -- it would copy the
+    # whole box inside NumPy, which releases the GIL and so would not be
+    # the GIL-bound kernel this is meant to be.
+    flat = view.reshape(-1, order="F")
     n = flat.size
     stride = max(1, n // 4096)
     for _ in range(work):
@@ -60,23 +56,42 @@ def python_kernel(view, work=2):
         flat[0] = acc
 
 
-def time_threaded(views, nthreads):
-    """Best-of-3 wall time for running python_kernel over ``views``."""
-    barrier = threading.Barrier(nthreads)
+def timed(nthreads, body):
+    """Wall time for running ``body(t)`` on ``nthreads`` threads.
+
+    The workers are parked on a barrier before the clock starts, so spawning
+    them is not charged to the measurement -- otherwise every added thread pays
+    a startup cost and the speedup comes out too low.
+    """
+    barrier = threading.Barrier(nthreads + 1)  # +1 for this thread
 
     def worker(t):
         barrier.wait(timeout=300)
+        body(t)
+
+    with ThreadPoolExecutor(max_workers=nthreads) as pool:
+        futures = [pool.submit(worker, t) for t in range(nthreads)]
+        barrier.wait(timeout=300)  # all workers up; start the clock
+        t0 = time.perf_counter()
+        for f in futures:
+            f.result()
+        return time.perf_counter() - t0
+
+
+def best_of(nthreads, body, n=3):
+    """Best of ``n`` timed runs, after a warm-up."""
+    timed(nthreads, body)
+    return min(timed(nthreads, body) for _ in range(n))
+
+
+def time_threaded(views, nthreads):
+    """Best-of-3 wall time for running python_kernel over ``views``."""
+
+    def body(t):
         for i in range(t, len(views), nthreads):
             python_kernel(views[i])
 
-    def once():
-        t0 = time.perf_counter()
-        with ThreadPoolExecutor(max_workers=nthreads) as pool:
-            list(pool.map(worker, range(nthreads)))
-        return time.perf_counter() - t0
-
-    once()  # warm-up
-    return min(once() for _ in range(3))
+    return best_of(nthreads, body)
 
 
 @pytest.fixture(scope="function")
@@ -124,11 +139,7 @@ def test_python_kernel_scales_without_the_gil(bench_views):
 @pytest.mark.skipif(
     (os.cpu_count() or 1) < NTHREADS, reason=f"needs >= {NTHREADS} cores"
 )
-@pytest.mark.skipif(
-    not _amrex_is_free_threading_safe(),
-    reason="AMReX predates the host-thread-safety work (AMReX-Codes/amrex#5615)",
-)
-def test_per_thread_mfiter_scales(boxarr, distmap):
+def test_per_thread_mfiter_scales(needs_amrex_free_threading, boxarr, distmap):
     """The same, but with each thread driving its own MFIter.
 
     This is the pattern the AMReX free-threading fixes unlock; before them the
@@ -137,23 +148,19 @@ def test_per_thread_mfiter_scales(boxarr, distmap):
     mf = amr.MultiFab(boxarr, distmap, 1, 0)
     mf.set_val(1.0)
 
-    def run(nthreads):
-        barrier = threading.Barrier(nthreads)
+    # enough work per box that the measurement is signal rather than noise
+    work = 8
 
-        def worker(t):
-            barrier.wait(timeout=300)
+    def run(nthreads):
+        def body(t):
             for mfi in mf:
                 if mfi.index % nthreads == t:
-                    python_kernel(mf.array(mfi).to_xp(copy=False, order="F"))
+                    python_kernel(mf.array(mfi).to_xp(copy=False, order="F"), work)
 
-        t0 = time.perf_counter()
-        with ThreadPoolExecutor(max_workers=nthreads) as pool:
-            list(pool.map(worker, range(nthreads)))
-        return time.perf_counter() - t0
+        return best_of(nthreads, body)
 
-    run(1)  # warm-up
-    t1 = min(run(1) for _ in range(3))
-    tn = min(run(NTHREADS) for _ in range(3))
+    t1 = run(1)
+    tn = run(NTHREADS)
     print(f"\nper-thread MFIter: {t1:.4f} s -> {tn:.4f} s ({t1 / tn:.2f}x)")
 
     if FREE_THREADED and not GIL_ENABLED:

--- a/tools/bench_free_threading.py
+++ b/tools/bench_free_threading.py
@@ -59,7 +59,11 @@ def kernel_numpy(view, work):
 
 def kernel_python(view, work):
     """Python-level loop over the same data; holds the GIL throughout."""
-    flat = view.reshape(-1)
+    # order="F" matters: to_xp() hands back an F-contiguous view, and a
+    # default C-order reshape of that cannot alias it -- it would copy the
+    # whole box inside NumPy, which releases the GIL and so would not be
+    # the GIL-bound kernel this is meant to be.
+    flat = view.reshape(-1, order="F")
     n = flat.size
     stride = max(1, n // 4096)
     for _ in range(work):
@@ -87,37 +91,49 @@ def make_multifab(ncell, max_grid_size, ncomp):
     return mf
 
 
-def run_snapshot(mf, kernel, work, nthreads):
-    """Serial MFIter pass to collect views, then run the kernels in a pool."""
-    views = [mf.array(mfi).to_xp(copy=False, order="F") for mfi in mf]
-    barrier = threading.Barrier(nthreads)
+def _timed(nthreads, body):
+    """Wall time for running ``body(t)`` on ``nthreads`` threads.
+
+    The pool is built and the workers are parked on a barrier before the clock
+    starts, so thread startup is not charged to the measurement -- otherwise
+    every added thread pays a spawn cost and the speedup is understated.
+    """
+    barrier = threading.Barrier(nthreads + 1)  # +1 for this thread
 
     def worker(t):
         barrier.wait(timeout=300)
+        body(t)
+
+    with ThreadPoolExecutor(max_workers=nthreads) as pool:
+        futures = [pool.submit(worker, t) for t in range(nthreads)]
+        barrier.wait(timeout=300)  # all workers are up; start the clock
+        t0 = time.perf_counter()
+        for f in futures:
+            f.result()
+        return time.perf_counter() - t0
+
+
+def run_snapshot(mf, kernel, work, nthreads):
+    """Serial MFIter pass to collect views, then run the kernels in a pool."""
+    views = [mf.array(mfi).to_xp(copy=False, order="F") for mfi in mf]
+
+    def body(t):
         for i in range(t, len(views), nthreads):
             kernel(views[i], work)
 
-    t0 = time.perf_counter()
-    with ThreadPoolExecutor(max_workers=nthreads) as pool:
-        list(pool.map(worker, range(nthreads)))
-    return time.perf_counter() - t0
+    return _timed(nthreads, body)
 
 
 def run_mfiter(mf, kernel, work, nthreads):
     """Each thread drives its own MFIter and claims boxes round-robin."""
-    barrier = threading.Barrier(nthreads)
 
-    def worker(t):
-        barrier.wait(timeout=300)
+    def body(t):
         for mfi in mf:
             if mfi.index % nthreads != t:
                 continue
             kernel(mf.array(mfi).to_xp(copy=False, order="F"), work)
 
-    t0 = time.perf_counter()
-    with ThreadPoolExecutor(max_workers=nthreads) as pool:
-        list(pool.map(worker, range(nthreads)))
-    return time.perf_counter() - t0
+    return _timed(nthreads, body)
 
 
 RUNNERS = {"snapshot": run_snapshot, "mfiter": run_mfiter}
@@ -193,14 +209,16 @@ def describe_runtime():
 
 def print_table(results):
     for kernel_name, per_threads in results.items():
-        base = per_threads[min(per_threads)]
-        print(f"\n{kernel_name} kernel")
+        base_threads = min(per_threads)
+        base = per_threads[base_threads]
+        print(f"\n{kernel_name} kernel  (baseline: {base_threads} thread(s))")
         print(f"  {'threads':>7}  {'time [s]':>9}  {'speedup':>8}  {'efficiency':>10}")
         for nthreads in sorted(per_threads):
             t = per_threads[nthreads]
+            speedup = base / t
             print(
-                f"  {nthreads:>7}  {t:>9.4f}  {base / t:>8.2f}x  "
-                f"{100 * base / t / nthreads:>9.0f}%"
+                f"  {nthreads:>7}  {t:>9.4f}  {speedup:>8.2f}x  "
+                f"{100 * speedup / (nthreads / base_threads):>9.0f}%"
             )
 
 
@@ -212,13 +230,20 @@ def compare(paths):
             runs.append(json.load(f))
     labels = ["GIL on" if run["runtime"]["gil_enabled"] else "GIL off" for run in runs]
 
-    for kernel_name in sorted(runs[0]["results"]):
+    runs = [r for r in runs if "results" in r]
+    if not runs:
+        print("none of those files hold scaling results (--overhead runs do not)")
+        return
+
+    for kernel_name in sorted(set.intersection(*(set(r["results"]) for r in runs))):
         print(f"\n{kernel_name} kernel -- time [s] and speedup vs. 1 thread")
         header = "  threads"
         for label in labels:
             header += f"  {label:>16}"
         print(header)
-        threads = sorted(int(k) for k in runs[0]["results"][kernel_name])
+        threads = sorted(
+            set.intersection(*(set(map(int, r["results"][kernel_name])) for r in runs))
+        )
         for nthreads in threads:
             row = f"  {nthreads:>7}"
             for run in runs:

--- a/tools/bench_free_threading.py
+++ b/tools/bench_free_threading.py
@@ -228,9 +228,10 @@ def compare(paths):
     for path in paths:
         with open(path) as f:
             runs.append(json.load(f))
-    labels = ["GIL on" if run["runtime"]["gil_enabled"] else "GIL off" for run in runs]
-
+    # Filter before building the labels, or an --overhead file passed alongside
+    # a scaling file contributes a column header with no column under it.
     runs = [r for r in runs if "results" in r]
+    labels = ["GIL on" if run["runtime"]["gil_enabled"] else "GIL off" for run in runs]
     if not runs:
         print("none of those files hold scaling results (--overhead runs do not)")
         return

--- a/tools/bench_free_threading.py
+++ b/tools/bench_free_threading.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Free-threading scaling benchmark for pyAMReX.
+
+Measures how a per-box Python compute kernel scales with the number of Python
+threads. On a free-threaded interpreter the same binary can be run with the GIL
+off and on, which makes the comparison exact -- same build, same machine, one
+environment variable apart::
+
+    PYTHON_GIL=0 python tools/bench_free_threading.py --json off.json
+    PYTHON_GIL=1 python tools/bench_free_threading.py --json on.json
+    python tools/bench_free_threading.py --compare off.json on.json
+
+Two kernels are measured because they answer different questions:
+
+``numpy``
+    A vectorised expression. NumPy releases the GIL inside the ufunc, so even a
+    GIL build scales somewhat; this is the pattern most pyAMReX code already
+    uses.
+``python``
+    A Python-level loop over the same data. This holds the GIL for its whole
+    duration, so it cannot scale at all on a GIL build. This is where
+    free-threading actually changes what is possible.
+
+Two iteration modes:
+
+``snapshot`` (default)
+    One serial MFIter pass collects the per-box Array4 views, then the thread
+    pool runs the kernels. Works on any build.
+``mfiter``
+    Each thread drives its own MFIter and picks its boxes by index. Requires
+    the free-threading fixes to AMReX (``MFIter::depth`` and the FabArrayBase
+    caches); on an unfixed build this aborts on
+    "Nested or multiple active MFIters is not supported by default".
+"""
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import sysconfig
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import amrex.space3d as amr
+
+# ---------------------------------------------------------------------------
+# kernels
+# ---------------------------------------------------------------------------
+
+
+def kernel_numpy(view, work):
+    """Vectorised update; NumPy releases the GIL for the ufuncs."""
+    for _ in range(work):
+        view *= 1.0000001
+        view += 1.0
+
+
+def kernel_python(view, work):
+    """Python-level loop over the same data; holds the GIL throughout."""
+    flat = view.reshape(-1)
+    n = flat.size
+    stride = max(1, n // 4096)
+    for _ in range(work):
+        acc = 0.0
+        for i in range(0, n, stride):
+            acc += float(flat[i]) * 1.5
+        flat[0] = acc
+
+
+KERNELS = {"numpy": kernel_numpy, "python": kernel_python}
+
+
+# ---------------------------------------------------------------------------
+# harness
+# ---------------------------------------------------------------------------
+
+
+def make_multifab(ncell, max_grid_size, ncomp):
+    domain = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(*([ncell - 1] * 3)))
+    ba = amr.BoxArray(domain)
+    ba.max_size(max_grid_size)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, ncomp, 0)
+    mf.set_val(1.0)
+    return mf
+
+
+def run_snapshot(mf, kernel, work, nthreads):
+    """Serial MFIter pass to collect views, then run the kernels in a pool."""
+    views = [mf.array(mfi).to_xp(copy=False, order="F") for mfi in mf]
+    barrier = threading.Barrier(nthreads)
+
+    def worker(t):
+        barrier.wait(timeout=300)
+        for i in range(t, len(views), nthreads):
+            kernel(views[i], work)
+
+    t0 = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=nthreads) as pool:
+        list(pool.map(worker, range(nthreads)))
+    return time.perf_counter() - t0
+
+
+def run_mfiter(mf, kernel, work, nthreads):
+    """Each thread drives its own MFIter and claims boxes round-robin."""
+    barrier = threading.Barrier(nthreads)
+
+    def worker(t):
+        barrier.wait(timeout=300)
+        for mfi in mf:
+            if mfi.index % nthreads != t:
+                continue
+            kernel(mf.array(mfi).to_xp(copy=False, order="F"), work)
+
+    t0 = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=nthreads) as pool:
+        list(pool.map(worker, range(nthreads)))
+    return time.perf_counter() - t0
+
+
+RUNNERS = {"snapshot": run_snapshot, "mfiter": run_mfiter}
+
+
+def bench(args):
+    runner = RUNNERS[args.mode]
+    results = {}
+    for kernel_name in args.kernels:
+        kernel = KERNELS[kernel_name]
+        per_threads = {}
+        for nthreads in args.threads:
+            mf = make_multifab(args.ncell, args.max_grid_size, args.ncomp)
+            runner(mf, kernel, args.work, nthreads)  # warm-up
+            samples = [
+                runner(mf, kernel, args.work, nthreads) for _ in range(args.repeats)
+            ]
+            per_threads[nthreads] = min(samples)
+            print(
+                f"  {kernel_name:>6} {nthreads:>3} threads: "
+                f"{min(samples):8.4f} s  (median {statistics.median(samples):.4f} s)",
+                flush=True,
+            )
+            mf.clear()
+        results[kernel_name] = per_threads
+    return results
+
+
+def overhead(args):
+    """Single-threaded cost of an MFIter + fill_boundary loop.
+
+    This is the A/B for the mutexes added to AMReX: run it on an unmodified
+    checkout, then again on the patched one.
+    """
+    domain = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(*([args.ncell - 1] * 3)))
+    ba = amr.BoxArray(domain)
+    ba.max_size(args.max_grid_size)
+    dm = amr.DistributionMapping(ba)
+    mf = amr.MultiFab(ba, dm, 1, 1)
+    mf.set_val(1.0)
+
+    def loop(n):
+        t0 = time.perf_counter()
+        for _ in range(n):
+            for mfi in mf:
+                mf.array(mfi)
+            mf.fill_boundary()
+        return time.perf_counter() - t0
+
+    loop(2)  # warm-up
+    samples = [loop(args.repeats) for _ in range(5)]
+    per_iter = min(samples) / args.repeats
+    print(f"  MFIter + fill_boundary: {per_iter * 1e3:.4f} ms / iteration")
+    return {"mfiter_fill_boundary_s": per_iter}
+
+
+# ---------------------------------------------------------------------------
+# reporting
+# ---------------------------------------------------------------------------
+
+
+def describe_runtime():
+    return {
+        "python": sys.version.split()[0],
+        "free_threaded": bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
+        "gil_enabled": getattr(sys, "_is_gil_enabled", lambda: True)(),
+        "cpu_count": os.cpu_count(),
+        "amrex_version": amr.__version__,
+        "gpu_backend": amr.Config.gpu_backend,
+        "precision": amr.Config.precision,
+    }
+
+
+def print_table(results):
+    for kernel_name, per_threads in results.items():
+        base = per_threads[min(per_threads)]
+        print(f"\n{kernel_name} kernel")
+        print(f"  {'threads':>7}  {'time [s]':>9}  {'speedup':>8}  {'efficiency':>10}")
+        for nthreads in sorted(per_threads):
+            t = per_threads[nthreads]
+            print(
+                f"  {nthreads:>7}  {t:>9.4f}  {base / t:>8.2f}x  "
+                f"{100 * base / t / nthreads:>9.0f}%"
+            )
+
+
+def compare(paths):
+    """Print a side-by-side table from result files written by ``--json``."""
+    runs = []
+    for path in paths:
+        with open(path) as f:
+            runs.append(json.load(f))
+    labels = ["GIL on" if run["runtime"]["gil_enabled"] else "GIL off" for run in runs]
+
+    for kernel_name in sorted(runs[0]["results"]):
+        print(f"\n{kernel_name} kernel -- time [s] and speedup vs. 1 thread")
+        header = "  threads"
+        for label in labels:
+            header += f"  {label:>16}"
+        print(header)
+        threads = sorted(int(k) for k in runs[0]["results"][kernel_name])
+        for nthreads in threads:
+            row = f"  {nthreads:>7}"
+            for run in runs:
+                per = run["results"][kernel_name]
+                t = per[str(nthreads)]
+                base = per[str(threads[0])]
+                row += f"  {t:>9.4f} {base / t:>5.2f}x"
+            print(row)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--ncell", type=int, default=128, help="cells per dimension")
+    p.add_argument("--max-grid-size", type=int, default=32, help="box size")
+    p.add_argument("--ncomp", type=int, default=1, help="components per box")
+    p.add_argument("--work", type=int, default=1, help="kernel repetitions per box")
+    p.add_argument("--repeats", type=int, default=5, help="timed samples")
+    p.add_argument("--threads", type=int, nargs="+", default=None)
+    p.add_argument("--kernels", nargs="+", default=list(KERNELS), choices=list(KERNELS))
+    p.add_argument("--mode", default="snapshot", choices=list(RUNNERS))
+    p.add_argument("--json", help="write results here")
+    p.add_argument("--overhead", action="store_true", help="single-thread locking A/B")
+    p.add_argument("--compare", nargs="+", help="print a table from result files")
+    args = p.parse_args(argv)
+
+    if args.compare:
+        compare(args.compare)
+        return 0
+
+    if args.threads is None:
+        ncpu = os.cpu_count() or 1
+        args.threads = [n for n in (1, 2, 4, 8, 14, 20) if n <= ncpu] or [1]
+
+    amr.initialize(
+        [
+            "amrex.verbose=0",
+            "tiny_profiler.enabled=0",
+            "amrex.throw_exception=1",
+            "amrex.signal_handling=0",
+        ]
+    )
+    try:
+        runtime = describe_runtime()
+        print("runtime:", json.dumps(runtime))
+        if args.overhead:
+            payload = {"runtime": runtime, "overhead": overhead(args)}
+        else:
+            results = bench(args)
+            print_table(results)
+            payload = {"runtime": runtime, "args": vars(args), "results": results}
+        if args.json:
+            with open(args.json, "w") as f:
+                json.dump(payload, f, indent=2)
+            print(f"\nwrote {args.json}")
+    finally:
+        amr.finalize()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/bench_free_threading.py
+++ b/tools/bench_free_threading.py
@@ -165,8 +165,12 @@ def bench(args):
 def overhead(args):
     """Single-threaded cost of an MFIter + fill_boundary loop.
 
-    This is the A/B for the mutexes added to AMReX: run it on an unmodified
-    checkout, then again on the patched one.
+    Run it on an unmodified AMReX and again on the patched one to check the
+    added locking did not cost anything visible. Read it as a ceiling, not a
+    measurement of the locks: the loop is driven from Python, so per-box
+    interpreter and pybind11 overhead dominate an uncontended lock/unlock by
+    orders of magnitude. It answers "does this show up at all?", which is the
+    question that matters here, not "what does a lock cost?".
     """
     domain = amr.Box(amr.IntVect(0, 0, 0), amr.IntVect(*([args.ncell - 1] * 3)))
     ba = amr.BoxArray(domain)


### PR DESCRIPTION
Closes #612.

> [!NOTE]
> Stacked on #611 (`Python_FIND_ABI`) — review the second commit.
> Requires AMReX-Codes/amrex#5615; without it the second concurrent `MFIter` aborts the process.
> **Merge order:** #5615 first, then repoint AMReX, then this.

> [!WARNING]
> **Two lines must be reverted before this merges**, both marked `TEMPORARY` in
> commit `2e0bc7a`: `commit_amrex` in `dependencies.json`, and `pyAMReX_amrex_repo` in
> `cmake/dependencies/AMReX.cmake`. They point AMReX at the #5615 branch. Without them
> this PR does not compile in CI — `src/Base/ParmParse.cpp` calls `ParmParse::tableCopy()`,
> which only exists in #5615 — and before that, every concurrency test was skipped, so CI
> reported green while running exactly one of them. Pinned, the suite goes from
> *1 passed, 13 skipped* to **15 passed**. The repo URI has to move too, not just the SHA:
> FetchContent clones and then checks out, and a plain clone of `AMReX-Codes/amrex` cannot
> check out a commit that so far exists only on the fork. Once #5615 lands, revert both and
> set `commit_amrex` to the merged SHA.

## Summary

We publish `cp313t`/`cp314t` wheels, but the modules used the two-argument `PYBIND11_MODULE` form, so importing pyAMReX re-enabled the GIL process-wide:

```console
$ python3.14t -X warn_default_gil -c "import sys, amrex.space3d; print(sys._is_gil_enabled())"
RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module
'amrex.space3d.amrex_3d_pybind', which has not declared that it can run safely
without the GIL.
True
```

The tag is a promise, not a flag, so most of this PR is the audit behind it — and the tests that keep it honest.

## The contract

Same rule NumPy follows: **pyAMReX's and AMReX's own global state is race-free; your data is yours to synchronize.**

Safe from any number of threads: working on distinct objects (including ones built from the same `BoxArray`/`DistributionMapping`), reading the same object, each thread driving **its own `MFIter`** even over the same `MultiFab`, creating and releasing zero-copy views, and querying `ParmParse`.

Yours to synchronize: writing the same data from two threads, exactly as with a NumPy array.

Main thread only: `initialize`/`finalize`; MPI-collective calls unless AMReX is built with `AMReX_MPI_THREAD_MULTIPLE=ON`; RNG reseeding (`init_random` forwards to `amrex::InitRandom`, which reseeds process-global state); `TinyProfiler`; external GPU streams; dynamic `MFIter` scheduling.

All of this is written up in the new `docs/source/usage/threading.rst`.

## Changes

- `py::mod_gil_not_used()` on all three dimensionalities.
- A mutex around `initialize`/`finalize`, so a contract violation serialises instead of corrupting the AMReX instance stack, `ParmParse.pretty_print_table()` renders to a string and hands that to `py::print()` instead of holding a `scoped_ostream_redirect` across the walk -- that redirect swaps `std::cout`'s stream buffer process-wide, so it could capture a concurrent `amrex::Print()`. `ParmParse.to_dict()` walks `ParmParse::tableCopy()`, a locked snapshot.
- `Programming Language :: Python :: Free Threading :: 2 - Beta` — deliberately not `3 - Stable` until this has soaked in CI across platforms.
- A second ctest target running the concurrency tests with `PYTHON_GIL=0`.
- `tests/test_free_threading.py` — 13 concurrency tests. Each asserts a computed value rather than the absence of a crash. Threads are spawned *inside* a test, never across tests, because the autouse `amrex_init` fixture wraps every test in `initialize`/`finalize`.
- `tests/test_free_threading_perf.py` — two scaling regression tests, off unless `PYAMREX_BENCH=1`.
- `tools/bench_free_threading.py` — scaling harness with a GIL-on/GIL-off compare mode: the same binary, one environment variable apart.

## Testing

CPython 3.14 free-threaded, built with `pyAMReX_amrex_src` against AMReX-Codes/amrex#5615.

| | |
|---|---|
| Import no longer re-enables the GIL | no warning, `sys._is_gil_enabled()` → `False` |
| Full suite, `PYTHON_GIL=0` and `=1` | 249 passed, 95 skipped — both |
| Concurrency tests, `--count=50` | 750 / 750 |
| CUDA (RTX A2000) | 15/15; 300/300 at `--count=20` |
| SYCL (Intel Iris Xe) | green |
| GIL-enabled CPython 3.14 build | 248 passed — tag inert, `cpython-314` ABI tag |
| ThreadSanitizer | no races in AMReX or pyAMReX code |

A Python-level per-box kernel over a 128³ domain in 64 boxes, 14-core / 20-thread CPU:

| threads | GIL enabled | GIL disabled |
|--:|--:|--:|
| 1 | 1.00× | 1.00× |
| 2 | 1.07× | 1.93× |
| 4 | 1.06× | 3.55× |
| 8 | 0.99× | 4.92× |
| 14 | 0.97× | 6.25× |
| 20 | 0.97× | **7.29×** |

A NumPy-vectorised kernel over the same data is memory-bandwidth-bound and scales weakly either way (2.6× at 20 threads without the GIL) — but *with* the GIL it degrades to 0.39× at 20 threads, the threads contending for the lock rather than computing.

The AMReX-side locking costs +0.2% single-threaded on an `MFIter` + `fill_boundary` loop, inside the ±1.6% run-to-run spread.

## Follow-ups

- Releasing the GIL around long AMReX calls is orthogonal (a no-op on free-threaded builds) — #613.
- **CMake floor.** In a conda-forge prefix carrying both `python3.14` and `python3.14t`, only CMake ≥ 4.1 finds `Development.Module` for the `t` ABI; 3.31.4 and 4.0.3 fail with *"Could NOT find Python (missing: Development.Module)"* while still locating the interpreter. `pyproject.toml` asks for `cmake>=3.24.0` — worth revisiting for the `cp3xxt` wheels.
- **dpnp has no `cp314t` build**, so `to_xp()`/`to_dpnp()` zero-copy views are unavailable on free-threaded SYCL until Intel ships one. CuPy does have one, so CUDA is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


