### PR TITLE
Dependencies: AMReX CUDA CMake 3.25+

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -301,7 +301,7 @@ jobs:
             -DAMReX_SPACEDIM="1;2;3"    \
             -DCMAKE_CUDA_STANDARD=17    \
             -DCMAKE_CXX_STANDARD=17     \
-            -DAMReX_CUDA_ARCH=8.0       \
+            -DCMAKE_CUDA_ARCHITECTURES=80 \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
             -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
         cmake --build build --target pip_install -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ string(JSON pyamrex_version GET "${dependencies_data}" version_pyamrex)
 
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.24.0)
+cmake_minimum_required(VERSION 3.25.0)
 project(pyAMReX VERSION ${pyamrex_version})
 
 include(${pyAMReX_SOURCE_DIR}/cmake/pyAMReXFunctions.cmake)
@@ -26,11 +26,6 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 endif()
 
-# CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
-# https://cmake.org/cmake/help/latest/policy/CMP0104.html
-if(POLICY CMP0104)
-    cmake_policy(SET CMP0104 OLD)
-endif()
 # device link step not yet fully implemented in AMReX logic
 # https://cmake.org/cmake/help/latest/policy/CMP0105.html
 if(POLICY CMP0105)

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,6 +2,6 @@
     "version_pyamrex": "26.08",
     "version_amrex": "26.08",
     "version_pybind11_min": "v3.0.0",
-    "commit_amrex": "5273b558c13011573e1b6bf71860db4fcc1f0cfb",
+    "commit_amrex": "19e6fba747b65a37d08f3fecef3ff2935318f26b",
     "commit_pybind11": "v3.1.0"
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,6 +2,6 @@
     "version_pyamrex": "26.08",
     "version_amrex": "26.08",
     "version_pybind11_min": "v3.0.0",
-    "commit_amrex": "19e6fba747b65a37d08f3fecef3ff2935318f26b",
+    "commit_amrex": "06424932b7572c829ca9fe31a6e178c164bf232c",
     "commit_pybind11": "v3.1.0"
 }

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -82,6 +82,7 @@ CMake Option                    Default & Values                             Des
 =============================== ============================================ ===========================================================
 ``BUILD_TESTING``               **ON**/OFF                                   Build tests
 ``CMAKE_BUILD_TYPE``            RelWithDebInfo/**Release**/Debug             Type of build, symbols & optimizations
+``CMAKE_CUDA_ARCHITECTURES``    **native**/all/all-major/``80``/...          Nvidia GPU architectures to compile for (``AMReX_GPU_BACKEND=CUDA``)
 ``CMAKE_INSTALL_PREFIX``        system-dependent path                        Install path prefix
 ``CMAKE_VERBOSE_MAKEFILE``      ON/**OFF**                                   Print all compiler commands to the terminal during build
 ``AMReX_OMP``                   ON/**OFF**                                   Enable OpenMP
@@ -158,6 +159,37 @@ If you also want to select a CUDA compiler:
 
    Please clean your build directory with ``rm -rf build/`` after changing the compiler.
    Now call ``cmake -S . -B build`` (+ further options) again to re-initialize the build configuration.
+
+
+.. _building-cmake-gpu-archs:
+
+Select GPU Architectures
+------------------------
+
+For Nvidia GPUs, pyAMReX uses the standard CMake interface to select the CUDA architectures to compile for.
+By default, we select ``native``, i.e., CMake detects the architecture of the GPU(s) visible on the machine that runs ``cmake`` and pyAMReX is built exactly for those.
+
+If no GPU is visible at configuration time (a typical situation on HPC login nodes, in containers and in CI) then configuration stops with an error and you need to select the architecture explicitly, either as a CMake option:
+
+.. code-block:: bash
+
+   cmake -S . -B build -DAMReX_GPU_BACKEND=CUDA -DCMAKE_CUDA_ARCHITECTURES=80
+
+or as an `environment variable <https://cmake.org/cmake/help/latest/envvar/CUDAARCHS.html>`__:
+
+.. code-block:: bash
+
+   export CUDAARCHS=80
+
+Architectures are written as integers, e.g., ``80`` for A100 (compute capability 8.0) and ``90`` for H100.
+`Multiple architectures <https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html>`__ are separated by semicolons (``"80;90"``), and the special values ``native``, ``all`` and ``all-major`` are supported as well.
+
+.. note::
+
+   The older AMReX-specific spellings ``-DAMReX_CUDA_ARCH=8.0`` and ``export AMREX_CUDA_ARCH=8.0`` still work, but are deprecated and warn.
+   They are translated to the CMake variables above, including their historical value formats (``Auto``, ``Common``, ``Volta``, ``8.0``, ``7.0+PTX``, whitespace-separated lists).
+
+For AMD GPUs, select the architecture with ``-DAMReX_AMD_ARCH=gfx90a`` or ``export AMREX_AMD_ARCH=gfx90a``.
 
 
 Run

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -7,7 +7,7 @@ pyAMReX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++20 <https://en.wikipedia.org/wiki/C%2B%2B20>`__ compiler, e.g., GCC 12+, Clang 14, NVCC 12.4, MSVC 19.39 or newer
-- `CMake 3.24.0+ <https://cmake.org>`__
+- `CMake 3.25.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy
 - `pybind11 3.0.0+ <https://github.com/pybind/pybind11/>`__: we automatically download and compile a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.24.0",
+    "cmake>=3.25.0",
     "packaging>=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -63,14 +63,14 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(["cmake", "--version"])
         except OSError:
             raise RuntimeError(
-                "CMake 3.24.0+ must be installed to build the following "
+                "CMake 3.25.0+ must be installed to build the following "
                 + "extensions: "
                 + ", ".join(e.name for e in self.extensions)
             )
 
         cmake_version = parse(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
-        if cmake_version < parse("3.24.0"):
-            raise RuntimeError("CMake >= 3.24.0 is required")
+        if cmake_version < parse("3.25.0"):
+            raise RuntimeError("CMake >= 3.25.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
## Summary

Bumps `commit_amrex` to [AMReX-Codes/amrex#4773](https://github.com/AMReX-Codes/amrex/pull/4773) (as [BLAST-WarpX/warpx#7202](https://github.com/BLAST-WarpX/warpx/pull/7202) does for WarpX): CUDA architectures are now selected through the standard CMake interface and the CMake minimum rises to 3.25.
This moves our CI over to the new spelling and raises pyAMReX's own CMake minimum to match.

## Details

The variables we usually set in our scripts still work, but are deprecated and warn on configure.

Environment variables:

| old (deprecated, warns)            | new                        |
|------------------------------------|----------------------------|
| `export AMREX_CUDA_ARCH=8.0`       | `export CUDAARCHS=80`      |
| `export AMREX_CUDA_ARCH="7.0;7.5"` | `export CUDAARCHS="70;75"` |

CMake options:

| old (deprecated, warns)    | new                                               |
|----------------------------|---------------------------------------------------|
| `-DAMReX_CUDA_ARCH=8.0`    | `-DCMAKE_CUDA_ARCHITECTURES=80`                   |
| `-DAMReX_CUDA_ARCH=Auto`   | `-DCMAKE_CUDA_ARCHITECTURES=native` (new default) |
| `-DAMReX_CUDA_ARCH=Common` | `-DCMAKE_CUDA_ARCHITECTURES=all-major`            |

Values are integers (`80`, not `8.0`); `native`, `all`, `all-major` and the `90a` forms are supported as well.

User-facing:
- CMake 3.25.0+ is now required (was 3.24.0); documented in `docs/source/install/dependencies.rst`.
- The default is `native`, resolved from the GPUs visible to `cmake`. Configuring where no GPU is visible (HPC login node, container, CI) now requires an explicit architecture — our CI sets one.
- New "Select GPU Architectures" section in `docs/source/install/cmake.rst`, plus a `CMAKE_CUDA_ARCHITECTURES` row in the build options table.
- `commit_amrex` moves 17 commits forward, from `5273b558` to `19e6fba7` — the same AMReX that WarpX#7202 pins, to keep the stack consistent.

Internal:
- Removed `cmake_policy(SET CMP0104 OLD)`, the pre-3.20 path AMReX dropped; keeping it would clear `CMAKE_CUDA_ARCHITECTURES`.
- `CMP0105` is deliberately **kept**: it is a separate policy about device link options that AMReX#4773 does not address. Because a policy is still set to `OLD`, the `CMAKE_WARN_DEPRECATED OFF` work-around stays too — unlike WarpX#7202, which could drop both. Retiring `CMP0105` is a good follow-up, but wants a CUDA link-step test this PR does not provide.
- Migrated `.github/workflows/ubuntu.yml` to `-DCMAKE_CUDA_ARCHITECTURES=80`.

## Testing

- Configured `AMReX_GPU_BACKEND=CUDA` with `-DCMAKE_CUDA_ARCHITECTURES=80` against the new pin: configures cleanly, reports `CUDA architectures: 80`, and fetches AMReX `19e6fba7`.
- `-DAMReX_CUDA_ARCH=8.0` still configures, warns as documented and resolves to `80`.
- No new CMake deprecation warnings at configure.
- Sphinx docs build with no warnings from the changed pages.
